### PR TITLE
[vgpu-manager] Remove create/update/delete perms for pods in ClusterRole

### DIFF
--- a/assets/state-vgpu-manager/0210_clusterrole.yaml
+++ b/assets/state-vgpu-manager/0210_clusterrole.yaml
@@ -23,14 +23,15 @@ rules:
   - ""
   resources:
   - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods/eviction
   verbs:
   - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
This was missed in https://github.com/NVIDIA/gpu-operator/commit/6330c78808cedd96ee16e3fc7de46123b8a1457f