### PR TITLE
[RBAC cleanup] move namespaced resources to Role from ClusterRole

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -641,18 +641,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          - prometheusrules
-          verbs:
-          - get
-          - list
-          - create
-          - watch
-          - update
-          - delete
-        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterroles
@@ -665,22 +653,6 @@ spec:
           - update
           - patch
           - delete
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - pods/eviction
-          - services
-          - services/finalizers
-          - events
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - ""
           resources:
@@ -703,17 +675,22 @@ spec:
           - update
           - patch
         - apiGroups:
-          - apps
+          - ""
           resources:
-          - daemonsets
+          - pods
+          - pods/eviction
           verbs:
+          - create
           - get
           - list
           - watch
+          - update
+          - patch
+          - delete
         - apiGroups:
           - apps
           resources:
-          - controllerrevisions
+          - daemonsets
           verbs:
           - get
           - list
@@ -728,18 +705,6 @@ spec:
           - create
           - update
           - watch
-          - delete
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - create
-          - get
-          - list
-          - watch
-          - update
-          - patch
           - delete
         - apiGroups:
           - apiextensions.k8s.io
@@ -772,6 +737,14 @@ spec:
         - apiGroups:
           - apps
           resources:
+          - controllerrevisions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
           - daemonsets
           verbs:
           - create
@@ -786,7 +759,10 @@ spec:
           resources:
           - configmaps
           - endpoints
+          - events
           - secrets
+          - services
+          - services/finalizers
           - serviceaccounts
           verbs:
           - create
@@ -795,6 +771,30 @@ spec:
           - watch
           - update
           - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - create
+          - watch
+          - update
           - delete
       deployments:
       - name: gpu-operator

--- a/deployments/gpu-operator/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/templates/clusterrole.yaml
@@ -52,21 +52,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  - pods
-  - pods/eviction
-  - services
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get
@@ -86,6 +71,19 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/eviction
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
   - apps
   resources:
   - daemonsets
@@ -93,26 +91,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  - prometheusrules
-  verbs:
-  - get
-  - list
-  - create
-  - watch
-  - update
-  - delete
 - apiGroups:
   - nvidia.com
   resources:
@@ -140,18 +118,6 @@ rules:
   - list
   - watch
   - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
 - apiGroups:
   - node.k8s.io
   resources:

--- a/deployments/gpu-operator/templates/role.yaml
+++ b/deployments/gpu-operator/templates/role.yaml
@@ -22,6 +22,14 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - daemonsets
   verbs:
   - create
@@ -35,7 +43,13 @@ rules:
   - ""
   resources:
   - configmaps
+  - endpoints
+  - events
+  - pods
+  - pods/eviction
   - secrets
+  - services
+  - services/finalizers
   - serviceaccounts
   verbs:
   - create
@@ -44,4 +58,28 @@ rules:
   - watch
   - update
   - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
   - delete


### PR DESCRIPTION
Since limited the caching of resources to the `gpu-operator` and `openshift` namespace, we should now be good to move all namespaced resources to roles from ClusterRole. The GPU Operator should no longer need Cluster-level permissions for most (if not all) of the namespaced resources it interacts with