### PR TITLE
Adding volume mount to sandbox DP to support GPU healthcheck

### DIFF
--- a/assets/state-sandbox-device-plugin/0500_daemonset.yaml
+++ b/assets/state-sandbox-device-plugin/0500_daemonset.yaml
@@ -67,6 +67,8 @@ spec:
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
+            - name: vfio
+              mountPath: /dev/vfio
       volumes:
         - name: device-plugin
           hostPath:
@@ -75,3 +77,6 @@ spec:
           hostPath:
             path: /run/nvidia/validations
             type: DirectoryOrCreate
+        - name: vfio
+          hostPath:
+            path: /dev/vfio


### PR DESCRIPTION
This PR updates the Sandbox Device Plugin Daemonset with a volume mount to support the update to GPU healthcheck added [here](https://github.com/NVIDIA/kubevirt-gpu-device-plugin/pull/105)

Details about the update to health check from the above mentioned PR are below

For a GPU configured as passthrough , device plugin does not update the GPU count on the node when a GPU falls off the bus.

To reproduce follow the steps

Remove the GPU from the bus
echo "1" > /sys/bus/pci/devices/<gpu_pci_id>/remove

Validated the GPU is no longer visible from the host using lspci
lspci -nnk -d 10de:

The number of GPUs exposed on k8s node doesn't change.

Watching for iommu groups under /dev/vfio creates a fsnotify when the GPU falls off the bus
