### PR TITLE
Fix migManager data sample config

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -387,7 +387,7 @@ migManager:
   # config:
   #   name: custom-mig-parted-configs
   #   create: true
-  #   data: |-
+  #   data:
   #     config.yaml: |-
   #       version: v1
   #       mig-configs:


### PR DESCRIPTION
Hey,
Small but needed change, using the current template generation of custom ConfigMap simply fails due to incorrect data type provided to template. Also official documentation shows the correct syntax: [https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-mig.html#example-custom-mig-configuration](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-mig.html#example-custom-mig-configuration)
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: custom-mig-config
data:
  config.yaml: |
    version: v1
    mig-configs:
      all-disabled:
        - devices: all
          mig-enabled: false
      
      five-1g-one-2g:
        - devices: all 
          mig-enabled: true
          mig-devices:
            "1g.10gb": 5
            "2g.20gb": 1
```
Thanks!