### PR TITLE
bump golang to 1.24.1 and golangci-lint to 1.64.7

### DIFF
--- a/validator/versions.mk
+++ b/validator/versions.mk
@@ -16,4 +16,4 @@
 include $(CURDIR)/../versions.mk
 
 CUDA_SAMPLES_VERSION ?= 11.7.1
-GOLANG_VERSION ?= 1.24.0
+GOLANG_VERSION ?= 1.24.1

--- a/versions.mk
+++ b/versions.mk
@@ -19,8 +19,8 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v24.9.2
 
-GOLANG_VERSION ?= 1.24.0
+GOLANG_VERSION ?= 1.24.1
 
-GOLANGCI_LINT_VERSION ?= v1.64.5
+GOLANGCI_LINT_VERSION ?= v1.64.7
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always 2> /dev/null || echo "")


### PR DESCRIPTION
go 1.24.1 includes quite a few fixes in multiple areas - https://github.com/golang/go/issues?q=milestone%3AGo1.24.1+label%3ACherryPickApproved