### PR TITLE
bump go and golangci-lint versions, lint fixes

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -3623,7 +3623,7 @@ func isDaemonSetReady(name string, n ClusterPolicyController) gpuv1.State {
 func getPodsOwnedbyDaemonset(ds *appsv1.DaemonSet, pods []corev1.Pod, n ClusterPolicyController) []corev1.Pod {
 	dsPodList := []corev1.Pod{}
 	for _, pod := range pods {
-		if pod.OwnerReferences == nil || len(pod.OwnerReferences) < 1 {
+		if len(pod.OwnerReferences) < 1 {
 			n.logger.Info("Driver Pod has no owner DaemonSet", "pod", pod.Name)
 			continue
 		}

--- a/versions.mk
+++ b/versions.mk
@@ -19,8 +19,8 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v24.9.2
 
-GOLANG_VERSION ?= 1.23.5
+GOLANG_VERSION ?= 1.23.6
 
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v1.64.5
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always 2> /dev/null || echo "")


### PR DESCRIPTION
Bumps the golang and golangci-lint version. It also fixes the new gosimple lint issue from the golangci-lint update. 

This PR is needed to unblock the gitlab CI builds. See [here](https://gitlab.com/nvidia/kubernetes/gpu-operator/-/pipelines/1672377793)

For context, go [here](https://staticcheck.dev/docs/checks/#S1009)