### PR TITLE
[release-24.6] bump cuda base images to fix CVE 2024-6345

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -221,13 +221,13 @@ spec:
     - name: mig-manager-image
       image: nvcr.io/nvidia/cloud-native/k8s-mig-manager@sha256:781fb47e264d9e0fbc8da5bd046e5e678316c866bc36ddd4b56d4eb0de682d5b
     - name: init-container-image
-      image: nvcr.io/nvidia/cuda@sha256:b0b6c9286f20432ba9becb711aff2d1c1bd56e47b33e6d1cab04aba926c067fe
+      image: nvcr.io/nvidia/cuda@sha256:de5b598bca89850567c4c104411d66bb52f47c9179199e6a3be6829b7ac586a2
     - name: gpu-operator-validator-image
       image: registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-validator:main-latest-ubi8
     - name: k8s-driver-manager-image
       image: nvcr.io/nvidia/cloud-native/k8s-driver-manager@sha256:740abc3ff657545c10effd5354f09af525200ed9a1b7623f0c2e8c7bd9e4a4e2
     - name: vfio-manager-image
-      image: nvcr.io/nvidia/cuda@sha256:b0b6c9286f20432ba9becb711aff2d1c1bd56e47b33e6d1cab04aba926c067fe
+      image: nvcr.io/nvidia/cuda@sha256:de5b598bca89850567c4c104411d66bb52f47c9179199e6a3be6829b7ac586a2
     - name: sandbox-device-plugin-image
       image: nvcr.io/nvidia/kubevirt-gpu-device-plugin@sha256:969147c01d63be5d1fe458f32f1cc0c7408cf3062531db91408e2fc57b4d8a67
     - name: vgpu-device-manager-image
@@ -878,9 +878,9 @@ spec:
                   - name: "MIG_MANAGER_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/k8s-mig-manager@sha256:781fb47e264d9e0fbc8da5bd046e5e678316c866bc36ddd4b56d4eb0de682d5b"
                   - name: "CUDA_BASE_IMAGE"
-                    value: "nvcr.io/nvidia/cuda@sha256:b0b6c9286f20432ba9becb711aff2d1c1bd56e47b33e6d1cab04aba926c067fe"
+                    value: "nvcr.io/nvidia/cuda@sha256:de5b598bca89850567c4c104411d66bb52f47c9179199e6a3be6829b7ac586a2"
                   - name: "VFIO_MANAGER_IMAGE"
-                    value: "nvcr.io/nvidia/cuda@sha256:b0b6c9286f20432ba9becb711aff2d1c1bd56e47b33e6d1cab04aba926c067fe"
+                    value: "nvcr.io/nvidia/cuda@sha256:de5b598bca89850567c4c104411d66bb52f47c9179199e6a3be6829b7ac586a2"
                   - name: "SANDBOX_DEVICE_PLUGIN_IMAGE"
                     value: "nvcr.io/nvidia/kubevirt-gpu-device-plugin@sha256:969147c01d63be5d1fe458f32f1cc0c7408cf3062531db91408e2fc57b4d8a67"
                   - name: "VGPU_DEVICE_MANAGER_IMAGE"

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -83,7 +83,7 @@ operator:
   initContainer:
     image: cuda
     repository: nvcr.io/nvidia
-    version: 12.5.1-base-ubi8
+    version: 12.6.1-base-ubi8
     imagePullPolicy: IfNotPresent
   tolerations:
   - key: "node-role.kubernetes.io/master"
@@ -468,7 +468,7 @@ vfioManager:
   enabled: true
   repository: nvcr.io/nvidia
   image: cuda
-  version: 12.5.1-base-ubi8
+  version: 12.6.1-base-ubi8
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   env: []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GOLANG_VERSION=x.x.x
 
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubi8 as builder
+FROM nvcr.io/nvidia/cuda:12.6.1-base-ubi8 as builder
 
 RUN yum install -y wget make git gcc
 
@@ -55,7 +55,7 @@ ARG VERSION="unknown"
 ARG GIT_COMMIT="unknown"
 RUN make gpu-operator
 
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubi8
+FROM nvcr.io/nvidia/cuda:12.6.1-base-ubi8
 
 # Remove CUDA libs(compat etc) in favor of libs installed by the NVIDIA driver
 RUN dnf remove -y cuda-*

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -15,7 +15,7 @@
 ARG CUDA_SAMPLE_IMAGE=undefined
 ARG GOLANG_VERSION=x.x.x
 
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubi8 as build
+FROM nvcr.io/nvidia/cuda:12.6.1-base-ubi8 as build
 
 RUN yum install -y wget make git gcc
 
@@ -51,7 +51,7 @@ FROM ${CUDA_SAMPLE_IMAGE} AS sample-builder
 RUN mkdir /artifacts
 RUN cp /cuda-samples/vectorAdd /artifacts/vectorAdd
 
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubi8
+FROM nvcr.io/nvidia/cuda:12.6.1-base-ubi8
 
 # Remove CUDA libs(compat etc) in favor of libs installed by the NVIDIA driver
 RUN dnf remove -y cuda-*


### PR DESCRIPTION
The gpu-operator v24.6.1 tag currently has two HIGH CVEs appearing on its security scans. These CVEs are inherited through the use of the `cuda:12.5.1-base-ubi8` base image. This CVE has since been fixed in the latest cuda base image `12.6.1-base-ubi8`

Limiting this changeset to the release-24.6 branch as we are using ubi9 base images in the `main` branch  