### PR TITLE
fix the pinned version of the upload-pages-artifact action

### DIFF
--- a/.github/workflows/deploy-helm-repo-to-pages.yml
+++ b/.github/workflows/deploy-helm-repo-to-pages.yml
@@ -48,7 +48,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This fixes the gh-pages failures that were introduced by this [commit](https://github.com/NVIDIA/gpu-operator/commit/731ceb98fbc131f57b5b0e65c8259d072967e663). 

Currently, our gh-pages helm repo shows v24.9.2 as the latest gpu-operator chart, even though v25.3.1 and v25.3.0 charts have been committed to the branch