### PR TITLE
clusterpolicy_controller: watch Nodes' GPU labels to support scale-up

### DIFF
--- a/pkg/controller/clusterpolicy/clusterpolicy_controller.go
+++ b/pkg/controller/clusterpolicy/clusterpolicy_controller.go
@@ -8,11 +8,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -49,6 +52,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to Node labels and requeue the owner ClusterPolicy
+	err = addWatchNewGPUNode(c, mgr, r)
+	if err != nil {
+		return err
+	}
+
 	// TODO(user): Modify this to be the types you create that are owned by the primary resource
 	// Watch for changes to secondary resource Pods and requeue the owner ClusterPolicy
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
@@ -60,6 +69,75 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	return nil
+}
+
+func addWatchNewGPUNode(c controller.Controller, mgr manager.Manager, r reconcile.Reconciler) error {
+	// https://book-v1.book.kubebuilder.io/beyond_basics/controller_watches.html
+
+	// 'UpdateFunc' and 'CreateFunc' used to judge if a event about the object is
+	// what we want. If that is true, the event will be processed by the reconciler.
+	p := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			labels := e.Meta.GetLabels()
+
+			gpuCommonLabelMissing := hasGPULabels(labels) && !hasCommonGPULabel(labels)
+			if gpuCommonLabelMissing {
+				log.Info("New node needs an update, GPU common label missing.",
+					"name", e.Meta.GetName())
+			}
+
+			return gpuCommonLabelMissing
+		},
+
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newLabels := e.MetaNew.GetLabels()
+
+			gpuCommonLabelMissing := hasGPULabels(newLabels) && !hasCommonGPULabel(newLabels)
+			gpuCommonLabelOutdated := !hasGPULabels(newLabels) && hasCommonGPULabel(newLabels)
+			needsUpdate := gpuCommonLabelMissing || gpuCommonLabelOutdated
+			if needsUpdate {
+				log.Info("Node needs an update",
+					"name", e.MetaNew.GetName(),
+				    "gpuCommonLabelMissing", gpuCommonLabelMissing,
+				    "gpuCommonLabelOutdated", gpuCommonLabelOutdated)
+			}
+
+			return needsUpdate
+		},
+	}
+
+	// Define a mapping from the Node object in the event to one or more
+	// ClusterPolicy objects to Reconcile
+	mapFn := handler.ToRequestsFunc(
+		func(a handler.MapObject) []reconcile.Request {
+			// find all the ClusterPolicy to trigger their reconciliation
+			opts := []client.ListOption{} // Namespace = "" to list across all namespaces.
+			list := &gpuv1.ClusterPolicyList{}
+
+			err := mgr.GetClient().List(context.TODO(), list, opts...)
+			if err != nil {
+				log.Error(err, "Unable to list ClusterPolicies")
+				return []reconcile.Request{}
+			}
+
+			cp_to_rec := []reconcile.Request{}
+
+			for _, cp := range list.Items {
+				cp_to_rec = append(cp_to_rec, reconcile.Request{NamespacedName: types.NamespacedName{
+					Name:      cp.ObjectMeta.GetName(),
+					Namespace: cp.ObjectMeta.GetNamespace(),
+				}})
+			}
+			log.Info("Reconciliate ClusterPolicies after node label update", "nb", len(cp_to_rec))
+
+			return cp_to_rec
+		})
+
+	err := c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestsFromMapFunc{
+        ToRequests: mapFn,
+    }, p)
+
+	return err
 }
 
 // blank assignment to verify that ReconcileClusterPolicy implements reconcile.Reconciler


### PR DESCRIPTION
This patch adds a custom Watch to the controller. The GPU operator
watches for Node events. When it happens, it checks if the GPU common
label is correctly applied and synchronized with the NFD labels.

When a mismatch is detected, the custom mapping function looks up all
the existing ClusterPolicy objects and requests a reconciliation.

Without this patch, when new nodes joined the cluster, they would
not load the Nvidia driver & toolkit until a GPU operator
reconciliation would be triggered (for instance by deleting an object
controlled by the operator).

Fixes #81

Signed-off-by: Kevin Pouget <kpouget@redhat.com>