### PR TITLE
chore(deploy/chart): remove enableNodeFeatureApi option from nfd

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -559,7 +559,6 @@ ccManager:
   resources: {}
 
 node-feature-discovery:
-  enableNodeFeatureApi: true
   priorityClassName: system-node-critical
   gc:
     enable: true


### PR DESCRIPTION
Since NodeFeatureAPI is enabled by default starting from v0.17, the enableNodeFeatureApi has been removed.

https://kubernetes-sigs.github.io/node-feature-discovery/v0.17/reference/feature-gates.html