### PR TITLE
remove redundant calls of os.GetEnv(OPERATOR_NAMESPACE)

### DIFF
--- a/controllers/clusterpolicy_controller.go
+++ b/controllers/clusterpolicy_controller.go
@@ -62,6 +62,7 @@ type ClusterPolicyReconciler struct {
 	client.Client
 	Log              logr.Logger
 	Scheme           *runtime.Scheme
+	Namespace        string
 	conditionUpdater conditions.Updater
 }
 

--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -759,15 +758,7 @@ func (n *ClusterPolicyController) init(ctx context.Context, reconciler *ClusterP
 	n.scheme = reconciler.Scheme
 
 	if len(n.controls) == 0 {
-		clusterPolicyCtrl.operatorNamespace = os.Getenv("OPERATOR_NAMESPACE")
-
-		if clusterPolicyCtrl.operatorNamespace == "" {
-			n.logger.Error(nil, "OPERATOR_NAMESPACE environment variable not set, cannot proceed")
-			// we cannot do anything without the operator namespace,
-			// let the operator Pod run into `CrashloopBackOff`
-
-			os.Exit(1)
-		}
+		clusterPolicyCtrl.operatorNamespace = reconciler.Namespace
 
 		version, err := OpenshiftVersion(ctx)
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -66,7 +66,7 @@ func TestDriverRenderMinimal(t *testing.T) {
 		testName = "driver-minimal"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -95,7 +95,7 @@ func TestDriverRenderRDMA(t *testing.T) {
 		testName = "driver-rdma"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -128,7 +128,7 @@ func TestDriverRDMAHostMOFED(t *testing.T) {
 	const (
 		testName = "driver-rdma-hostmofed"
 	)
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -162,7 +162,7 @@ func TestDriverSpec(t *testing.T) {
 	const (
 		testName = "driver-full-spec"
 	)
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -250,7 +250,7 @@ func TestDriverGDS(t *testing.T) {
 		testName = "driver-gds"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -288,7 +288,7 @@ func TestDriverGDRCopy(t *testing.T) {
 		testName = "driver-gdrcopy"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -328,7 +328,7 @@ func TestDriverGDRCopyOpenShift(t *testing.T) {
 		toolkitImage = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fecaebc1d51b28bc3548171907e4d91823a031d7a6a694ab686999be2b4d867"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -383,7 +383,7 @@ func TestDriverAdditionalConfigs(t *testing.T) {
 		testName = "driver-additional-configs"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -414,7 +414,7 @@ func TestDriverOpenshiftDriverToolkit(t *testing.T) {
 		toolkitImage = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fecaebc1d51b28bc3548171907e4d91823a031d7a6a694ab686999be2b4d867"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -459,7 +459,7 @@ func TestDriverPrecompiled(t *testing.T) {
 		testName = "driver-precompiled"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -550,7 +550,7 @@ func TestVGPUHostManagerDaemonset(t *testing.T) {
 	const (
 		testName = "driver-vgpu-host-manager"
 	)
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -582,7 +582,7 @@ func TestVGPUHostManagerDaemonsetOpenShift(t *testing.T) {
 		rhcosVersion = "413.92.202304252344-0"
 		toolkitImage = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fecaebc1d51b28bc3548171907e4d91823a031d7a6a694ab686999be2b4d867"
 	)
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -711,7 +711,7 @@ func TestDriverVGPULicensing(t *testing.T) {
 		testName = "driver-vgpu-licensing"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)
@@ -776,7 +776,7 @@ func TestDriverSecretEnv(t *testing.T) {
 		testName = "driver-secret-env"
 	)
 
-	state, err := NewStateDriver(nil, nil, manifestDir)
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
 	require.Nil(t, err)
 	stateDriver, ok := state.(*stateDriver)
 	require.True(t, ok)

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -19,7 +19,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -139,18 +138,13 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 
 	additionalCfgs := &additionalConfigs{}
 
-	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
-	if operatorNamespace == "" {
-		return nil, fmt.Errorf("OPERATOR_NAMESPACE environment variable not set")
-	}
-
 	if !cr.Spec.UsePrecompiledDrivers() {
 		if cr.Spec.IsRepoConfigEnabled() {
 			destinationDir, err := getRepoConfigPath(pool.osRelease)
 			if err != nil {
 				return nil, fmt.Errorf("ERROR: failed to get destination directory for custom repo config: %w", err)
 			}
-			volumeMounts, itemsToInclude, err := s.createConfigMapVolumeMounts(ctx, operatorNamespace,
+			volumeMounts, itemsToInclude, err := s.createConfigMapVolumeMounts(ctx, s.namespace,
 				cr.Spec.RepoConfig.Name, destinationDir)
 			if err != nil {
 				return nil, fmt.Errorf("ERROR: failed to create ConfigMap VolumeMounts for custom repo config: %w", err)
@@ -165,7 +159,7 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 			if err != nil {
 				return nil, fmt.Errorf("ERROR: failed to get destination directory for custom repo config: %w", err)
 			}
-			volumeMounts, itemsToInclude, err := s.createConfigMapVolumeMounts(ctx, operatorNamespace,
+			volumeMounts, itemsToInclude, err := s.createConfigMapVolumeMounts(ctx, s.namespace,
 				cr.Spec.CertConfig.Name, destinationDir)
 			if err != nil {
 				return nil, fmt.Errorf("ERROR: failed to create ConfigMap VolumeMounts for custom certs: %w", err)
@@ -218,7 +212,7 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 	// mount any custom kernel module configuration parameters at /drivers
 	if cr.Spec.IsKernelModuleConfigEnabled() {
 		destinationDir := "/drivers"
-		volumeMounts, itemsToInclude, err := s.createConfigMapVolumeMounts(ctx, operatorNamespace,
+		volumeMounts, itemsToInclude, err := s.createConfigMapVolumeMounts(ctx, s.namespace,
 			cr.Spec.KernelModuleConfig.Name, destinationDir)
 		if err != nil {
 			return nil, fmt.Errorf("ERROR: failed to create ConfigMap VolumeMounts for kernel module configuration: %w", err)

--- a/internal/state/state_skel.go
+++ b/internal/state/state_skel.go
@@ -44,9 +44,10 @@ type stateSkel struct {
 	name        string
 	description string
 
-	client   client.Client
-	scheme   *runtime.Scheme
-	renderer render.Renderer
+	namespace string
+	client    client.Client
+	scheme    *runtime.Scheme
+	renderer  render.Renderer
 }
 
 // Name provides the State name


### PR DESCRIPTION
This is a follow up from the review comments in #1584. Instead of using `os.GetEnv` to retrieve this value, we call it once and we propagate the value through structs instead