### PR TITLE
enable hostPID in mps-control-daemon

### DIFF
--- a/assets/state-mps-control-daemon/0400_daemonset.yaml
+++ b/assets/state-mps-control-daemon/0400_daemonset.yaml
@@ -25,6 +25,7 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       serviceAccountName: nvidia-device-plugin
+      hostPID: true
       initContainers:
         - image: "FILLED BY THE OPERATOR"
           name: toolkit-validation

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2479,9 +2479,14 @@ func handleDevicePluginConfig(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 		// add configmap volume mount
 		addSharedMountsForPluginConfig(&obj.Spec.Template.Spec.Containers[i], config.DevicePlugin.Config)
 	}
-	// Enable process ns sharing for PID access
-	shareProcessNamespace := true
-	obj.Spec.Template.Spec.ShareProcessNamespace = &shareProcessNamespace
+
+	// if hostPID is already set, we skip setting the shareProcessNamespace field
+	// for context, go to https://github.com/kubernetes-client/go/blob/master/kubernetes/docs/V1PodSpec.md
+	if !obj.Spec.Template.Spec.HostPID {
+		// Enable process ns sharing for PID access
+		shareProcessNamespace := true
+		obj.Spec.Template.Spec.ShareProcessNamespace = &shareProcessNamespace
+	}
 	// add configmap volume
 	obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, createConfigMapVolume(config.DevicePlugin.Config.Name, nil))
 


### PR DESCRIPTION
See [here](https://github.com/NVIDIA/k8s-dra-driver/pull/115) for context

Additionally, as our gpu drivers run in the host's pid namespace, this change would allow for viewing the mps server and workload processes when querying nvidia-smi from the driver context. This is useful for demo and debugging purposes.
