### PR TITLE
Revert "Bump NVIDIA/holodeck from 0.2.1 to 0.2.3"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out code
       - name: Set up Holodeck
-        uses: NVIDIA/holodeck@v0.2.3
+        uses: NVIDIA/holodeck@v0.2.1
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -270,7 +270,7 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out code
       - name: Set up Holodeck
-        uses: NVIDIA/holodeck@v0.2.3
+        uses: NVIDIA/holodeck@v0.2.1
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This reverts commit 57bb5ca2df6205004d15b8a37b7630481d59a644.

We have started to see the following errors in holodeck

```
rsync: [sender] send_files failed to open "/home/runner/work/gpu-operator/gpu-operator/.cache/key": Permission denied (13)
```

```
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1338) [sender=3.2.7]

sent 440,772 bytes  received 11,846 bytes  905,236.00 bytes/sec
total size is 10,410,022  speedup is 23.00
receiving incremental file list
rsync: [sender] link_stat "/tmp/logs" failed: No such file or directory (2)
```