### PR TITLE
Fixed example in values.yaml

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -387,7 +387,7 @@ migManager:
   # config:
   #   name: custom-mig-parted-configs
   #   create: true
-  #   data: |-
+  #   data:
   #     config.yaml: |-
   #       version: v1
   #       mig-configs:


### PR DESCRIPTION
The `data` key must be an object, as described below, but the example shows a string.