### PR TITLE
fix govet issues and pin golangci-lint version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.60.1
           args: -v --timeout 5m
           skip-cache: true
       - run: make check

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2846,7 +2846,7 @@ func transformOpenShiftDriverToolkitContainer(obj *appsv1.DaemonSet, config *gpu
 			return nil, nil
 		}
 
-		return nil, fmt.Errorf(fmt.Sprintf("could not find the '%s' container", name))
+		return nil, fmt.Errorf("could not find the '%s' container", name)
 	}
 
 	if !n.ocpDriverToolkit.enabled {

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -190,7 +190,7 @@ func (f *Framework) AfterEach(ctx context.Context) {
 			for namespaceKey, namespaceErr := range nsDeletionErrors {
 				messages = append(messages, fmt.Sprintf("Couldn't delete ns: %q: %s (%#v)", namespaceKey, namespaceErr, namespaceErr))
 			}
-			e2elog.Failf(strings.Join(messages, ","))
+			ginkgo.Fail(strings.Join(messages, ","))
 		}
 	}()
 

--- a/validator/main.go
+++ b/validator/main.go
@@ -1031,7 +1031,7 @@ func (m *MOFED) validate() error {
 
 	present, err := m.isMellanoxDevicePresent()
 	if err != nil {
-		log.Errorf(err.Error())
+		log.Errorf("Error trying to retrieve Mellanox device - %s\n", err.Error())
 		return err
 	}
 	if !present {


### PR DESCRIPTION
The code in the main branch has started to fail lint checks with the golangci-lint version (`v1.60.1). The latest golangci-lint  version is automatically pulled by the actions pipeline  as we don't pin any version. 

This PR ensures that the CI status of the main branch remains green by pinning the golangci-lint version