### PR TITLE
bump DCGM and DCGM exporter versions to 4.1.1

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -203,9 +203,9 @@ spec:
     - name: gpu-operator-image
       image: ghcr.io/nvidia/gpu-operator:main-latest
     - name: dcgm-exporter-image
-      image: nvcr.io/nvidia/k8s/dcgm-exporter@sha256:ccf8d1435f7dc12fe3ad11613923c5a83894054449efe828e304244afdd05704
+      image: nvcr.io/nvidia/k8s/dcgm-exporter@sha256:c835d8cede5d25398b4d49404aa0f651ce28ead5ee698121528b4d2939db9359
     - name: dcgm-image
-      image: nvcr.io/nvidia/cloud-native/dcgm@sha256:459fe7b4a8167e50533e76d79182f36bcc8c24ef47f65b5e8dc7419c9351051b
+      image: nvcr.io/nvidia/cloud-native/dcgm@sha256:b821571f8256cb104884827d797aa66362f0fcb05307f6edf43def2dd33ca24a
     - name: container-toolkit-image
       image: nvcr.io/nvidia/k8s/container-toolkit@sha256:d934033f9ff89087d555850eb1da150eaaa27b11e5ad21db1b874b8bc0b8d35b
     - name: driver-image
@@ -901,9 +901,9 @@ spec:
                   - name: "CONTAINER_TOOLKIT_IMAGE"
                     value: "nvcr.io/nvidia/k8s/container-toolkit@sha256:d934033f9ff89087d555850eb1da150eaaa27b11e5ad21db1b874b8bc0b8d35b"
                   - name: "DCGM_IMAGE"
-                    value: "nvcr.io/nvidia/cloud-native/dcgm@sha256:459fe7b4a8167e50533e76d79182f36bcc8c24ef47f65b5e8dc7419c9351051b"
+                    value: "nvcr.io/nvidia/cloud-native/dcgm@sha256:b821571f8256cb104884827d797aa66362f0fcb05307f6edf43def2dd33ca24a"
                   - name: "DCGM_EXPORTER_IMAGE"
-                    value: "nvcr.io/nvidia/k8s/dcgm-exporter@sha256:ccf8d1435f7dc12fe3ad11613923c5a83894054449efe828e304244afdd05704"
+                    value: "nvcr.io/nvidia/k8s/dcgm-exporter@sha256:c835d8cede5d25398b4d49404aa0f651ce28ead5ee698121528b4d2939db9359"
                   - name: "DEVICE_PLUGIN_IMAGE"
                     value: "nvcr.io/nvidia/k8s-device-plugin@sha256:7089559ce6153018806857f5049085bae15b3bf6f1c8bd19d8b12f707d087dea"
                   - name: "DRIVER_IMAGE"

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -303,7 +303,7 @@ dcgm:
   enabled: false
   repository: nvcr.io/nvidia/cloud-native
   image: dcgm
-  version: 4.1.0-1-ubuntu22.04
+  version: 4.1.1-1-ubuntu22.04
   imagePullPolicy: IfNotPresent
   args: []
   env: []
@@ -313,7 +313,7 @@ dcgmExporter:
   enabled: true
   repository: nvcr.io/nvidia/k8s
   image: dcgm-exporter
-  version: 4.1.0-4.0.2-ubuntu22.04
+  version: 4.1.1-4.0.4-ubuntu22.04
   imagePullPolicy: IfNotPresent
   env:
     - name: DCGM_EXPORTER_LISTEN


### PR DESCRIPTION
DCGM 4.1.1 release notes - https://docs.nvidia.com/datacenter/dcgm/latest/release-notes/changelog.html#id2

DCGM Exporter 4.1.1-4.0.4 - https://github.com/NVIDIA/dcgm-exporter/releases/tag/4.1.1-4.0.4

