### PR TITLE
upgrade golang version to v1.22.5

### DIFF
--- a/validator/versions.mk
+++ b/validator/versions.mk
@@ -16,4 +16,4 @@
 include $(CURDIR)/../versions.mk
 
 CUDA_SAMPLES_VERSION ?= 11.7.1
-GOLANG_VERSION ?= 1.22.2
+GOLANG_VERSION ?= 1.22.5

--- a/versions.mk
+++ b/versions.mk
@@ -19,6 +19,6 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v24.3.0
 
-GOLANG_VERSION ?= 1.22.2
+GOLANG_VERSION ?= 1.22.5
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always 2> /dev/null || echo "")


### PR DESCRIPTION
This version bump address the following CVE:

https://nvd.nist.gov/vuln/detail/CVE-2024-24791  
