### PR TITLE
[holodeck-ci] bump k8s, cri-tools and calico versions

### DIFF
--- a/tests/holodeck.yaml
+++ b/tests/holodeck.yaml
@@ -30,5 +30,6 @@ spec:
   kubernetes:
     install: true
     installer: kubeadm
-    version: v1.31.0
-    crictlVersion: v1.31.1
+    version: v1.32.1
+    crictlVersion: v1.32.0
+    calicoVersion: v3.29.1


### PR DESCRIPTION
Updating the holodeck version may take time as we haven't had enough cycles to investigate the regressions from the latest version. Until then, we can have our current holodeck point to the newer versions of K8s, calico and crictl