### PR TITLE
[validator] address edge case where nvidia-smi on host is empty

### DIFF
--- a/validator/main.go
+++ b/validator/main.go
@@ -693,6 +693,13 @@ func isDriverManagedByOperator(ctx context.Context) (bool, error) {
 
 func validateHostDriver(silent bool) error {
 	log.Info("Attempting to validate a pre-installed driver on the host")
+	fileInfo, err := os.Lstat("/host/usr/bin/nvidia-smi")
+	if err != nil {
+		return fmt.Errorf("no 'nvidia-smi' file present on the host: %w", err)
+	}
+	if fileInfo.Size() == 0 {
+		return fmt.Errorf("empty 'nvidia-smi' file found on the host")
+	}
 	command := "chroot"
 	args := []string{"/host", "nvidia-smi"}
 


### PR DESCRIPTION
This restores the logic that was accidentally removed in https://github.com/NVIDIA/gpu-operator/commit/c46ade78beebc4ae3dd7de934974f5871baa0bd3