### PR TITLE
Fix regression introduced in helm hook entrypoint commands

### DIFF
--- a/deployments/gpu-operator/templates/cleanup_crd.yaml
+++ b/deployments/gpu-operator/templates/cleanup_crd.yaml
@@ -35,7 +35,7 @@ spec:
           image: {{ include "gpu-operator.fullimage" . }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
           command:
-          - /bin/sh
+          - sh
           - -c
           - >
               kubectl delete clusterpolicy cluster-policy;

--- a/deployments/gpu-operator/templates/upgrade_crd.yaml
+++ b/deployments/gpu-operator/templates/upgrade_crd.yaml
@@ -83,7 +83,7 @@ spec:
           image: {{ include "gpu-operator.fullimage" . }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
           command:
-          - /bin/sh
+          - sh
           - -c
           - >
             kubectl apply -f /opt/gpu-operator/nvidia.com_clusterpolicies.yaml;


### PR DESCRIPTION
After switching the operator image to the distroless base image, /bin/sh is no longer a valid file. The 'sh' binary is present in the image at /busybox/sh and is present in the executable search path.