### PR TITLE
switch to the more current qemu artifact image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,6 +144,8 @@ jobs:
           echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
@@ -189,6 +191,8 @@ jobs:
           echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
This PR should fix the more recent CI flakes (segfaults in the arm build) we've been observing. 

This GitHub [issue](https://github.com/tonistiigi/binfmt/issues/215) provides some insight as to why these multi-arch build flakes have been observed. Switching from the `latest` (2+ years old) tag to `master` (last updated a day ago) seems to fix the problem in `mig-parted`, so we apply the same solution here. 