### PR TITLE
Add driver rootfs and /host to vgpu-device-manager

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -26,6 +26,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -2093,4 +2094,30 @@ func (c *CCManagerSpec) IsEnabled() bool {
 		return false
 	}
 	return *c.Enabled
+}
+
+// +kubebuilder:object:generate=false
+type ConfigWithName interface {
+	GetName() string
+}
+
+// GetConfigMapName returns the config's name if it's non-empty and differs from defaultName,
+// otherwise returns defaultName. The boolean indicates whether a custom name was used.
+func GetConfigMapName[T ConfigWithName](config T, defaultName string) (string, bool) {
+	if name := config.GetName(); name != "" {
+		return name, name != defaultName
+	}
+	return defaultName, false
+}
+
+func (c *MIGGPUClientsConfigSpec) GetName() string {
+	return ptr.Deref(c, MIGGPUClientsConfigSpec{}).Name
+}
+
+func (c *MIGPartedConfigSpec) GetName() string {
+	return ptr.Deref(c, MIGPartedConfigSpec{}).Name
+}
+
+func (c *VGPUDevicesConfigSpec) GetName() string {
+	return ptr.Deref(c, VGPUDevicesConfigSpec{}).Name
 }

--- a/assets/state-vgpu-device-manager/0600_daemonset.yaml
+++ b/assets/state-vgpu-device-manager/0600_daemonset.yaml
@@ -54,6 +54,12 @@ spec:
           name: vgpu-config
         - mountPath: /sys
           name: host-sys
+        - mountPath: /host
+          name: host-root
+          mountPropagation: HostToContainer
+        - name: driver-install-dir
+          mountPath: /driver-root
+          mountPropagation: HostToContainer
       volumes:
       - name: vgpu-config
         configMap:
@@ -62,6 +68,13 @@ spec:
         hostPath:
           path: /sys
           type: Directory
+      - name: host-root
+        hostPath:
+          path: "/"
+      - name: driver-install-dir
+        hostPath:
+          path: "/run/nvidia/driver"
+          type: DirectoryOrCreate
       - name: run-nvidia-validations
         hostPath:
           path: /run/nvidia/validations

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -535,24 +535,24 @@ func createConfigMap(n ClusterPolicyController, configMapIdx int) (gpuv1.State, 
 
 	// avoid creating default 'mig-parted-config' ConfigMap if custom one is provided
 	if obj.Name == MigPartedDefaultConfigMapName {
-		if config.MIGManager.Config != nil && config.MIGManager.Config.Name != "" && config.MIGManager.Config.Name != MigPartedDefaultConfigMapName {
-			logger.Info(fmt.Sprintf("Not creating resource, custom ConfigMap provided: %s", config.MIGManager.Config.Name))
+		if name, isCustom := gpuv1.GetConfigMapName(config.MIGManager.Config, MigPartedDefaultConfigMapName); isCustom {
+			logger.Info("Not creating resource, custom ConfigMap provided", "Name", name)
 			return gpuv1.Ready, nil
 		}
 	}
 
 	// avoid creating default 'gpu-clients' ConfigMap if custom one is provided
 	if obj.Name == MigDefaultGPUClientsConfigMapName {
-		if config.MIGManager.GPUClientsConfig != nil && config.MIGManager.GPUClientsConfig.Name != "" {
-			logger.Info(fmt.Sprintf("Not creating resource, custom ConfigMap provided: %s", config.MIGManager.GPUClientsConfig.Name))
+		if name, isCustom := gpuv1.GetConfigMapName(config.MIGManager.GPUClientsConfig, MigDefaultGPUClientsConfigMapName); isCustom {
+			logger.Info("Not creating resource, custom ConfigMap provided", "Name", name)
 			return gpuv1.Ready, nil
 		}
 	}
 
 	// avoid creating default vGPU device manager ConfigMap if custom one provided
 	if obj.Name == VgpuDMDefaultConfigMapName {
-		if config.VGPUDeviceManager.Config != nil && config.VGPUDeviceManager.Config.Name != "" {
-			logger.Info(fmt.Sprintf("Not creating resource, custom ConfigMap provided: %s", config.VGPUDeviceManager.Config.Name))
+		if name, isCustom := gpuv1.GetConfigMapName(config.VGPUDeviceManager.Config, VgpuDMDefaultConfigMapName); isCustom {
+			logger.Info("Not creating resource, custom ConfigMap provided", "Name", name)
 			return gpuv1.Ready, nil
 		}
 	}
@@ -1808,10 +1808,7 @@ func TransformMIGManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec,
 			continue
 		}
 
-		name := MigPartedDefaultConfigMapName
-		if config.MIGManager.Config != nil && config.MIGManager.Config.Name != "" && config.MIGManager.Config.Name != MigPartedDefaultConfigMapName {
-			name = config.MIGManager.Config.Name
-		}
+		name, _ := gpuv1.GetConfigMapName(config.MIGManager.Config, MigPartedDefaultConfigMapName)
 		obj.Spec.Template.Spec.Volumes[i].ConfigMap.Name = name
 		break
 	}
@@ -1822,10 +1819,7 @@ func TransformMIGManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec,
 			continue
 		}
 
-		name := MigDefaultGPUClientsConfigMapName
-		if config.MIGManager.GPUClientsConfig != nil && config.MIGManager.GPUClientsConfig.Name != "" {
-			name = config.MIGManager.GPUClientsConfig.Name
-		}
+		name, _ := gpuv1.GetConfigMapName(config.MIGManager.GPUClientsConfig, MigDefaultGPUClientsConfigMapName)
 		obj.Spec.Template.Spec.Volumes[i].ConfigMap.Name = name
 		break
 	}
@@ -2064,10 +2058,7 @@ func TransformVGPUDeviceManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPoli
 			continue
 		}
 
-		name := VgpuDMDefaultConfigMapName
-		if config.VGPUDeviceManager.Config != nil && config.VGPUDeviceManager.Config.Name != "" {
-			name = config.VGPUDeviceManager.Config.Name
-		}
+		name, _ := gpuv1.GetConfigMapName(config.VGPUDeviceManager.Config, VgpuDMDefaultConfigMapName)
 		obj.Spec.Template.Spec.Volumes[i].ConfigMap.Name = name
 		break
 	}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/yaml v1.5.0
 )
@@ -154,7 +155,6 @@ require (
 	k8s.io/component-base v0.33.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20250610211856-8b98d1ed966a // indirect
 	k8s.io/kubectl v0.33.2 // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect


### PR DESCRIPTION
This PR mounts the NVIDIA driver rootfs, the host rootfs and the `gpu-clients` ConfigMap to the `vgpu-device-manager` container to enable MIG configuration before the vGPU configuration when MIG-backed vGPU types are included in the selected vGPU configuration.

`nvidia-mig-parted` requires NVML to configure MIG and the host rootfs to start/stop systemd services.

Related vGPU device manager PR: https://github.com/NVIDIA/vgpu-device-manager/pull/93