### PR TITLE
Add 'nodefeatures/finalizers' for nfs worker Role

### DIFF
--- a/deployments/gpu-operator/charts/node-feature-discovery/templates/role.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/templates/role.yaml
@@ -11,6 +11,7 @@ rules:
   - nfd.k8s-sigs.io
   resources:
   - nodefeatures
+  - nodefeatures/finalizers
   verbs:
   - create
   - get


### PR DESCRIPTION
I've run into following issue:
```
worker E0718 10:20:12.156046       1 main.go:91] "error while running" err="failed to advertise features (via CRD API): failed to update NodeFeature object \"skynet-dev-4dxsm\": nodefeatures.nfd.k8s-sigs.io \"skynet-dev-4dxsm\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>"
```
NFD role does not have permissions for the finalizers and failing 

helm values:
```
node-feature-discovery:
  worker:
    serviceAccount:
      name: node-feature-discovery-worker
      create: true
```
