### PR TITLE
add prometheus CR permissions back to gpu-operator clusterrole

### DIFF
--- a/deployments/gpu-operator/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/templates/clusterrole.yaml
@@ -89,6 +89,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
+  - delete
+- apiGroups:
   - nvidia.com
   resources:
   - clusterpolicies

--- a/deployments/gpu-operator/templates/role.yaml
+++ b/deployments/gpu-operator/templates/role.yaml
@@ -46,18 +46,6 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  - prometheusrules
-  verbs:
-  - get
-  - list
-  - create
-  - watch
-  - update
-  - delete
-- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/NVIDIA/gpu-operator/pull/750

It seems that the Clusterpolicy controller's informers expect to be able list and watch  ServiceMonitors in the cluster scope when the `ServiceMonitor` CRD is installed.

To reproduce this, install the latest gpu-operator helm chart on a cluster that already has the kube-prometheus stack installed