### PR TITLE
bump node-feature-discovery to v0.17.2

### DIFF
--- a/deployments/gpu-operator/Chart.lock
+++ b/deployments/gpu-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: node-feature-discovery
   repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-  version: 0.17.1
-digest: sha256:36b19ee48219ae0a7e56a33ce786eaeb1a33e59ad6ee3d98fca049b2e0215b9a
-generated: "2025-01-28T08:42:19.492742-05:00"
+  version: 0.17.2
+digest: sha256:4c55d30d958027ef8997a2976449326de3c90049025c3ebb9bee017cad32cc3f
+generated: "2025-02-25T09:08:49.128088-08:00"

--- a/deployments/gpu-operator/Chart.yaml
+++ b/deployments/gpu-operator/Chart.yaml
@@ -19,6 +19,6 @@ keywords:
 
 dependencies:
   - name: node-feature-discovery
-    version: v0.17.1
+    version: v0.17.2
     repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
     condition: nfd.enabled

--- a/deployments/gpu-operator/charts/node-feature-discovery/Chart.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.17.1
+appVersion: v0.17.2
 description: 'Detects hardware features available on each node in a Kubernetes cluster,
   and advertises those features using node labels. '
 home: https://github.com/kubernetes-sigs/node-feature-discovery
@@ -11,4 +11,4 @@ name: node-feature-discovery
 sources:
 - https://github.com/kubernetes-sigs/node-feature-discovery
 type: application
-version: 0.17.1
+version: 0.17.2

--- a/deployments/gpu-operator/charts/node-feature-discovery/templates/worker.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/templates/worker.yaml
@@ -106,7 +106,7 @@ spec:
         {{- end }}
         - "-metrics={{ .Values.worker.metricsPort | default "8081"}}"
         - "-grpc-health={{ .Values.worker.healthPort | default "8082" }}"
-        {{- with .Values.gc.extraArgs }}
+        {{- with .Values.worker.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         ports:


### PR DESCRIPTION
NFD v0.17.2 includes a bug fix its the helm chart

> This patch release updates dependencies and fixes the worker.extraArgs value in the Helm chart.

https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.17.2