### PR TITLE
Allow k8s-device-plugin daemonset run in nonpriveleged mode

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -767,6 +767,12 @@ type DevicePluginSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="MPS related configuration for the NVIDIA Device Plugin"
 	MPS *MPSConfig `json:"mps,omitempty"`
+
+	// Unpriveleged indicates NVIDIA Device Plugin should run with securityContext: priveleged: false
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Run NVIDIA Device Plugin daemon set with privileged false, which alllows limiting NVIDIA_VISIBLE_DEVICES"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	Unprivileged *bool `json:"enabled,omitempty"`
 }
 
 // DevicePluginConfig defines ConfigMap name for NVIDIA Device Plugin config

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1359,6 +1359,11 @@ func TransformDevicePlugin(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 	}
 	obj.Spec.Template.Spec.Containers[0].Image = image
 
+	// set privileged false if overriden
+	if config.Unprivileged {
+		obj.Spec.Template.Spec.Containers[0].SecurityContext.Privileged = false
+	}
+
 	// update image pull policy
 	obj.Spec.Template.Spec.Containers[0].ImagePullPolicy = gpuv1.ImagePullPolicy(config.DevicePlugin.ImagePullPolicy)
 


### PR DESCRIPTION
Following this https://github.com/NVIDIA/k8s-device-plugin/issues/435#issuecomment-1930087603 commonly used workaround to limit device plugin to be able to expose only certain devices. 

With this change one can:
- set mig strategy to None
- set `NVIDIA_VISIBLE_DEVICES=...` for the k8s-device-plugin
- and set `unprivileged: true` for k8s-device-plugin

And thus have a device plugin only expose needed GPUs to allow for k8s not to schedule pods to certain GPUs.

The configuration is tested by me in our cluster but the comment with the workaround I mentioned seems to be somewhat widely referred to (and I assume adopted).

_Obviously I'm new in this repo - let me know what else I can do to push this forward._