### PR TITLE
[nvidia-driver] mount /run/nvidia-fabricmanager

### DIFF
--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -111,6 +111,8 @@ spec:
           - name: run-nvidia
             mountPath: /run/nvidia
             mountPropagation: Bidirectional
+          - name: run-nvidia-fabricmanager
+            mountPath: /run/nvidia-fabricmanager
           - name: run-nvidia-topologyd
             mountPath: /run/nvidia-topologyd
           - name: var-log
@@ -284,6 +286,10 @@ spec:
         - name: host-os-release
           hostPath:
             path: "/etc/os-release"
+        - name: run-nvidia-fabricmanager
+          hostPath:
+            path: /run/nvidia-fabricmanager
+            type: DirectoryOrCreate
         - name: run-nvidia-topologyd
           hostPath:
             path: /run/nvidia-topologyd

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -170,6 +170,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -269,6 +271,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -188,6 +188,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -292,6 +294,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -240,6 +240,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -425,6 +427,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -170,6 +170,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -314,6 +316,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -170,6 +170,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -314,6 +316,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -170,6 +170,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -260,6 +262,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -240,6 +240,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -370,6 +372,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -172,6 +172,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -263,6 +265,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -174,6 +174,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -336,6 +338,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -172,6 +172,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -330,6 +332,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -200,6 +200,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -337,6 +339,10 @@ spec:
       - hostPath:
           path: /dev/vfio
         name: vfio
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -152,6 +152,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -252,6 +254,10 @@ spec:
       - hostPath:
           path: /dev/vfio
         name: vfio
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -170,6 +170,8 @@ spec:
         - mountPath: /run/nvidia
           mountPropagation: Bidirectional
           name: run-nvidia
+        - mountPath: /run/nvidia-fabricmanager
+          name: run-nvidia-fabricmanager
         - mountPath: /run/nvidia-topologyd
           name: run-nvidia-topologyd
         - mountPath: /var/log
@@ -266,6 +268,10 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: host-os-release
+      - hostPath:
+          path: /run/nvidia-fabricmanager
+          type: DirectoryOrCreate
+        name: run-nvidia-fabricmanager
       - hostPath:
           path: /run/nvidia-topologyd
           type: DirectoryOrCreate

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -270,6 +270,8 @@ spec:
           - name: run-nvidia
             mountPath: /run/nvidia
             mountPropagation: Bidirectional
+          - name: run-nvidia-fabricmanager
+            mountPath: /run/nvidia-fabricmanager
           - name: run-nvidia-topologyd
             mountPath: /run/nvidia-topologyd
           - name: var-log
@@ -594,6 +596,10 @@ spec:
           hostPath:
             path: /dev/vfio
         {{- end }}
+        - name: run-nvidia-fabricmanager
+          hostPath:
+            path: /run/nvidia-fabricmanager
+            type: DirectoryOrCreate
         - name: run-nvidia-topologyd
           hostPath:
             path: /run/nvidia-topologyd


### PR DESCRIPTION
This PR adds support for Blackwell GPUs like B200. 

For GPUs with NVLink5+ switches, the fabricmanager needs to be able to access the `/run/nvidia-fabricmanager/fm_sm_ipc.socket` created on the host. 