### PR TITLE
[Dockerfile] use official K8s URL to download kubectl

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,7 +102,7 @@ COPY hack/must-gather.sh /usr/bin/gather
 
 # Install must-gather dependency: `kubectl`
 ARG TARGETARCH
-RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${OS_ARCH}/kubectl
+RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${OS_ARCH}/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 


### PR DESCRIPTION
This change ensures that the latest stable kubectl binary is downloaded whenever the container image
is built. The current URL -
https://storage.googleapis.com/kubernetes-release/release/stable.txt no longer returns the latest stable release, so we are now switching to the actively maintained download URL of upstream Kubernetes.

This change should address the CVE-2024-34156