### PR TITLE
Bump actions/upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/deploy-helm-repo-to-pages.yml
+++ b/.github/workflows/deploy-helm-repo-to-pages.yml
@@ -48,7 +48,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/