### PR TITLE
Fix regression introduced in the sandbox-validator's preStop command

### DIFF
--- a/assets/state-sandbox-validation/0500_daemonset.yaml
+++ b/assets/state-sandbox-validation/0500_daemonset.yaml
@@ -129,7 +129,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/*"]
+                command: ["sh", "-c", "rm -f /run/nvidia/validations/*"]
           volumeMounts:
             - name: run-nvidia-validations
               mountPath: "/run/nvidia/validations"


### PR DESCRIPTION
After switching the validator image to the distroless base image, /bin/sh is no longer a valid file. The 'sh' binary is present in the image at /busybox/sh and is present in the executable search path.