### PR TITLE
[dcgm-exporter] Add option hostNetwork for dcgmExporter

### DIFF
--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -337,6 +337,9 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostNetwork:
+                    description: Run the DCGM Exporter pod on the host’s network, sharing the node’s network interfaces and IP address
+                    type: boolean
                   image:
                     description: NVIDIA DCGM Exporter image name
                     pattern: '[a-zA-Z0-9\-]+'

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -337,6 +337,9 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostNetwork:
+                    description: Run the DCGM Exporter pod on the host’s network, sharing the node’s network interfaces and IP address
+                    type: boolean
                   image:
                     description: NVIDIA DCGM Exporter image name
                     pattern: '[a-zA-Z0-9\-]+'

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -337,6 +337,9 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostNetwork:
+                    description: Run the DCGM Exporter pod on the host’s network, sharing the node’s network interfaces and IP address
+                    type: boolean
                   image:
                     description: NVIDIA DCGM Exporter image name
                     pattern: '[a-zA-Z0-9\-]+'

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -322,6 +322,7 @@ dcgmExporter:
       value: "true"
     - name: DCGM_EXPORTER_COLLECTORS
       value: "/etc/dcgm-exporter/dcp-metrics-included.csv"
+  hostNetwork: false
   resources: {}
   service:
     internalTrafficPolicy: Cluster


### PR DESCRIPTION
Is it possible to add the `hostnetwork` option to the `dcgm-exporter` via `gpu-operator` ? 
because the `dcgm-exporter` itself already provides that option :
https://github.com/NVIDIA/dcgm-exporter/blob/8fd69339fe2138459d3618508c3ebb1f43b51f79/deployment/templates/daemonset.yaml#L49-L50

Why is this necessary? because the label on the `dcgm-exporter` metrics does not have a node label to display the node name, while the label provided by the `dcgm-exporter` that is possible to display the node name is only `hostname`.

If `hostnetwork: false` then in the value `hostname` label will use the pod name, 
but if `hostnetwork: true` then in the value `hostname` label will use the node name.

And this is useful for monitoring tools that require access to node-level network interfaces or need to expose ports directly on the node.