### PR TITLE
Allow devicePlugin.config.default to be none.

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -450,7 +450,9 @@ spec:
     {{- if .Values.devicePlugin.config.name }}
     config:
       name: {{ .Values.devicePlugin.config.name }}
+      {{- if .Values.devicePlugin.config.default }}
       default: {{ .Values.devicePlugin.config.default }}
+      {{- end }}
     {{- end }}
   dcgm:
     enabled: {{ .Values.dcgm.enabled }}


### PR DESCRIPTION
This commit allows someone not to set a clusterwide policy for GPUs It will take the default behaviour. Only if a node has selector for a particular devicePlugin config (with a given name). This config will be used

Hello!

Thanks for making this contribution! When contributing to this repository please keep in mind the following:
- [You should sign your work](https://github.com/NVIDIA/gpu-operator/blob/master/CONTRIBUTING.md).
- You should be making your contribution against the [gitlab.com repository](https://gitlab.com/nvidia/kubernetes/gpu-operator) as github.com is just a mirror.
