### PR TITLE
Always add 'config' emptyDir volume to MPS daemonset

### DIFF
--- a/assets/state-mps-control-daemon/0400_daemonset.yaml
+++ b/assets/state-mps-control-daemon/0400_daemonset.yaml
@@ -71,6 +71,9 @@ spec:
               value: ""
             - name: PROCESS_TO_SIGNAL
               value: ""
+          volumeMounts:
+            - name: config
+              mountPath: /config
       containers:
         - image: "FILLED BY OPERATOR"
           name: mps-control-daemon-ctr
@@ -92,6 +95,8 @@ spec:
               mountPath: /dev/shm
             - name: mps-root
               mountPath: /mps
+            - name: config
+              mountPath: /config
         - image: "FILLED BY THE OPERATOR"
           name: config-manager
           command: ["config-manager"]
@@ -120,6 +125,9 @@ spec:
               value: "1" # SIGHUP
             - name: PROCESS_TO_SIGNAL
               value: "/usr/bin/mps-control-daemon"
+          volumeMounts:
+            - name: config
+              mountPath: /config
       volumes:
         - name: run-nvidia
           hostPath:
@@ -132,3 +140,5 @@ spec:
         - name: mps-shm
           hostPath:
             path: /run/nvidia/mps/shm
+        - name: config
+          emptyDir: {}


### PR DESCRIPTION
This was missed in https://github.com/NVIDIA/gpu-operator/pull/1070

The following error is resolved with this PR:
```
$ kubectl logs -n gpu-operator nvidia-device-plugin-mps-control-daemon-j57tn -c config-manager-init
W1028 20:45:36.571294     120 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I1028 20:45:36.571587     120 main.go:246] Waiting for change to 'nvidia.com/device-plugin.config' label
I1028 20:45:36.591680     120 main.go:248] Label change detected: nvidia.com/device-plugin.config=
I1028 20:45:36.591906     120 main.go:360] No value set. Selecting default name: mps
I1028 20:45:36.591922     120 main.go:304] Updating to config: mps
E1028 20:45:36.592027     120 main.go:208] error creating symlink: symlink /available-configs/mps /config/config.yaml: no such file or directory
```