### PR TITLE
#1421 Add port annotation for prometheus

### DIFF
--- a/assets/state-dcgm-exporter/0600_service.yaml
+++ b/assets/state-dcgm-exporter/0600_service.yaml
@@ -7,6 +7,7 @@ metadata:
     app: nvidia-dcgm-exporter
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/port: "9400"
 spec:
   selector:
     app: nvidia-dcgm-exporter

--- a/assets/state-node-status-exporter/0500_service.yaml
+++ b/assets/state-node-status-exporter/0500_service.yaml
@@ -7,6 +7,7 @@ metadata:
     app: nvidia-node-status-exporter
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
 spec:
   selector:
     app: nvidia-node-status-exporter

--- a/assets/state-operator-metrics/0200_service.yaml
+++ b/assets/state-operator-metrics/0200_service.yaml
@@ -7,6 +7,7 @@ metadata:
     app: gpu-operator
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
 spec:
   selector:
     app: gpu-operator


### PR DESCRIPTION
Relates to issue #1421

Add port annotation for Prometheus to use when scraping for metrics. This should allow support for more hosting scenarios where Prometheus may be trying a default port, e.g. 9100, rather than trying the ports defined on the service automatically.

