### PR TITLE
Renovate: Automate operand version bumps in GPU Operator

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prHourlyLimit": 10,
+  "prConcurrentLimit": 10,
+  "dependencyDashboard": false,
+  "extends": [
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard",
+    "config:recommended",
+    ":disableDependencyDashboard"
+  ],
+  "forkProcessing": "enabled",
+  "ignorePaths": ["vendor/**"],
+  "enabledManagers": ["custom.regex"],
+  "recreateWhen": "always",
+  "separateMultipleMajor": false,
+  "separateMinorPatch": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
+      ],
+      "matchStrings": [
+        "[-\\s]*value:\\s*\"?(?<depName>[^:\"]+)(?::(?<currentValue>[^@\"]+))?@(?<currentDigest>sha256:[a-f0-9]{64})\"?",
+        "[-\\s]*image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]{64})",
+        "- name: (?<suffix>[\\w-]+)[-\\s]*image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "versioningTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "deployments/gpu-operator/values.yaml"
+      ],
+      "matchStrings": [
+       "[-\\s]*repository:\\s*(?<repo>\\S+)\\s*\\n(?:\\s*#.*\\n|\\s*\\n)*[-\\s]*image:\\s*(?<image>\\S+)\\s*\\n(?:\\s*#.*\\n|\\s*\\n)*[-\\s]*version:\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "{{repo}}/{{image}}",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "loose"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": [
+        "nvcr.io/nvidia/cloud-native/k8s-driver-manager",
+        "nvcr.io/nvidia/cloud-native/k8s-kata-manager",
+        "nvcr.io/nvidia/cloud-native/vgpu-device-manager",
+        "nvcr.io/nvidia/cloud-native/vgpu-cc-manager",
+        "nvcr.io/nvidia/kubevirt-gpu-device-plugin",
+        "nvcr.io/nvidia/k8s-device-plugin"
+      ],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "separateMajorMinor": false
+    },
+    {
+      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": [
+       "nvcr.io/nvidia/k8s/container-toolkit",
+       "nvcr.io/nvidia/cloud-native/k8s-mig-manager"
+      ],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ubuntu(?<ubuntu>\\d+\\.\\d+)$",
+      "separateMajorMinor": false
+    },
+    {
+      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": [
+       "nvcr.io/nvidia/cuda"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-base-ubi9$",
+      "separateMajorMinor": false
+    },
+    {
+      "groupName": "bump all nvcr packages for deploymens and clusterservice, skip driver",
+      "matchPackageNames": ["/.*/"]
+    },
+    {
+      "matchPackageNames": ["nvcr.io/nvidia/driver"],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,21 @@
+name: Renovate
+
+on:
+  schedule:
+     - cron: "0 9 * * *" # every day at 9:00 AM UTC
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v43.0.2
+        with:
+          configurationFile: .github/renovate.json
+        env:
+          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RENOVATE_REPOSITORIES: '["NVIDIA/gpu-operator"]'
+          RENOVATE_ONBOARDING: false

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -80,8 +80,8 @@ operator:
   # to be passed during helm upgrade.
   upgradeCRD: true
   initContainer:
-    image: cuda
     repository: nvcr.io/nvidia
+    image: cuda
     version: 12.8.1-base-ubi9
     imagePullPolicy: IfNotPresent
   tolerations:
@@ -192,8 +192,8 @@ driver:
       timeoutSeconds: 300
       deleteEmptyDir: false
   manager:
-    image: k8s-driver-manager
     repository: nvcr.io/nvidia/cloud-native
+    image: k8s-driver-manager
     # When choosing a different version of k8s-driver-manager, DO NOT downgrade to a version lower than v0.6.4
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
     version: v0.8.0
@@ -464,8 +464,8 @@ vgpuManager:
   env: []
   resources: {}
   driverManager:
-    image: k8s-driver-manager
     repository: nvcr.io/nvidia/cloud-native
+    image: k8s-driver-manager
     # When choosing a different version of k8s-driver-manager, DO NOT downgrade to a version lower than v0.6.4
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
     version: v0.8.0
@@ -498,8 +498,8 @@ vfioManager:
   env: []
   resources: {}
   driverManager:
-    image: k8s-driver-manager
     repository: nvcr.io/nvidia/cloud-native
+    image: k8s-driver-manager
     # When choosing a different version of k8s-driver-manager, DO NOT downgrade to a version lower than v0.6.4
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
     version: v0.8.0


### PR DESCRIPTION
Pipeline:
https://github.com/shivakunv/gpu-operator/actions/runs/16165499570
Test PR ( forked repo)
https://github.com/shivakunv/gpu-operator/pull/260

driver update skipped
[nvcr.io/nvidia/driver](http://nvcr.io/nvidia/driver)
Driver updates were skipped because the driver digest could not be identified.
We are not uploading the images with specefic tags like driver:550 , driver:570 , etc . As a result , Renovate updates all digests with the latest one , which is incorrect .
Possible solution is to adopt SHA256 digest-based updates along with proper tagging.
