### PR TITLE
add pod watch permissions for k8s-driver-manager

### DIFF
--- a/assets/state-driver/0210_clusterrole.yaml
+++ b/assets/state-driver/0210_clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -48,6 +48,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/manifests/state-driver/0210_clusterrole.yaml
+++ b/manifests/state-driver/0210_clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This PR fixes the errors observed in the k8s-driver-manager logs

```
Waiting for the operator-validator to shutdown
E0314 21:14:42.026922  889965 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: pods \"nvidia-operator-validator-pqvkz\" is forbidden: User \"system:serviceaccount:test-operator:nvidia-driver\" cannot watch resource \"pods\" in API group \"\" in the namespace \"test-operator\""
E0314 21:14:43.420192  889965 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: pods \"nvidia-operator-validator-pqvkz\" is forbidden: User \"system:serviceaccount:test-operator:nvidia-driver\" cannot watch resource \"pods\" in API group \"\" in the namespace \"test-operator\""
pod/nvidia-operator-validator-pqvkz condition met
Waiting for the container-toolkit to shutdown
E0314 21:14:43.577872  890304 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: pods \"nvidia-container-toolkit-daemonset-m265n\" is forbidden: User \"system:serviceaccount:test-operator:nvidia-driver\" cannot watch resource \"pods\" in API group \"\" in the namespace \"test-operator\""
E0314 21:14:44.676844  890304 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: pods \"nvidia-container-toolkit-daemonset-m265n\" is forbidden: User \"system:serviceaccount:test-operator:nvidia-driver\" cannot watch resource \"pods\" in API group \"\" in the namespace \"test-operator\""
E0314 21:14:47.318828  890304 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: pods \"nvidia-container-toolkit-daemonset-m265n\" is forbidden: User \"system:serviceaccount:test-operator:nvidia-driver\" cannot watch resource \"pods\" in API group \"\" in the namespace \"test-operator\""
pod/nvidia-container-toolkit-daemonset-m265n condition met
```