### PR TITLE
[CI] specify crictl version in holodeck yaml config

### DIFF
--- a/tests/holodeck.yaml
+++ b/tests/holodeck.yaml
@@ -23,3 +23,4 @@ spec:
     install: true
     installer: kubeadm
     version: v1.28.5
+    crictlVersion: v1.28.0


### PR DESCRIPTION
The default CRICTL version in holodeck is `v1.22.0`. Ideally the version in crictl should be in sync with the Kubernetes version used. This PR does just that