### PR TITLE
Feat: Allow to configure kubelet root directory

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -174,6 +174,11 @@ type HostPathsSpec struct {
 	// DriverInstallDir represents the root at which driver files including libraries,
 	// config files, and executables can be found.
 	DriverInstallDir string `json:"driverInstallDir,omitempty"`
+
+	// KubeletRootDir represents the location of the kubelet root directory.
+	// If empty, it will default to "/var/lib/kubelet".
+	// +kubebuilder:default="/var/lib/kubelet"
+	KubeletRootDir string `json:"kubeletRootDir,omitempty"`
 }
 
 // EnvVar represents an environment variable present in a Container.

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -1504,6 +1504,12 @@ spec:
                       DriverInstallDir represents the root at which driver files including libraries,
                       config files, and executables can be found.
                     type: string
+                  kubeletRootDir:
+                    default: /var/lib/kubelet
+                    description: |-
+                      KubeletRootDir represents the location of the kubelet root directory.
+                      If empty, it will default to "/var/lib/kubelet".
+                    type: string
                   rootFS:
                     description: |-
                       RootFS represents the path to the root filesystem of the host.

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -1504,6 +1504,12 @@ spec:
                       DriverInstallDir represents the root at which driver files including libraries,
                       config files, and executables can be found.
                     type: string
+                  kubeletRootDir:
+                    default: /var/lib/kubelet
+                    description: |-
+                      KubeletRootDir represents the location of the kubelet root directory.
+                      If empty, it will default to "/var/lib/kubelet".
+                    type: string
                   rootFS:
                     description: |-
                       RootFS represents the path to the root filesystem of the host.

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -181,6 +181,8 @@ const (
 	HostRootEnvName = "HOST_ROOT"
 	// DefaultDriverInstallDir represents the default path of a driver container installation
 	DefaultDriverInstallDir = "/run/nvidia/driver"
+	// DefaultKubeletRootDir represents the default path of a kubelet root directory
+	DefaultKubeletRootDir = "/var/lib/kubelet"
 	// DriverInstallDirEnvName is the name of the envvar used by the driver-validator to represent the driver install dir
 	DriverInstallDirEnvName = "DRIVER_INSTALL_DIR"
 	// DriverInstallDirCtrPathEnvName is the name of the envvar used by the driver-validator to represent the path
@@ -1848,6 +1850,18 @@ func TransformDCGMExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 		obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, metricsConfigVol)
 
 		setContainerEnv(&(obj.Spec.Template.Spec.Containers[0]), "DCGM_EXPORTER_COLLECTORS", MetricsConfigMountPath)
+	}
+
+	const podResourcesVolume = "pod-gpu-resources"
+	kubeletRootDir := config.HostPaths.KubeletRootDir
+	if len(kubeletRootDir) > 0 && kubeletRootDir != DefaultKubeletRootDir {
+		for i := range obj.Spec.Template.Spec.Volumes {
+			volume := &obj.Spec.Template.Spec.Volumes[i]
+			if volume.Name == podResourcesVolume {
+				volume.HostPath.Path = filepath.Join(kubeletRootDir, "pod-resources")
+				break
+			}
+		}
 	}
 
 	for _, env := range config.DCGMExporter.Env {

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -1248,7 +1248,8 @@ func TestTransformDCGMExporter(t *testing.T) {
 			description: "transform dcgm exporter",
 			ds: NewDaemonset().
 				WithContainer(corev1.Container{Name: "dcgm-exporter"}).
-				WithContainer(corev1.Container{Name: "dummy"}),
+				WithContainer(corev1.Container{Name: "dummy"}).
+				WithHostPathVolume("pod-resources", "/var/lib/kubelet/pod-resources", nil),
 			cpSpec: &gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
 					Repository:       "nvcr.io/nvidia/cloud-native",
@@ -1274,7 +1275,9 @@ func TestTransformDCGMExporter(t *testing.T) {
 					{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "nvidia-dcgm:5555"},
 					{Name: "foo", Value: "bar"},
 				},
-			}).WithContainer(corev1.Container{Name: "dummy"}).WithPullSecret("pull-secret").WithRuntimeClassName("nvidia"),
+			}).WithContainer(corev1.Container{Name: "dummy"}).WithPullSecret("pull-secret").
+				WithRuntimeClassName("nvidia").
+				WithHostPathVolume("pod-resources", "/var/lib/kubelet/pod-resources", nil),
 		},
 		{
 			description: "transform dcgm exporter with hostPID enabled",
@@ -1606,6 +1609,32 @@ func TestTransformDCGMExporter(t *testing.T) {
 					},
 				}).
 				WithRuntimeClassName("nvidia"),
