### PR TITLE
[OCP] restrict RBAC perms of gpu-operator in OLM bundle

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -587,7 +587,12 @@ spec:
         - apiGroups:
           - nvidia.com
           resources:
-          - '*'
+          - clusterpolicies
+          - clusterpolicies/finalizers
+          - clusterpolicies/status
+          - nvidiadrivers
+          - nvidiadrivers/finalizers
+          - nvidiadrivers/status
           verbs:
           - create
           - delete
@@ -610,7 +615,14 @@ spec:
           resources:
           - securitycontextconstraints
           verbs:
-          - '*'
+          - use
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
         - apiGroups:
           - security.openshift.io
           resources:
@@ -627,7 +639,13 @@ spec:
           - roles
           - rolebindings
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
         - apiGroups:
           - ""
           resources:
@@ -656,8 +674,6 @@ spec:
           resources:
           - deployments
           - daemonsets
-          - replicasets
-          - statefulsets
           verbs:
           - create
           - delete
@@ -690,7 +706,13 @@ spec:
           resources:
           - leases
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -716,121 +738,13 @@ spec:
           resources:
           - customresourcedefinitions
           verbs:
+          - create
           - get
           - list
           - watch
-      permissions:
-      - serviceAccountName: gpu-operator
-        rules:
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - roles
-          - rolebindings
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - pods/eviction
-          - services
-          - services/finalizers
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
+          - update
           - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
           - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - controllerrevisions
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          - prometheusrules
-          verbs:
-          - get
-          - create
-          - list
-          - update
-          - watch
-          - delete
-        - apiGroups:
-          - apps
-          resourceNames:
-          - gpu-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-        - apiGroups:
-          - nvidia.com
-          resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - '*'
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - get
-          - list
-          - watch
       deployments:
       - name: gpu-operator
         spec:

--- a/deployments/gpu-operator/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/templates/clusterrole.yaml
@@ -147,10 +147,8 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
   - coordination.k8s.io
   resources:
-  - configmaps
   - leases
   verbs:
   - get


### PR DESCRIPTION
This PR does the following:

- Remove the wildcard perms found in the ClusterRole defined in the OpenShift OLM bundle
- Remove the unnecessary Role as gpu-operator only needs the ClusterRole
- Parity with the helm chart 


Verified and tested on an OpenShift cluster