### PR TITLE
bump golang to 1.23.3

### DIFF
--- a/validator/versions.mk
+++ b/validator/versions.mk
@@ -16,4 +16,4 @@
 include $(CURDIR)/../versions.mk
 
 CUDA_SAMPLES_VERSION ?= 11.7.1
-GOLANG_VERSION ?= 1.22.7
+GOLANG_VERSION ?= 1.23.3

--- a/versions.mk
+++ b/versions.mk
@@ -19,6 +19,6 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v24.9.0
 
-GOLANG_VERSION ?= 1.22.8
+GOLANG_VERSION ?= 1.23.3
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always 2> /dev/null || echo "")


### PR DESCRIPTION
go 1.23.3 includes a fix for a regression in multi-arch image builds introduced in go 1.23