+		},
+		{
+			description: "transform dcgm exporter with custom kubelet root",
+			ds: NewDaemonset().
+				WithContainer(corev1.Container{Name: "dcgm-exporter"}).
+				WithHostPathVolume("pod-gpu-resources", "/var/lib/kubelet/pod-resources", nil),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				HostPaths: gpuv1.HostPathsSpec{
+					KubeletRootDir: "/custom-kubelet",
+				},
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Repository:      "nvcr.io/nvidia/cloud-native",
+					Image:           "dcgm-exporter",
+					Version:         "v1.0.0",
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+			expectedDs: NewDaemonset().WithContainer(corev1.Container{
+				Name:            "dcgm-exporter",
+				Image:           "nvcr.io/nvidia/cloud-native/dcgm-exporter:v1.0.0",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Env: []corev1.EnvVar{
+					{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "nvidia-dcgm:5555"},
+				},
+			}).WithRuntimeClassName("nvidia").
+				WithHostPathVolume("pod-gpu-resources", "/custom-kubelet/pod-resources", nil),
 		},
 	}
 

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -1504,6 +1504,12 @@ spec:
                       DriverInstallDir represents the root at which driver files including libraries,
                       config files, and executables can be found.
                     type: string
+                  kubeletRootDir:
+                    default: /var/lib/kubelet
+                    description: |-
+                      KubeletRootDir represents the location of the kubelet root directory.
+                      If empty, it will default to "/var/lib/kubelet".
+                    type: string
                   rootFS:
                     description: |-
                       RootFS represents the path to the root filesystem of the host.

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -15,6 +15,9 @@ spec:
   hostPaths:
     rootFS: {{ .Values.hostPaths.rootFS }}
     driverInstallDir: {{ .Values.hostPaths.driverInstallDir }}
+    {{- if .Values.hostPaths.kubeletRootDir }}
+    kubeletRootDir: {{ .Values.hostPaths.kubeletRootDir }}
+    {{- end }}
   operator:
     {{- if .Values.operator.runtimeClass }}
     runtimeClass: {{ .Values.operator.runtimeClass }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -34,6 +34,10 @@ hostPaths:
   # config files, and executables can be found.
   driverInstallDir: "/run/nvidia/driver"
 
+  # kubeletRootDir represents the root with the kubelet base directory
+  # if empty will use /var/lib/kubelet as the default path
+  # kubeletRootDir: ""
+
 daemonsets:
   labels: {}
   annotations: {}


### PR DESCRIPTION
This pull request introduces a new configuration option `KubeletRootDir` to specify the root directory for the kubelet base directory. The changes include updates to the cluster policy types, CRD manifests, controllers, and tests to support this new configuration.

### Configuration Enhancements:

* Added `KubeletRootDir` field to the `HostPathsSpec` struct in `api/nvidia/v1/clusterpolicy_types.go` to represent the kubelet base directory.
* Updated CRD manifests (`bundle/manifests/nvidia.com_clusterpolicies.yaml`, `config/crd/bases/nvidia.com_clusterpolicies.yaml`, `deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml`) to include the new `KubeletRootDir` field.

### Controller Updates:

* Added `DefaultKubeletRootDir` constant and updated `preProcessDaemonSet` function in `controllers/object_controls.go` to transform the kubelet root directory if a custom one is configured. [[1]](diffhunk://#diff-634d1afac63d5d768c5ce2a20a947dc0842a3480923500e36c0d6da8dd220e84R178-R186) [[2]](diffhunk://#diff-634d1afac63d5d768c5ce2a20a947dc0842a3480923500e36c0d6da8dd220e84R751-R753)
* Implemented `transformForKubeletRootDir` function in `controllers/object_controls.go` to apply necessary transformations for custom kubelet root directory.

### Testing:

* Added `TestTransformForKubeletRootDir` function in `controllers/transforms_test.go` to validate the transformations for different kubelet root directory configurations.

### Deployment Configuration:

* Updated `deployments/gpu-operator/templates/clusterpolicy.yaml` and `deployments/gpu-operator/values.yaml` to include the new `kubeletRootDir` configuration. [[1]](diffhunk://#diff-3af3dbe02c9930f0b55cad1ac6cc0ce46dcf024b64a7bcceaaf3442753b11dddR18) [[2]](diffhunk://#diff-aecfc7542f3194d151b0a0812fa08dca7a2147da1c6bc06f41f19aa2b4f934afR35-R38)

Closes #1358 
Closes #745 