### PR TITLE
Expands regexp to also match 64k page size kernels

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2814,7 +2814,7 @@ func transformGDRCopyContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolic
 // 2. ensure to meet k8s constraints for metadata.name, i.e it
 // must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
 func getSanitizedKernelVersion(kernelVersion string) string {
-	archRegex := regexp.MustCompile("x86_64|aarch64")
+	archRegex := regexp.MustCompile("x86_64(?:_64k)?|aarch64(?:_64k)?")
 	// remove arch strings, "_" and any trailing "." from the kernel version
 	sanitizedVersion := strings.TrimSuffix(strings.ReplaceAll(archRegex.ReplaceAllString(kernelVersion, ""), "_", "."), ".")
 	return strings.ToLower(sanitizedVersion)

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -1065,3 +1065,21 @@ func TestDCGMExporter(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSanitizedKernelVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"5.14.0-427.37.1.el9_4.aarch64_64k", "5.14.0-427.37.1.el9.4"},
+		{"5.14.0-427.37.1.el9_4.aarch64", "5.14.0-427.37.1.el9.4"},
+		{"5.14.0-427.37.1.el9_4.x86_64_64k", "5.14.0-427.37.1.el9.4"},
+		{"5.14.0-427.37.1.el9_4.x86_64", "5.14.0-427.37.1.el9.4"},
+	}
+
+	for _, test := range tests {
+		result := getSanitizedKernelVersion(test.input)
+		require.NotEmpty(t, result)
+		require.Equal(t, test.expected, result)
+	}
+}

--- a/internal/state/driver.go
+++ b/internal/state/driver.go
@@ -642,7 +642,7 @@ func getRuntimeSpec(ctx context.Context, k8sClient client.Client, info clusterin
 // 2. ensure to meet k8s constraints for metadata.name, i.e it
 // must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
 func getSanitizedKernelVersion(kernelVersion string) string {
-	archRegex := regexp.MustCompile("x86_64|aarch64")
+	archRegex := regexp.MustCompile("x86_64(?:_64k)?|aarch64(?:_64k)?")
 	// remove arch strings, "_" and any trailing "." from the kernel version
 	sanitizedVersion := strings.TrimSuffix(strings.ReplaceAll(archRegex.ReplaceAllString(kernelVersion, ""), "_", "."), ".")
 	return strings.ToLower(sanitizedVersion)

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -770,3 +770,21 @@ func TestDriverVGPULicensing(t *testing.T) {
 	require.Equal(t, string(o), actual)
 
 }
+
+func TestGetSanitizedKernelVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"5.14.0-427.37.1.el9_4.aarch64_64k", "5.14.0-427.37.1.el9.4"},
+		{"5.14.0-427.37.1.el9_4.aarch64", "5.14.0-427.37.1.el9.4"},
+		{"5.14.0-427.37.1.el9_4.x86_64_64k", "5.14.0-427.37.1.el9.4"},
+		{"5.14.0-427.37.1.el9_4.x86_64", "5.14.0-427.37.1.el9.4"},
+	}
+
+	for _, test := range tests {
+		result := getSanitizedKernelVersion(test.input)
+		require.NotEmpty(t, result)
+		require.Equal(t, test.expected, result)
+	}
+}


### PR DESCRIPTION
This patch fixes #1207 

https://go.dev/play/p/rIQkPgUIS4D?v=goprev