### PR TITLE
bump node-feature-discovery to v0.17.1

### DIFF
--- a/deployments/gpu-operator/Chart.lock
+++ b/deployments/gpu-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: node-feature-discovery
   repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-  version: 0.17.0
-digest: sha256:21baa50c4947a80eb075f1db42f9521672dbbcbbea309b0f2d6d9c05fbdd8a65
-generated: "2024-12-24T11:04:04.635377-08:00"
+  version: 0.17.1
+digest: sha256:36b19ee48219ae0a7e56a33ce786eaeb1a33e59ad6ee3d98fca049b2e0215b9a
+generated: "2025-01-28T08:42:19.492742-05:00"

--- a/deployments/gpu-operator/Chart.yaml
+++ b/deployments/gpu-operator/Chart.yaml
@@ -19,6 +19,6 @@ keywords:
 
 dependencies:
   - name: node-feature-discovery
-    version: v0.17.0
+    version: v0.17.1
     repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
     condition: nfd.enabled

--- a/deployments/gpu-operator/charts/node-feature-discovery/Chart.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.17.0
+appVersion: v0.17.1
 description: 'Detects hardware features available on each node in a Kubernetes cluster,
   and advertises those features using node labels. '
 home: https://github.com/kubernetes-sigs/node-feature-discovery
@@ -11,4 +11,4 @@ name: node-feature-discovery
 sources:
 - https://github.com/kubernetes-sigs/node-feature-discovery
 type: application
-version: 0.17.0
+version: 0.17.1

--- a/deployments/gpu-operator/charts/node-feature-discovery/templates/role.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/templates/role.yaml
@@ -15,6 +15,7 @@ rules:
   - create
   - get
   - update
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
As per the release notes of [v0.17.1](https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.17.1), this version contains a fix which allows NFD to run in k8s clusters where the `OwnerReferencesPermissionEnforcement ` admission controller has been enabled. We should be including this fix as well 