### PR TITLE
Mssing Docker image for node-feature-discovery from values

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -163,6 +163,8 @@ gfd:
   priorityClassName: system-node-critical
 
 node-feature-discovery:
+  image:
+    repository: quay.io/kubernetes_incubator/node-feature-discovery
   worker:
     tolerations:
     - key: "node-role.kubernetes.io/master"


### PR DESCRIPTION
I'm using a private repository in my company and I need to set all the Docker images in the Helm values; the one in the PR is missing from the values.

```
Signed-off-by: Diego Najar <dignajar@gmail.com>
```
