### PR TITLE
Upload e2e test artifacts with different names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-logs
+          name: containerd-e2e-test-logs
           path: ./logs/
           retention-days: 15
 
@@ -311,6 +311,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-logs
+          name: nvidiadriver-e2e-test-logs
           path: ./logs/
           retention-days: 15


### PR DESCRIPTION
This PR makes sure there are no name conflicts between the artifacts (logs) generated by the different e2e tests. If we use the same name and both jobs fail, artifacts will fail to upload. See https://github.com/NVIDIA/gpu-operator/actions/runs/9391769904/job/25865185987?pr=735#step:9:22 for an example where this occurred.