### PR TITLE
[release-24.9] drop the distro-specific tag suffix from the device-plugin image

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -242,7 +242,7 @@ devicePlugin:
   enabled: true
   repository: nvcr.io/nvidia
   image: k8s-device-plugin
-  version: v0.17.0-ubi9
+  version: v0.17.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   args: []
@@ -356,7 +356,7 @@ gfd:
   enabled: true
   repository: nvcr.io/nvidia
   image: k8s-device-plugin
-  version: v0.17.0-ubi9
+  version: v0.17.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   env:


### PR DESCRIPTION
Signed-off-by: Tariq Ibrahim <tibrahim@nvidia.com>
(cherry picked from commit 14d5d4b27ceb5333bcc7a381e58a077ab73eadb0)