### PR TITLE
[olm] add perms for pods and pods/eviction in operator Role

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -775,6 +775,8 @@ spec:
           - services
           - services/finalizers
           - serviceaccounts
+          - pods
+          - pods/eviction
           verbs:
           - create
           - get


### PR DESCRIPTION
This change aligns the gpu-operator Role object across our helm chart and OLM bundle