### PR TITLE
[GDS][GDRCopy] remove unnecessary liveness probe

### DIFF
--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -212,15 +212,6 @@ spec:
           successThreshold: 1
           periodSeconds: 10
           timeoutSeconds: 10
-        livenessProbe:
-          exec:
-            command:
-              [sh, -c, 'lsmod | grep nvidia_fs']
-          periodSeconds: 30
-          initialDelaySeconds: 30
-          failureThreshold: 1
-          successThreshold: 1
-          timeoutSeconds: 10
       - image: "FILLED BY THE OPERATOR"
         imagePullPolicy: IfNotPresent
         name: nvidia-gdrcopy-ctr
@@ -247,15 +238,6 @@ spec:
           failureThreshold: 120
           successThreshold: 1
           periodSeconds: 10
-          timeoutSeconds: 10
-        livenessProbe:
-          exec:
-            command:
-              [sh, -c, 'lsmod | grep gdrdrv']
-          periodSeconds: 30
-          initialDelaySeconds: 30
-          failureThreshold: 1
-          successThreshold: 1
           timeoutSeconds: 10
         # Only kept when OpenShift DriverToolkit side-car is enabled.
       - image: "FILLED BY THE OPERATOR"

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -281,17 +281,6 @@ spec:
         - ocp_dtk_entrypoint
         image: nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1-rhcos4.13
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - lsmod | grep gdrdrv
-          failureThreshold: 1
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 10
         name: nvidia-gdrcopy-ctr
         securityContext:
           privileged: true

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -209,17 +209,6 @@ spec:
         - -xc
         image: nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - lsmod | grep gdrdrv
-          failureThreshold: 1
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 10
         name: nvidia-gdrcopy-ctr
         securityContext:
           privileged: true

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -209,17 +209,6 @@ spec:
         - -xc
         image: nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - lsmod | grep nvidia_fs
-          failureThreshold: 1
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 10
         name: nvidia-fs-ctr
         securityContext:
           privileged: true

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -457,15 +457,6 @@ spec:
           successThreshold: 1
           periodSeconds: 10
           timeoutSeconds: 10
-        livenessProbe:
-          exec:
-            command:
-              [sh, -c, 'lsmod | grep nvidia_fs']
-          periodSeconds: 30
-          initialDelaySeconds: 30
-          failureThreshold: 1
-          successThreshold: 1
-          timeoutSeconds: 10
       {{- end }}
       # Note: GDRCopy is not supported along with precompiled drivers.
       #       Detect this in the controller and throw an error if
@@ -525,15 +516,6 @@ spec:
           failureThreshold: 120
           successThreshold: 1
           periodSeconds: 10
-          timeoutSeconds: 10
-        livenessProbe:
-          exec:
-            command:
-              [sh, -c, 'lsmod | grep gdrdrv']
-          periodSeconds: 30
-          initialDelaySeconds: 30
-          failureThreshold: 1
-          successThreshold: 1
           timeoutSeconds: 10
       {{- end }}
       # TODO: introduce UseOpenShiftDriverToolkit field into NVIDIADriver CR?


### PR DESCRIPTION
This PR removes the liveness probes from the GDS and GDRCopy containers of the driver-daemonset. We've noticed cases where the livenessProbes timeout due to long response times of the `lsmod` commands which have led to undesirable restarts of the container leaving the driver daemonset in a bad state