### PR TITLE
controller-runtime cache should only list-watch resources in the operator namespace

### DIFF
--- a/controllers/clusterinfo/clusterinfo.go
+++ b/controllers/clusterinfo/clusterinfo.go
@@ -341,7 +341,7 @@ func getOpenshiftDTKImages(ctx context.Context, c *rest.Config) map[string]strin
 	logger := log.FromContext(ctx)
 
 	name := "driver-toolkit"
-	namespace := "openshift"
+	namespace := consts.OpenshiftNamespace
 
 	ocpImageClient, err := imagesv1.NewForConfig(c)
 	if err != nil {

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
+	"github.com/NVIDIA/gpu-operator/internal/consts"
 	"github.com/NVIDIA/gpu-operator/internal/utils"
 )
 
@@ -3705,7 +3706,7 @@ func ocpHasDriverToolkitImageStream(n *ClusterPolicyController) (bool, error) {
 	ctx := n.ctx
 	found := &apiimagev1.ImageStream{}
 	name := "driver-toolkit"
-	namespace := "openshift"
+	namespace := consts.OpenshiftNamespace
 	err := n.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, found)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -39,6 +39,9 @@ const (
 	// Containerd runtime
 	Containerd = "containerd"
 
+	// OpenshiftNamespace indicates the main namespace of an  Openshift cluster
+	OpenshiftNamespace = "openshift"
+
 	OcpDriverToolkitVersionLabel        = "openshift.driver-toolkit.rhcos"
 	OcpDriverToolkitIdentificationLabel = "openshift.driver-toolkit"
 	NfdOSTreeVersionLabelKey            = "feature.node.kubernetes.io/system-os_release.OSTREE_VERSION"


### PR DESCRIPTION
The controller-runtime `Manager ` object exposes the `cache.Options` struct which contains fields used to set the caching strategy of the controller.

By default, the controller's cache lists and watches namespaced-resources from all namespaces. With this change, we set the caching strategy to only list and watch for K8s resources that are created in the gpu-operator's namespace. 

Note: This change only affects Kubernetes resources that have the namespace-scope. The cluster-scoped resources like Nodes, ClusterPolicy, NVIDIADriver will continue to be cached as before