### PR TITLE
Cleanup extraneous envvars from values.yaml

### DIFF
--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           - name: ENABLE_GPU_POD_EVICTION
             value: "true"
           - name: ENABLE_AUTO_DRAIN
-            value: "true"
+            value: "false"
           - name: DRAIN_USE_FORCE
             value: "false"
           - name: DRAIN_POD_SELECTOR_LABEL

--- a/assets/state-operator-validation/0500_daemonset.yaml
+++ b/assets/state-operator-validation/0500_daemonset.yaml
@@ -127,7 +127,7 @@ spec:
           - name: WITH_WAIT
             value: "false"
           - name: WITH_WORKLOAD
-            value: "true"
+            value: "false"
           - name: MIG_STRATEGY
             value: "FILLED BY OPERATOR"
           - name: NODE_NAME

--- a/assets/state-vfio-manager/0600_daemonset.yaml
+++ b/assets/state-vfio-manager/0600_daemonset.yaml
@@ -36,6 +36,8 @@ spec:
           # always use runc for driver containers
           - name: NVIDIA_VISIBLE_DEVICES
             value: void
+          - name: ENABLE_GPU_POD_EVICTION
+            value: "false"
           - name: ENABLE_AUTO_DRAIN
             value: "false"
           - name: OPERATOR_NAMESPACE

--- a/assets/state-vgpu-manager/0500_daemonset.yaml
+++ b/assets/state-vgpu-manager/0500_daemonset.yaml
@@ -42,6 +42,8 @@ spec:
           # always use runc for driver containers
           - name: NVIDIA_VISIBLE_DEVICES
             value: void
+          - name: ENABLE_GPU_POD_EVICTION
+            value: "false"
           - name: ENABLE_AUTO_DRAIN
             value: "false"
           - name: OPERATOR_NAMESPACE

--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -123,12 +123,7 @@ metadata:
             },
             "validator": {
               "plugin": {
-                "env": [
-                  {
-                    "name": "WITH_WORKLOAD",
-                    "value": "false"
-                  }
-                ]
+                "env": []
               }
             },
             "vgpuManager": {

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -60,9 +60,7 @@ validator:
   args: []
   resources: {}
   plugin:
-    env:
-      - name: WITH_WORKLOAD
-        value: "false"
+    env: []
 
 operator:
   repository: nvcr.io/nvidia
@@ -198,19 +196,7 @@ driver:
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
     version: v0.8.0
     imagePullPolicy: IfNotPresent
-    env:
-      - name: ENABLE_GPU_POD_EVICTION
-        value: "true"
-      - name: ENABLE_AUTO_DRAIN
-        value: "false"
-      - name: DRAIN_USE_FORCE
-        value: "false"
-      - name: DRAIN_POD_SELECTOR_LABEL
-        value: ""
-      - name: DRAIN_TIMEOUT_SECONDS
-        value: "0s"
-      - name: DRAIN_DELETE_EMPTYDIR_DATA
-        value: "false"
+    env: []
   env: []
   resources: {}
   # Private mirror repository configuration
@@ -249,19 +235,7 @@ devicePlugin:
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   args: []
-  env:
-    - name: PASS_DEVICE_SPECS
-      value: "true"
-    - name: FAIL_ON_INIT_ERROR
-      value: "true"
-    - name: DEVICE_LIST_STRATEGY
-      value: envvar
-    - name: DEVICE_ID_STRATEGY
-      value: uuid
-    - name: NVIDIA_VISIBLE_DEVICES
-      value: all
-    - name: NVIDIA_DRIVER_CAPABILITIES
-      value: all
+  env: []
   resources: {}
   # Plugin configuration
   # Use "name" to either point to an existing ConfigMap or to create a new one with a list of configurations(i.e with create=true).
@@ -315,13 +289,7 @@ dcgmExporter:
   image: dcgm-exporter
   version: 4.2.3-4.1.3-ubuntu22.04
   imagePullPolicy: IfNotPresent
-  env:
-    - name: DCGM_EXPORTER_LISTEN
-      value: ":9400"
-    - name: DCGM_EXPORTER_KUBERNETES
-      value: "true"
-    - name: DCGM_EXPORTER_COLLECTORS
-      value: "/etc/dcgm-exporter/dcp-metrics-included.csv"
+  env: []
   resources: {}
   service:
     internalTrafficPolicy: Cluster
@@ -364,11 +332,7 @@ gfd:
   version: v0.17.3
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
-  env:
-    - name: GFD_SLEEP_INTERVAL
-      value: 60s
-    - name: GFD_FAIL_ON_INIT_ERROR
-      value: "true"
+  env: []
   resources: {}
 
 migManager:
@@ -378,9 +342,7 @@ migManager:
   version: v0.12.2-ubuntu20.04
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
-  env:
-    - name: WITH_REBOOT
-      value: "false"
+  env: []
   resources: {}
   # MIG configuration
   # Use "name" to either point to an existing ConfigMap or to create a new one with a list of configurations(i.e with create=true).
@@ -470,11 +432,7 @@ vgpuManager:
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
     version: v0.8.0
     imagePullPolicy: IfNotPresent
-    env:
-      - name: ENABLE_GPU_POD_EVICTION
-        value: "false"
-      - name: ENABLE_AUTO_DRAIN
-        value: "false"
+    env: []
 
 vgpuDeviceManager:
   enabled: true
@@ -504,11 +462,7 @@ vfioManager:
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
     version: v0.8.0
     imagePullPolicy: IfNotPresent
-    env:
-      - name: ENABLE_GPU_POD_EVICTION
-        value: "false"
-      - name: ENABLE_AUTO_DRAIN
-        value: "false"
+    env: []
 
 kataManager:
   enabled: false

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -219,7 +219,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -232,7 +232,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -374,7 +374,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -264,7 +264,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -264,7 +264,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -210,7 +210,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -319,7 +319,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -212,7 +212,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -282,7 +282,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -278,7 +278,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -216,7 +216,7 @@ spec:
         - name: ENABLE_GPU_POD_EVICTION
           value: "true"
         - name: ENABLE_AUTO_DRAIN
-          value: "true"
+          value: "false"
         - name: DRAIN_USE_FORCE
           value: "false"
         - name: DRAIN_POD_SELECTOR_LABEL

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -132,11 +132,7 @@ spec:
           - name: ENABLE_GPU_POD_EVICTION
             value: "true"
           - name: ENABLE_AUTO_DRAIN
-          {{- if eq .Driver.Spec.DriverType "vgpu-host-manager" }}
             value: "false"
-          {{- else }}
-            value: "true"
-          {{- end }}
           - name: DRAIN_USE_FORCE
             value: "false"
           - name: DRAIN_POD_SELECTOR_LABEL


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/NVIDIA/gpu-operator/commit/54c270cf3f91c39fb1d0b8e2597f389b70975228. When `cdi.enabled` and `cdi.default` are set to `true`, the controller will set `DEVICE_LIST_STRATEGY=ennvar,cdi-annotations` for the device plugin, however, this envvar is also set in `values.yaml` which will take precedence and overrides what the controller configured. While fixing this, I also discovered that many of the envvars specified in our values.yaml file are already set in the DaemonSet manifests in the `assets/` folder. 