### PR TITLE
[github-ci-e2e] update AWS EC2 AMI to the Ubuntu22.04 LTS variant

### DIFF
--- a/tests/holodeck.yaml
+++ b/tests/holodeck.yaml
@@ -23,7 +23,7 @@ spec:
     - 44.230.241.223/32
     image:
       architecture: amd64
-      imageId: ami-0ce2cb35386fc22e9
+      imageId: ami-07c175e73e37b02df
   containerRuntime:
     install: true
     name: containerd


### PR DESCRIPTION
The current AMI uses a non-LTS kernel `6.2.0-1017-aws`. 

We should switch to the LTS kernel. With the new AMI, we get the following kernel version

```
6.8.0-1021-aws
```

Reference: https://ubuntu.com/kernel/lifecycle