### PR TITLE
use apimachinery/pkg/util/json instead of sigs.k8s.io/json

### DIFF
--- a/cmd/gpuop-cfg/validate/csv/alm-examples.go
+++ b/cmd/gpuop-cfg/validate/csv/alm-examples.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"sigs.k8s.io/json"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	v1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 )
@@ -28,7 +28,7 @@ import (
 func validateALMExample(csv *v1alpha1.ClusterServiceVersion) error {
 	cpList := []v1.ClusterPolicy{}
 	example := csv.Annotations["alm-examples"]
-	err := json.UnmarshalCaseSensitivePreserveInts([]byte(example), &cpList)
+	err := json.Unmarshal([]byte(example), &cpList)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	k8s.io/client-go v0.31.2
 	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.19.1
-	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -176,6 +175,7 @@ require (
 	k8s.io/kubectl v0.31.0 // indirect
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect
 	oras.land/oras-go v1.2.5 // indirect
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.17.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect


### PR DESCRIPTION
This is a minor dep tree cleanup. We use the `apimachinery` package to invoke the json `Unmarshal` method which in turn invokes the `UnmarshalCaseSensitivePreserveInts` defined in the `sigs.k8s.io/json`  module.

With this change, we have one less direct dependency