### PR TITLE
Remove all CRDs when `operator.cleanupCRD` is `true`

### DIFF
--- a/deployments/gpu-operator/templates/cleanup_crd.yaml
+++ b/deployments/gpu-operator/templates/cleanup_crd.yaml
@@ -40,6 +40,10 @@ spec:
           - >
               kubectl delete clusterpolicy cluster-policy;
               kubectl delete crd clusterpolicies.nvidia.com;
-
+              kubectl delete crd nvidiadrivers.nvidia.com --ignore-not-found=true;
+              kubectl delete crd nodefeatures.nfd.k8s-sigs.io --ignore-not-found=true;
+              kubectl delete crd nodefeaturegroups.nfd.k8s-sigs.io --ignore-not-found=true;
+              kubectl delete crd nodefeaturerules.nfd.k8s-sigs.io --ignore-not-found=true;
+              kubectl delete crd noderesourcetopologies.topology.node.k8s.io --ignore-not-found=true;
       restartPolicy: OnFailure
 {{- end }}

--- a/deployments/gpu-operator/templates/cleanup_crd.yaml
+++ b/deployments/gpu-operator/templates/cleanup_crd.yaml
@@ -41,9 +41,10 @@ spec:
               kubectl delete clusterpolicy cluster-policy;
               kubectl delete crd clusterpolicies.nvidia.com;
               kubectl delete crd nvidiadrivers.nvidia.com --ignore-not-found=true;
+            {{- if .Values.nfd.enabled -}}
               kubectl delete crd nodefeatures.nfd.k8s-sigs.io --ignore-not-found=true;
               kubectl delete crd nodefeaturegroups.nfd.k8s-sigs.io --ignore-not-found=true;
               kubectl delete crd nodefeaturerules.nfd.k8s-sigs.io --ignore-not-found=true;
-              kubectl delete crd noderesourcetopologies.topology.node.k8s.io --ignore-not-found=true;
+            {{- end }}
       restartPolicy: OnFailure
 {{- end }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

Closes #1301

# Changes

Prior to this PR, when a user defined the value `operator.cleanupCRD: true`, only the ClusterPolicy CRD was removed. After these changes, all other CRDs deployable by this chart, in any configuration (except NodeResourceTopology), will also be removed on best effort basis (ignored if not found). These additional CRDs are the following:

* NodeFeature
* NodeFeatureGroup
* NodeFeatureRule
* NVIDIADriver