### PR TITLE
add glibc/lib to library search paths

### DIFF
--- a/validator/find.go
+++ b/validator/find.go
@@ -34,6 +34,7 @@ func (r root) getDriverLibraryPath() (string, error) {
 		"/lib64",
 		"/lib/x86_64-linux-gnu",
 		"/lib/aarch64-linux-gnu",
+		"/glibc/lib",
 	}
 
 	libraryPath, err := r.findFile("libnvidia-ml.so.1", librarySearchPaths...)


### PR DESCRIPTION
## Issue
When running Talos Linux, the Nvidia driver libraries are located under /usr/local/glibc/lib, and the binaries under /usr/local/bin. Using the default search paths, and a `driverInstallDir` value of `/usr/local` the validator is able to locate the binaries, but not the libraries.

## Proposed solution
Add "glibc/lib" to the library search path. This has been tested to work on a Talos cluster running 1.8.1, production drivers (550.90.07) and H100 GPUs

There are however several other Nvidia components that will have to be updated with this same change in order to support Talos Linux properly. I am currently aware these repos that require the same change:
* [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin)
* [mig-parted](https://github.com/NVIDIA/mig-parted)
* [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
* [go-nvlib](https://github.com/NVIDIA/go-nvlib)

See the referenced pull requests.
https://github.com/NVIDIA/k8s-device-plugin/pull/1001
https://github.com/NVIDIA/mig-parted/pull/137
https://github.com/NVIDIA/nvidia-container-toolkit/pull/751
https://github.com/NVIDIA/go-nvlib/pull/47

### Note
I have not tested all components that can be installed by the GPU Operator, like cc, katana and kubevirt components. These might require similar changes as well to properly support running on Talos Linux.