### PR TITLE
Allow custom metrics for DCGM Exporter

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -511,8 +511,9 @@ spec:
     {{- if .Values.dcgmExporter.args }}
     args: {{ toYaml .Values.dcgmExporter.args | nindent 6 }}
     {{- end }}
-    {{- if .Values.dcgmExporter.config }}
-    config: {{ toYaml .Values.dcgmExporter.config | nindent 6 }}
+    {{- if and (.Values.dcgmExporter.config) (.Values.dcgmExporter.config.name) }}
+    config:
+      name: {{ .Values.dcgmExporter.config.name }}
     {{- end }}
     {{- if .Values.dcgmExporter.serviceMonitor }}
     serviceMonitor: {{ toYaml .Values.dcgmExporter.serviceMonitor | nindent 6 }}

--- a/deployments/gpu-operator/templates/dcgm_exporter_config.yaml
+++ b/deployments/gpu-operator/templates/dcgm_exporter_config.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.dcgmExporter.config }}
+{{- if and (.Values.dcgmExporter.config.create) (not (empty .Values.dcgmExporter.config.data)) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.dcgmExporter.config.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gpu-operator.labels" . | nindent 4 }}
+data:
+  dcgm-metrics.csv: |
+{{- .Values.dcgmExporter.config.data | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -332,7 +332,26 @@ dcgmExporter:
     #   target_label: instance
     #   replacement: $1
     #   action: replace
+  # DCGM Exporter configuration
+  # This block is used to configure DCGM Exporter to emit a customized list of metrics.
+  # Use "name" to either point to an existing ConfigMap or to create a new one with a
+  # list of configurations (i.e with create=true).
+  # When pointing to an existing ConfigMap, the ConfigMap must exist in the same namespace as the release.
+  # The metrics are expected to be listed under a key called `dcgm-metrics.csv`.
+  # Use "data" to build an integrated ConfigMap from a set of custom metrics as
+  # part of the chart. An example of some custom metrics are shown below. Note that
+  # the contents of "data" must be in CSV format and be valid DCGM Exporter metric configurations.
+  # config:
+    # name: custom-dcgm-exporter-metrics
+    # create: true
+    # data: |-
+      # Format
+      # If line starts with a '#' it is considered a comment
+      # DCGM FIELD, Prometheus metric type, help message
 
+      # Clocks
+      # DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
+      # DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
 gfd:
   enabled: true
   repository: nvcr.io/nvidia


### PR DESCRIPTION
Closes #934 
Supersedes #935
Relates to NVIDIA/dcgm-exporter/pull/351

## Summary

This PR allows users to define a list of custom DCGM Exporter metrics during installation time. It secondarily documents in the values file the existence of the `config` element which, prior to this change, allowed users to point to an existing ConfigMap which contained such custom metrics. After this change users will be able to:

1. Use the values file as documentation to discover available fields for configuring DCGM Exporter via the Operator.
2. Define in-line to their values a list of their own custom metrics, obviating the need to pre-create a ConfigMap with the same contents.

This PR uses #803 by @frittentheke as a model to achieve as much consistency as possible for UX purposes.

## Demo

Templating results with defaults as shown in this PR.

<details><summary>Details</summary>
<p>

```sh
helm template gpu-operator . -s templates/clusterpolicy.yaml | yq .spec.dcgmExporter
```

```yaml
enabled: true
repository: nvcr.io/nvidia/k8s
image: dcgm-exporter
version: "3.3.7-3.5.0-ubuntu22.04"
imagePullPolicy: IfNotPresent
env:
  - name: DCGM_EXPORTER_LISTEN
    value: :9400
  - name: DCGM_EXPORTER_KUBERNETES
    value: "true"
  - name: DCGM_EXPORTER_COLLECTORS
    value: /etc/dcgm-exporter/dcp-metrics-included.csv
serviceMonitor:
  additionalLabels: {}
  enabled: false
  honorLabels: false
  interval: 15s
  relabelings: []
```

</p>
</details> 

Templating results with `dcgmExporter.config.name` defined. Same results with the addition of `create=false`.

<details><summary>Details</summary>
<p>

```sh
helm template gpu-operator . -s templates/clusterpolicy.yaml | yq .spec.dcgmExporter
```

```yaml
enabled: true
repository: nvcr.io/nvidia/k8s
image: dcgm-exporter
version: "3.3.7-3.5.0-ubuntu22.04"
imagePullPolicy: IfNotPresent
env:
  - name: DCGM_EXPORTER_LISTEN
    value: :9400
  - name: DCGM_EXPORTER_KUBERNETES
    value: "true"
  - name: DCGM_EXPORTER_COLLECTORS
    value: /etc/dcgm-exporter/dcp-metrics-included.csv
config:
  name: custom-dcgm-exporter-metrics
serviceMonitor:
  additionalLabels: {}
  enabled: false
  honorLabels: false
  interval: 15s
  relabelings: []
```

</p>
</details> 

Templating results with `name`, `create=true`, and `data` populated.

<details><summary>Details</summary>
<p>

```sh
helm template gpu-operator . -s templates/clusterpolicy.yaml | yq .spec.dcgmExporter
```

```yaml
enabled: true
repository: nvcr.io/nvidia/k8s
image: dcgm-exporter
version: "3.3.7-3.5.0-ubuntu22.04"
imagePullPolicy: IfNotPresent
env:
  - name: DCGM_EXPORTER_LISTEN
    value: :9400
  - name: DCGM_EXPORTER_KUBERNETES
    value: "true"
  - name: DCGM_EXPORTER_COLLECTORS
    value: /etc/dcgm-exporter/dcp-metrics-included.csv
config:
  name: custom-dcgm-exporter-metrics
serviceMonitor:
  additionalLabels: {}
  enabled: false
  honorLabels: false
  interval: 15s
  relabelings: []
```

```sh
helm template gpu-operator . -s templates/dcgm_exporter_config.yaml
```

```yaml
---
# Source: gpu-operator/templates/dcgm_exporter_config.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: custom-dcgm-exporter-metrics
  namespace: default
  labels:
    app.kubernetes.io/name: gpu-operator
    helm.sh/chart: gpu-operator-v24.6.1
    app.kubernetes.io/instance: gpu-operator
    app.kubernetes.io/version: "v24.6.1"
    app.kubernetes.io/managed-by: Helm
data:
  dcgm-metrics.csv: |
    # Format
    # If line starts with a '#' it is considered a comment
    # DCGM FIELD, Prometheus metric type, help message
    
    # Clocks
    DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
```

Installing chart from this PR and verifying the DCGM Exporter contains the volume pointing to the new ConfigMap.

```sh
kubectl -n nvidia-gpu-operator get ds nvidia-dcgm-exporter -o yaml | yq .spec.template.spec.volumes
```

```yaml
- hostPath:
    path: /var/lib/kubelet/pod-resources
    type: ""
  name: pod-gpu-resources
- hostPath:
    path: /run/nvidia
    type: ""
  name: run-nvidia
- configMap:
    defaultMode: 420
    items:
      - key: dcgm-metrics.csv
        path: dcgm-metrics.csv
    name: custom-dcgm-exporter-metrics
  name: metrics-config
```

</p>
</details> 