### PR TITLE
Mount the host's /dev into the mig-manager container

### DIFF
--- a/assets/state-mig-manager/0600_daemonset.yaml
+++ b/assets/state-mig-manager/0600_daemonset.yaml
@@ -66,6 +66,8 @@ spec:
           mountPath: /run/nvidia/validations
         - mountPath: /sys
           name: host-sys
+        - mountPath: /dev
+          name: host-dev
         - mountPath: /mig-parted-config
           name: mig-parted-config
         - mountPath: /host
@@ -86,6 +88,10 @@ spec:
       - name: host-sys
         hostPath:
           path: /sys
+          type: Directory
+      - name: host-dev
+        hostPath:
+          path: /dev
           type: Directory
       - name: mig-parted-config
         configMap:


### PR DESCRIPTION
After applying a MIG configuration but before regenerating the management CDI spec, it is required to run nvidia-smi to create the nvidia-cap* device nodes. For non-standard driver installs, where NVIDIA_DEV_ROOT=/ and NVIDIA_DRIVER_ROOT=/some/other/path, we need to make /dev writable inside of the mig-manager container.

Corresponding PR in mig-manager: https://github.com/NVIDIA/mig-parted/pull/82

I am planning to add a transform for the newly added `host-dev` volume in a follow-up -- the host path of the volume needs to be changed if a custom `hostPaths.rootFS` is configured in Clusterpolicy. There are a few other host path volumes, like `host-sys` and `host-os-release`, that were missed when adding `hostPaths.rootFS` to Clusterpolicy. I will add transforms for all of these in a follow-up. 
