### PR TITLE
add MIG conigs for the B200 GPU- 2901

### DIFF
--- a/assets/state-mig-manager/0400_configmap.yaml
+++ b/assets/state-mig-manager/0400_configmap.yaml
@@ -83,6 +83,20 @@ data:
           mig-devices:
             "1g.20gb": 4
 
+      # B200
+      all-1g.23gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.23gb": 7
+
+      # B200
+      all-1g.23gb.me:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.23gb+me": 1
+
       all-2g.20gb:
         - devices: all
           mig-enabled: true
@@ -157,12 +171,24 @@ data:
           mig-devices:
             "1g.24gb": 4
 
+      all-1g.45gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.45gb": 4
+
       all-2g.24gb:
         - devices: all
           mig-enabled: true
           mig-devices:
             "2g.24gb": 3
 
+      all-2g.45gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "2g.45gb": 3
+            
       # H100 NVL, H800 NVL
       all-3g.47gb:
         - devices: all
@@ -189,6 +215,12 @@ data:
           mig-devices:
             "3g.48gb": 2
 
+      all-3g.90gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "3g.90gb": 2
+
       all-4g.48gb:
         - devices: all
           mig-enabled: true
@@ -201,8 +233,23 @@ data:
           mig-devices:
             "7g.96gb": 1
 
-      # GH200 144G HBM3e, H200-141GB, H200 NVL, H100-96GB, GH200, H100 NVL, H800 NVL, H100-80GB, H800-80GB, A800-40GB, A800-80GB, A100-40GB, A100-80GB, A30-24GB, PG506-96GB
+      all-7g.180gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "7g.180gb": 1
+
+      # B200, GH200 144G HBM3e, H200-141GB, H200 NVL, H100-96GB, GH200, H100 NVL, H800 NVL, H100-80GB, H800-80GB, A800-40GB, A800-80GB, A100-40GB, A100-80GB, A30-24GB, PG506-96GB
       all-balanced:
+        # B200
+        - device-filter: ["0x290110DE"]
+          devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.23gb": 2
+            "2g.45gb": 1
+            "3g.90gb": 1
+
         # GH200 144G HBM3e
         - device-filter: ["0x234810DE"]
           devices: all


### PR DESCRIPTION
This is the nvidia-smi mig -lgip output of B200
```
$ nvidia-smi mig -lgip
+-----------------------------------------------------------------------------+
| GPU instance profiles:                                                      |
| GPU   Name             ID    Instances   Memory     P2P    SM    DEC   ENC  |
|                              Free/Total   GiB              CE    JPEG  OFA  |
|=============================================================================|
|   0  MIG 1g.23gb       19     7/7        22.00      No     18     1     0   |
|                                                             2     1     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 1g.23gb+me    20     1/1        22.00      No     18     1     0   |
|                                                             2     1     1   |
+-----------------------------------------------------------------------------+
|   0  MIG 1g.45gb       15     4/4        44.25      No     30     1     0   |
|                                                             2     1     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 2g.45gb       14     3/3        44.25      No     36     2     0   |
|                                                             4     2     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 3g.90gb        9     2/2        89.00      No     70     3     0   |
|                                                             6     3     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 7g.180gb       0     1/1        178.50     No     148    7     0   |
|                                                            16     7     1   |
+-----------------------------------------------------------------------------+
```