### PR TITLE
Fix regression introduced in the validator's preStop command

### DIFF
--- a/assets/state-operator-validation/0500_daemonset.yaml
+++ b/assets/state-operator-validation/0500_daemonset.yaml
@@ -154,7 +154,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/*-ready"]
+                command: ["sh", "-c", "rm -f /run/nvidia/validations/*-ready"]
           volumeMounts:
             - name: run-nvidia-validations
               mountPath: "/run/nvidia/validations"


### PR DESCRIPTION
After switching the operator image to the distroless base image, /bin/sh is no longer a valid file. The 'sh' binary is present in the image at /busybox/sh and is present in the executable search path.