### PR TITLE
fix rbac perms for pods in vfio-manager/vgpu-manager clusterrole

### DIFF
--- a/assets/state-sandbox-device-plugin/0210_clusterrole.yaml
+++ b/assets/state-sandbox-device-plugin/0210_clusterrole.yaml
@@ -15,6 +15,5 @@ rules:
   resources:
   - nodes
   - pods
-  - pods/eviction
   verbs:
   - "get"

--- a/assets/state-vfio-manager/0210_clusterrole.yaml
+++ b/assets/state-vfio-manager/0210_clusterrole.yaml
@@ -14,9 +14,22 @@ rules:
   - ""
   resources:
   - nodes
-  - pods
   verbs:
   - get
   - list
   - patch
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create

--- a/assets/state-vgpu-manager/0210_clusterrole.yaml
+++ b/assets/state-vgpu-manager/0210_clusterrole.yaml
@@ -26,6 +26,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This aligns the clusterroles across all of our "driver" daemonsets which have similar init containers -- NVIDIA driver, vGPU manager, and vfio-manager. 

Without this change, the gpu-operator was failing to create the vfio-manager clusterrole with the following error message:
```
Failed to reconcile state-vfio-manager: clusterroles.rbac.authorization.k8s.io "nvidia-vfio-manager" is forbidden: user "system:serviceaccount:nvidia-gpu-operator:gpu-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:nvidia-gpu-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
      {APIGroups:[""], Resources:["pods"], Verbs:["patch"]}
```

I added back `watch` permissions for pods in the vGPU Manager clusterrole to align with this change: https://github.com/NVIDIA/gpu-operator/pull/1346

This PR also removes unneeded perms for `pods/eviction` objects in the sandbox-device-plugin clusterrole.