### PR TITLE
move permissions for events from Role to ClusterRole

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -679,6 +679,7 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - events
           - pods
           - pods/eviction
           verbs:
@@ -761,7 +762,6 @@ spec:
           resources:
           - configmaps
           - endpoints
-          - events
           - secrets
           - services
           - services/finalizers

--- a/deployments/gpu-operator/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/templates/clusterrole.yaml
@@ -73,6 +73,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - pods
   - pods/eviction
   verbs:

--- a/deployments/gpu-operator/templates/role.yaml
+++ b/deployments/gpu-operator/templates/role.yaml
@@ -44,7 +44,6 @@ rules:
   resources:
   - configmaps
   - endpoints
-  - events
   - pods
   - pods/eviction
   - secrets


### PR DESCRIPTION
Events are a namespaced resource created in the `default` namespace (This is a K8s implementation detail). Since gpu-operator needs to create events in a namespace outside of its own, we grant it Cluster-scoped permissions to manage events

This fixes #1101 