### PR TITLE
disable privileged mode for toolkit-validation init containers

### DIFF
--- a/assets/gpu-feature-discovery/0500_daemonset.yaml
+++ b/assets/gpu-feature-discovery/0500_daemonset.yaml
@@ -30,12 +30,10 @@ spec:
           image: "FILLED BY THE OPERATOR"
           command: ['sh', '-c']
           args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done"]
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: run-nvidia
               mountPath: /run/nvidia
-              mountPropagation: Bidirectional
+              mountPropagation: HostToContainer
         - name: config-manager-init
           image: "FILLED BY THE OPERATOR"
           command: ["config-manager"]

--- a/assets/state-dcgm-exporter/0900_daemonset.yaml
+++ b/assets/state-dcgm-exporter/0900_daemonset.yaml
@@ -29,8 +29,6 @@ spec:
         image: "FILLED BY THE OPERATOR"
         command: ['sh', '-c']
         args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done"]
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: run-nvidia
             mountPath: "/run/nvidia"

--- a/assets/state-dcgm/0400_dcgm.yml
+++ b/assets/state-dcgm/0400_dcgm.yml
@@ -29,8 +29,6 @@ spec:
         image: "FILLED BY THE OPERATOR"
         command: ['sh', '-c']
         args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done"]
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: run-nvidia
             mountPath: /run/nvidia

--- a/assets/state-device-plugin/0500_daemonset.yaml
+++ b/assets/state-device-plugin/0500_daemonset.yaml
@@ -29,8 +29,6 @@ spec:
         name: toolkit-validation
         command: ['sh', '-c']
         args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done"]
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: run-nvidia-validations
             mountPath: /run/nvidia/validations

--- a/assets/state-mig-manager/0600_daemonset.yaml
+++ b/assets/state-mig-manager/0600_daemonset.yaml
@@ -29,8 +29,6 @@ spec:
           image: "FILLED BY THE OPERATOR"
           command: ['sh', '-c']
           args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container toolkit to be setup; sleep 5; done"]
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: run-nvidia-validations
               mountPath: /run/nvidia/validations

--- a/assets/state-mps-control-daemon/0400_daemonset.yaml
+++ b/assets/state-mps-control-daemon/0400_daemonset.yaml
@@ -30,8 +30,6 @@ spec:
           name: toolkit-validation
           command: ['sh', '-c']
           args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done"]
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: run-nvidia
               mountPath: /run/nvidia

--- a/assets/state-sandbox-device-plugin/0500_daemonset.yaml
+++ b/assets/state-sandbox-device-plugin/0500_daemonset.yaml
@@ -35,8 +35,6 @@ spec:
           env:
             - name: NVIDIA_VISIBLE_DEVICES
               value: void
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: run-nvidia-validations
               mountPath: /run/nvidia/validations


### PR DESCRIPTION
The `privileged: true` was required as the host mounts for the toolkit-validation containers were previously "Bidirectional". However, after this commit 2f156d6528882c68f9c9a13702771cc785afb0a7, the toolkit-validation init-container host mounts have since been changed to "HostToContainer" propagation.

In line with the principle of least privilege, we disable the privileged: true as they "HostToContainer" propagation don't necessitate privileged mode