### PR TITLE
drop the distro-specific tag suffix from the device-plugin image

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -242,7 +242,7 @@ devicePlugin:
   enabled: true
   repository: nvcr.io/nvidia
   image: k8s-device-plugin
-  version: v0.17.0-ubi9
+  version: v0.17.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   args: []
@@ -356,7 +356,7 @@ gfd:
   enabled: true
   repository: nvcr.io/nvidia
   image: k8s-device-plugin
-  version: v0.17.0-ubi9
+  version: v0.17.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   env:


### PR DESCRIPTION
Addressing @elezar's review comment in this PR.

Starting v0.17.0, device-plugin (and GFD) will no longer have distro-specific image variants. Only the following tags are available and both of which point to the same image

i) nvcr.io/nvidia/k8s-device-plugin:v0.17.0
ii) nvcr.io/nvidia/k8s-device-plugin:v0.17.0-ubi9

