### PR TITLE
Add support for SUSE SLE-Micro

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -279,6 +279,20 @@ var SubscriptionPathMap = map[string](MountPathToVolumeSource){
 			},
 		},
 	},
+	"sl-micro": {
+		"/etc/zypp/credentials.d": corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/zypp/credentials.d",
+				Type: newHostPathType(corev1.HostPathDirectory),
+			},
+		},
+		"/etc/SUSEConnect": corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/SUSEConnect",
+				Type: newHostPathType(corev1.HostPathFileOrCreate),
+			},
+		},
+	},
 }
 
 type controlFunc []func(n ClusterPolicyController) (gpuv1.State, error)
@@ -3304,7 +3318,7 @@ func transformDriverContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 	}
 
 	// set up subscription entitlements for RHEL(using K8s with a non-CRIO runtime) and SLES
-	if (release["ID"] == "rhel" && n.openshift == "" && n.runtime != gpuv1.CRIO) || release["ID"] == "sles" {
+	if (release["ID"] == "rhel" && n.openshift == "" && n.runtime != gpuv1.CRIO) || release["ID"] == "sles" || release["ID"] == "sl-micro" {
 		n.logger.Info("Mounting subscriptions into the driver container", "OS", release["ID"])
 		pathToVolumeSource, err := getSubscriptionPathsToVolumeSources()
 		if err != nil {

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -111,6 +111,20 @@ var SubscriptionPathMap = map[string]MountPathToVolumeSource{
 			},
 		},
 	},
+	"sl-micro": {
+		"/etc/zypp/credentials.d": corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/zypp/credentials.d",
+				Type: newHostPathType(corev1.HostPathDirectory),
+			},
+		},
+		"/etc/SUSEConnect": corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/SUSEConnect",
+				Type: newHostPathType(corev1.HostPathFileOrCreate),
+			},
+		},
+	},
 }
 
 // TODO: make this a public utils method
@@ -171,7 +185,7 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 		}
 
 		// set up subscription entitlements for RHEL(using K8s with a non-CRIO runtime) and SLES
-		if (pool.osRelease == "rhel" && openshiftVersion == "" && runtime != consts.CRIO) || pool.osRelease == "sles" {
+		if (pool.osRelease == "rhel" && openshiftVersion == "" && runtime != consts.CRIO) || pool.osRelease == "sles" || pool.osRelease == "sl-micro" {
 			logger.Info("Mounting subscriptions into the driver container", "OS", pool.osVersion)
 			pathToVolumeSource, err := getSubscriptionPathsToVolumeSources(pool.osRelease)
 			if err != nil {


### PR DESCRIPTION
This patch adds support for SUSE Linux Enterprise Micro. This is considered the preferred container host.