### PR TITLE
Disable `node-feature-discovery` when `nfd.enabled` is false

### DIFF
--- a/deployments/gpu-operator/templates/clusterrolebinding.yaml
+++ b/deployments/gpu-operator/templates/clusterrolebinding.yaml
@@ -9,6 +9,7 @@ subjects:
 - kind: ServiceAccount
   name: gpu-operator
   namespace: {{ $.Release.Namespace }}
+{{- if .Values.nfd.enabled }}
 - kind: ServiceAccount
   name: node-feature-discovery
   namespace: {{ $.Release.Namespace }}


### PR DESCRIPTION

Fixes #1038 
In clusterrolebinding.yaml, the `node-feature-discovery` is only included when `.Values.nfd.enabled` is true.