### PR TITLE
Remove unused RUNTIME_ARGS envvar from toolkit daemonset

### DIFF
--- a/assets/state-container-toolkit/0500_daemonset.yaml
+++ b/assets/state-container-toolkit/0500_daemonset.yaml
@@ -65,8 +65,6 @@ spec:
         env:
         - name: ROOT
           value: "/usr/local/nvidia"
-        - name: RUNTIME_ARGS
-          value: ""
         - name: NVIDIA_CONTAINER_RUNTIME_MODES_CDI_DEFAULT_KIND
           value: "management.nvidia.com/gpu"
         - name: NVIDIA_VISIBLE_DEVICES


### PR DESCRIPTION
The `RUNTIME_ARGS` envvar has had no effect on the container-toolkit for a number of releases now. This chagne removes the unnecessary environment variable from the toolkit-container daemonset.