### PR TITLE
Document `config` object in DCGM Exporter values

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -335,8 +335,8 @@ dcgmExporter:
   # Point to a ConfigMap with a customized list of metrics for DCGM Exporter to emit.
   # The ConfigMap must exist in the same namespace as the release.
   # The metrics are expected to be listed under a key called `dcgm-metrics.csv`.
-  config:
-    name: ""
+  # config:
+  #   name: ""
 gfd:
   enabled: true
   repository: nvcr.io/nvidia

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -332,7 +332,11 @@ dcgmExporter:
     #   target_label: instance
     #   replacement: $1
     #   action: replace
-
+  # Point to a ConfigMap with a customized list of metrics for DCGM Exporter to emit.
+  # The ConfigMap must exist in the same namespace as the release.
+  # The metrics are expected to be listed under a key called `dcgm-metrics.csv`.
+  config:
+    name: ""
 gfd:
   enabled: true
   repository: nvcr.io/nvidia


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

This PR documents the existence of the `config` struct in the ClusterPolicy by adding it, and a description, to the values file. The value has been commented out but can also be uncommented with `config.name` left as an empty string to be consistent with other areas of the chart.