### PR TITLE
Use POSIX sh instead of bash in entrypoint scripts and container probes

### DIFF
--- a/assets/state-container-toolkit/0400_configmap.yaml
+++ b/assets/state-container-toolkit/0400_configmap.yaml
@@ -7,9 +7,9 @@ metadata:
     app: nvidia-container-toolkit-daemonset
 data:
   entrypoint.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
-    until [[ -f /run/nvidia/validations/driver-ready ]]
+    until [ -f /run/nvidia/validations/driver-ready ]
     do
       echo "waiting for the driver validations to be ready..."
       sleep 5

--- a/assets/state-container-toolkit/0500_daemonset.yaml
+++ b/assets/state-container-toolkit/0500_daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             mountPath: /host-dev-char
       containers:
       - image: "FILLED BY THE OPERATOR"
-        command: ["/bin/bash", "-c"]
+        command: ["/bin/sh", "-c"]
         args:
           - /bin/entrypoint.sh
         env:

--- a/assets/state-dcgm-exporter/0800_configmap_openshift.yaml
+++ b/assets/state-dcgm-exporter/0800_configmap_openshift.yaml
@@ -7,6 +7,6 @@ metadata:
     app: nvidia-dcgm-exporter
 data:
   entrypoint.sh: |-
-    #!/bin/bash
+    #!/bin/sh
     chcon -t  container_file_t /var/lib/kubelet/pod-resources
     chcon -t  container_file_t /var/lib/kubelet/pod-resources/*

--- a/assets/state-device-plugin/0400_configmap.yaml
+++ b/assets/state-device-plugin/0400_configmap.yaml
@@ -7,9 +7,9 @@ metadata:
     app: nvidia-device-plugin-daemonset
 data:
   entrypoint.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
-    until [[ -f /run/nvidia/validations/driver-ready ]]
+    until [ -f /run/nvidia/validations/driver-ready ]
     do
       echo "waiting for the driver validations to be ready..."
       sleep 5

--- a/assets/state-device-plugin/0500_daemonset.yaml
+++ b/assets/state-device-plugin/0500_daemonset.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - image: "FILLED BY THE OPERATOR"
         name: nvidia-device-plugin
-        command: ["/bin/bash", "-c"]
+        command: ["/bin/sh", "-c"]
         args:
           - /bin/entrypoint.sh
         securityContext:

--- a/assets/state-kata-manager/0410_configmap.yaml
+++ b/assets/state-kata-manager/0410_configmap.yaml
@@ -7,11 +7,11 @@ metadata:
     app: nvidia-kata-manager
 data:
   entrypoint.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
-    if [[ "${CDI_ENABLED}" == "true" ]]; then
+    if [ "${CDI_ENABLED}" = "true" ]; then
       while true; do
-        if [[ -f /run/nvidia/validations/vfio-pci-ready ]]; then
+        if [ -f /run/nvidia/validations/vfio-pci-ready ]; then
           break
         fi
         echo "waiting for vfio-pci validations to complete..."

--- a/assets/state-kata-manager/0600_daemonset.yaml
+++ b/assets/state-kata-manager/0600_daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         - name: nvidia-kata-manager
           image: "FILLED BY THE OPERATOR"
           imagePullPolicy: IfNotPresent
-          command: ["/bin/bash", "-c"]
+          command: ["/bin/sh", "-c"]
           args:
             - /bin/entrypoint.sh
           env:
@@ -66,11 +66,11 @@ spec:
           readinessProbe:
             exec:
               command:
-                - bash
+                - sh
                 - "-c"
                 - |
                   pid_file="${KATA_ARTIFACTS_DIR}/k8s-kata-manager.pid"
-                  [[ -f "${pid_file}" ]] && [[ -d "/proc/$(cat $pid_file)" ]] && exit 0 || exit 1
+                  [ -f "${pid_file}" ] && [ -d "/proc/$(cat $pid_file)" ] && exit 0 || exit 1
             initialDelaySeconds: 5
             periodSeconds: 5
       terminationGracePeriodSeconds: 30

--- a/assets/state-mig-manager/0420_configmap.yaml
+++ b/assets/state-mig-manager/0420_configmap.yaml
@@ -7,9 +7,9 @@ metadata:
     app: nvidia-mig-manager
 data:
   entrypoint.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
-    until [[ -f /run/nvidia/validations/driver-ready ]]
+    until [ -f /run/nvidia/validations/driver-ready ]
     do
       echo "waiting for the driver validations to be ready..."
       sleep 5

--- a/assets/state-mig-manager/0600_daemonset.yaml
+++ b/assets/state-mig-manager/0600_daemonset.yaml
@@ -39,7 +39,7 @@ spec:
       - name: nvidia-mig-manager
         image: "FILLED BY THE OPERATOR"
         imagePullPolicy: IfNotPresent
-        command: [bash, -c]
+        command: [/bin/sh, -c]
         args:
           - /bin/entrypoint.sh
         env:

--- a/assets/state-vfio-manager/0400_configmap.yaml
+++ b/assets/state-vfio-manager/0400_configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nvidia-vfio-manager
 data:
   vfio-manage.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
     set -eu
 
@@ -25,9 +25,7 @@ data:
     }
 
     unbind_from_driver() {
-        local gpu=$1
-        local existing_driver_name
-        local existing_driver
+        gpu=$1
 
         [ -e "/sys/bus/pci/devices/$gpu/driver" ] || return 0
 
@@ -36,14 +34,12 @@ data:
 
         echo "unbinding device $gpu from driver $existing_driver_name"
         echo "$gpu" > "$existing_driver/unbind"
-        echo > /sys/bus/pci/devices/$gpu/driver_override
+        echo > "/sys/bus/pci/devices/$gpu/driver_override"
     }
 
     # unbind device from non vfio-pci driver
     unbind_from_other_driver() {
-        local gpu=$1
-        local existing_driver_name
-        local existing_driver
+        gpu=$1
 
         [ -e "/sys/bus/pci/devices/$gpu/driver" ] || return 0
 
@@ -54,22 +50,20 @@ data:
         [ "$existing_driver_name" != "vfio-pci" ] || return 0
         echo "unbinding device $gpu from driver $existing_driver_name"
         echo "$gpu" > "$existing_driver/unbind"
-        echo > /sys/bus/pci/devices/$gpu/driver_override
+        echo > "/sys/bus/pci/devices/$gpu/driver_override"
     }
 
     is_nvidia_gpu_device() {
-        local gpu=$1
+        gpu=$1
         # make sure device class is for NVIDIA GPU
         device_class_file=$(readlink -f "/sys/bus/pci/devices/$gpu/class")
         device_class=$(cat "$device_class_file")
-        [ "$device_class" == "0x030200" ] || [ "$device_class" == "0x030000" ] || return 1
+        [ "$device_class" = "0x030200" ] || [ "$device_class" = "0x030000" ] || return 1
         return 0
     }
 
     is_bound_to_vfio() {
-        local gpu=$1
-        local existing_driver_name
-        local existing_driver
+        gpu=$1
 
         # return if not bound to any driver
         [ -e "/sys/bus/pci/devices/$gpu/driver" ] || return 1
@@ -79,21 +73,21 @@ data:
 
         echo "existing driver is $existing_driver_name"
         # return if bound to other drivers(nvidia, nouveau)
-        [ "$existing_driver_name" == "vfio-pci" ] || return 1
+        [ "$existing_driver_name" = "vfio-pci" ] || return 1
 
         # bound to vfio
         return 0
     }
 
     unbind_device() {
-        local gpu=$1
+        gpu=$1
 
         if ! is_nvidia_gpu_device $gpu; then
             return 0
         fi
 
         echo "unbinding device $gpu"
-        unbind_from_driver $gpu
+        unbind_from_driver "$gpu"
         #for graphics mode, we need to unbind the auxiliary device as well
         aux_dev=$(get_graphics_aux_dev "$gpu")
         if [ "$aux_dev" != "NONE" ]; then
@@ -104,21 +98,21 @@ data:
 
     unbind_all() {
         for dev in /sys/bus/pci/devices/*; do
-            read vendor < $dev/vendor
+            read -r vendor < "$dev/vendor"
             if [ "$vendor" = "0x10de" ]; then
-                local dev_id=$(basename $dev)
-                unbind_device $dev_id
+                dev_id=$(basename "$dev")
+                unbind_device "$dev_id"
             fi
         done
     }
 
     bind_pci_device() {
-        local gpu=$1
+        gpu=$1
 
         if ! is_bound_to_vfio $gpu; then
           unbind_from_other_driver $gpu
           echo "binding device $gpu"
-          echo "vfio-pci" > /sys/bus/pci/devices/$gpu/driver_override
+          echo "vfio-pci" > "/sys/bus/pci/devices/$gpu/driver_override"
           echo "$gpu" > /sys/bus/pci/drivers/vfio-pci/bind
         else
           echo "device $gpu already bound to vfio-pci"
@@ -126,7 +120,7 @@ data:
     }
 
     get_graphics_aux_dev() {
-        local gpu=$1
+        gpu=$1
         device_class_file=$(readlink -f "/sys/bus/pci/devices/$gpu/class")
         device_class=$(cat "$device_class_file")
         if [ "$device_class" != "0x030000" ]; then
@@ -134,14 +128,14 @@ data:
           return
         fi
 
-        if ls "/sys/bus/pci/devices/$gpu" | grep consumer >& /dev/null; then
+        if ls "/sys/bus/pci/devices/$gpu" | grep consumer >/dev/null 2>&1; then
           aux_dev=$(ls "/sys/bus/pci/devices/$gpu" | grep consumer | awk -Fconsumer:pci: '{print $2}')
-          if [ "$aux_dev" == "" ]; then
+          if [ "$aux_dev" = "" ]; then
             echo "NONE"
             return
           fi
 
-          if ls "/sys/bus/pci/devices/$aux_dev/" >& /dev/null; then
+          if ls "/sys/bus/pci/devices/$aux_dev/" >/dev/null 2>&1; then
             echo "$aux_dev"
             return
           fi
@@ -151,9 +145,9 @@ data:
     }
 
     bind_device() {
-        local gpu=$1
+        gpu=$1
 
-        if ! is_nvidia_gpu_device $gpu; then
+        if ! is_nvidia_gpu_device "$gpu"; then
             echo "device $gpu is not a gpu!"
             return 0
         fi
@@ -169,10 +163,10 @@ data:
 
     bind_all() {
         for dev in /sys/bus/pci/devices/*; do
-            read vendor < $dev/vendor
+            read -r vendor < "$dev/vendor"
             if [ "$vendor" = "0x10de" ]; then
-                local dev_id=$(basename $dev)
-                bind_device $dev_id
+                dev_id=$(basename "$dev")
+                bind_device "$dev_id"
             fi
         done
     }
@@ -180,7 +174,7 @@ data:
     handle_bind() {
         chroot /host modprobe vfio-pci
         if [ "$DEVICE_ID" != "" ]; then
-            bind_device $DEVICE_ID
+            bind_device "$DEVICE_ID"
         elif [ "$ALL_DEVICES" = "true" ]; then
             bind_all
         else
@@ -190,7 +184,7 @@ data:
 
     handle_unbind() {
         if [ "$DEVICE_ID" != "" ]; then
-            unbind_device $DEVICE_ID
+            unbind_device "$DEVICE_ID"
         elif [ "$ALL_DEVICES" = "true" ]; then
             unbind_all
         else

--- a/assets/state-vfio-manager/0600_daemonset.yaml
+++ b/assets/state-vfio-manager/0600_daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         - name: nvidia-vfio-manager
           image: "FILLED BY THE OPERATOR"
           imagePullPolicy: IfNotPresent
-          command: ["/bin/bash", "-c"]
+          command: ["/bin/sh", "-c"]
           args:
             - /bin/vfio-manage.sh bind --all && sleep inf
           resources:


### PR DESCRIPTION
This change is needed now that we are moving all of our operands to distroless. The distroless `-dev` tags contain `sh` and not `bash`. 