### PR TITLE
bump golang version to v1.24.3

### DIFF
--- a/validator/versions.mk
+++ b/validator/versions.mk
@@ -16,4 +16,4 @@
 include $(CURDIR)/../versions.mk
 
 CUDA_SAMPLES_VERSION ?= 11.7.1
-GOLANG_VERSION ?= 1.24.2
+GOLANG_VERSION ?= 1.24.3

--- a/versions.mk
+++ b/versions.mk
@@ -19,7 +19,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v25.3.0
 
-GOLANG_VERSION ?= 1.24.2
+GOLANG_VERSION ?= 1.24.3
 
 GOLANGCI_LINT_VERSION ?= v2.1.6
 


### PR DESCRIPTION
go1.24.3 (released 2025-05-06) includes security fixes to the os package, as well as bug fixes to the runtime, the compiler, the linker, the go command, and the crypto/tls and os packages. 

See the [Go 1.24.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.3+label%3ACherryPickApproved) for details.