### PR TITLE
set NFD priority class to system-node-critical

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -500,6 +500,7 @@ ccManager:
 
 node-feature-discovery:
   enableNodeFeatureApi: true
+  priorityClassName: system-node-critical
   gc:
     enable: true
     replicaCount: 1


### PR DESCRIPTION
As node feature discovery is a critical component to the gpu-operator, we set the same priorityclass as that of the gpu-operator