### PR TITLE
Remove defaultRuntime as it's no longer used.

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -29,7 +29,6 @@ metadata:
           },
           "spec": {
             "operator": {
-              "defaultRuntime": "crio",
               "use_ocp_driver_toolkit": true,
               "initContainer": {
               }

--- a/config/samples/v1_clusterpolicy.yaml
+++ b/config/samples/v1_clusterpolicy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: gpu-cluster-policy
 spec:
   operator:
-    defaultRuntime: crio
     runtimeClass: nvidia
     initContainer: {}
     use_ocp_driver_toolkit: true

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -16,9 +16,6 @@ spec:
     rootFS: {{ .Values.hostPaths.rootFS }}
     driverInstallDir: {{ .Values.hostPaths.driverInstallDir }}
   operator:
-    {{- if .Values.operator.defaultRuntime }}
-    defaultRuntime: {{ .Values.operator.defaultRuntime }}
-    {{- end }}
     {{- if .Values.operator.runtimeClass }}
     runtimeClass: {{ .Values.operator.runtimeClass }}
     {{- end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -72,7 +72,6 @@ operator:
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   priorityClassName: system-node-critical
-  defaultRuntime: docker
   runtimeClass: nvidia
   use_ocp_driver_toolkit: false
   # cleanup CRD on chart un-install


### PR DESCRIPTION
The defaultRuntime field is no longer used as the runtime detection, so we don't need the field anymore. 