### PR TITLE
downgrade go from 1.23.0 to 1.22.7

### DIFF
--- a/validator/versions.mk
+++ b/validator/versions.mk
@@ -16,4 +16,4 @@
 include $(CURDIR)/../versions.mk
 
 CUDA_SAMPLES_VERSION ?= 11.7.1
-GOLANG_VERSION ?= 1.23.0
+GOLANG_VERSION ?= 1.22.7

--- a/versions.mk
+++ b/versions.mk
@@ -19,6 +19,6 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v24.6.1
 
-GOLANG_VERSION ?= 1.23.0
+GOLANG_VERSION ?= 1.22.7
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always 2> /dev/null || echo "")


### PR DESCRIPTION
Go 1.23 has a regression which has yet to be fixed (As of 16 Sep 2024). 

This regression is seen when invoking the `go` binary in multi-arch docker builds.

https://github.com/golang/go/issues/68976

Until a hotfix is released, we should downgrade to go 1.22