### PR TITLE
Align the custom mig-manager configmap in helm chart with device-plugin

### DIFF
--- a/deployments/gpu-operator/templates/mig_config.yaml
+++ b/deployments/gpu-operator/templates/mig_config.yaml
@@ -6,9 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-operator.labels" . | nindent 4 }}
-data:
-  config.yaml: |
-    version: v1
-    mig-configs:
-{{- .Values.migManager.config.data | nindent 6 }}
+data: {{ toYaml .Values.migManager.config.data | nindent 2 }}
 {{- end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -366,26 +366,29 @@ migManager:
   #   name: custom-mig-parted-configs
   #   create: true
   #   data: |-
-  #     all-disabled:
-  #       - devices: all
-  #         mig-enabled: false
-  #     custom-mig:
-  #       - devices: [0]
-  #         mig-enabled: false
-  #       - devices: [1]
-  #          mig-enabled: true
-  #          mig-devices:
-  #            "1g.10gb": 7
-  #       - devices: [2]
-  #         mig-enabled: true
-  #         mig-devices:
-  #           "2g.20gb": 2
-  #           "3g.40gb": 1
-  #       - devices: [3]
-  #         mig-enabled: true
-  #         mig-devices:
-  #           "3g.40gb": 1
-  #           "4g.40gb": 1
+  #     config.yaml: |-
+  #       version: v1
+  #       mig-configs:
+  #         all-disabled:
+  #           - devices: all
+  #             mig-enabled: false
+  #         custom-mig:
+  #           - devices: [0]
+  #             mig-enabled: false
+  #           - devices: [1]
+  #              mig-enabled: true
+  #              mig-devices:
+  #                "1g.10gb": 7
+  #           - devices: [2]
+  #             mig-enabled: true
+  #             mig-devices:
+  #               "2g.20gb": 2
+  #               "3g.40gb": 1
+  #           - devices: [3]
+  #             mig-enabled: true
+  #             mig-devices:
+  #               "3g.40gb": 1
+  #               "4g.40gb": 1
   config:
     default: "all-disabled"
     # Create a ConfigMap (default: false)

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -391,7 +391,7 @@ migManager:
     # Create a ConfigMap (default: false)
     create: false
     # ConfigMap name (either existing or to create a new one with create=true above)
-    name: "default-mig-parted-config"
+    name: ""
     # Data section for the ConfigMap to create (i.e only applies when create=true)
     data: {}
   gpuClientsConfig:


### PR DESCRIPTION
This PR aligns the `config.name` and `config.data` fields in the helm chart for both the mig-manager and the device-plugin.