### PR TITLE
[OCP] add back permissions to set finalizers on CRDs

### DIFF
--- a/assets/state-operator-validation/0210_clusterrole.yaml
+++ b/assets/state-operator-validation/0210_clusterrole.yaml
@@ -11,3 +11,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - nvidia.com
+  resources:
+  - clusterpolicies/finalizers
+  - nvidiadrivers/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/deployments/gpu-operator/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/templates/clusterrole.yaml
@@ -102,8 +102,10 @@ rules:
   - nvidia.com
   resources:
   - clusterpolicies
+  - clusterpolicies/finalizers
   - clusterpolicies/status
   - nvidiadrivers
+  - nvidiadrivers/finalizers
   - nvidiadrivers/status
   verbs:
   - create


### PR DESCRIPTION
This fixes the regression introduced from the commit - https://github.com/NVIDIA/gpu-operator/commit/590706361eaa31a568ab16ec5c5194ddfb8437de

It fixes the following error message observed in OCP clusters

```
time="2024-06-07T02:01:37Z" level=info msg="version: 0a321eba, commit: 0a321eb"
time="2024-06-07T02:01:37Z" level=info msg="Error: error validating cuda workload: failed to create cuda validation pod , err pods \"nvidia-cuda-validator-8bhk2\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"

```