### PR TITLE
Allow resource requests and limits to be configurable for all containers in driver pod

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2789,6 +2789,12 @@ func transformPeerMemoryContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPo
 			}
 			obj.Spec.Template.Spec.Containers[i].VolumeMounts = append(obj.Spec.Template.Spec.Containers[i].VolumeMounts, volumeMounts...)
 		}
+		if config.Driver.Resources != nil {
+			obj.Spec.Template.Spec.Containers[i].Resources = corev1.ResourceRequirements{
+				Requests: config.Driver.Resources.Requests,
+				Limits:   config.Driver.Resources.Limits,
+			}
+		}
 	}
 	return nil
 }
@@ -2877,6 +2883,12 @@ func transformGDSContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 		if err != nil {
 			return fmt.Errorf("ERROR: failed to transform the Driver Toolkit Container: %s", err)
 		}
+		if config.Driver.Resources != nil {
+			gdsContainer.Resources = corev1.ResourceRequirements{
+				Requests: config.Driver.Resources.Requests,
+				Limits:   config.Driver.Resources.Limits,
+			}
+		}
 	}
 	return nil
 }
@@ -2963,6 +2975,12 @@ func transformGDRCopyContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolic
 		err = transformOpenShiftDriverToolkitContainer(obj, config, n, "nvidia-gdrcopy-ctr")
 		if err != nil {
 			return fmt.Errorf("ERROR: failed to transform the Driver Toolkit Container: %w", err)
+		}
+		if config.Driver.Resources != nil {
+			gdrcopyContainer.Resources = corev1.ResourceRequirements{
+				Requests: config.Driver.Resources.Requests,
+				Limits:   config.Driver.Resources.Limits,
+			}
 		}
 	}
 	return nil
@@ -3120,6 +3138,14 @@ func transformOpenShiftDriverToolkitContainer(obj *appsv1.DaemonSet, config *gpu
 		}
 	}
 	obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, volSharedDir)
+
+	// set resource limits
+	if config.Driver.Resources != nil {
+		driverToolkitContainer.Resources = corev1.ResourceRequirements{
+			Requests: config.Driver.Resources.Requests,
+			Limits:   config.Driver.Resources.Limits,
+		}
+	}
 	return nil
 }
 

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -187,6 +187,10 @@ func TestDriverSpec(t *testing.T) {
 		ImagePullPolicy:  "Always",
 		ImagePullSecrets: []string{"secret-a", "secret-b"},
 		Resources: &nvidiav1alpha1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("200Mi"),
 				"cpu":    resource.MustParse("500m"),
@@ -623,6 +627,16 @@ func getMinimalDriverRenderData() *driverRenderData {
 				LivenessProbe:  getDefaultContainerProbeSpec(),
 				ReadinessProbe: getDefaultContainerProbeSpec(),
 				DriverType:     nvidiav1alpha1.GPU,
+				Resources: &nvidiav1alpha1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("300Mi"),
+					},
+				},
 			},
 			AppName:          "nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b",
 			Name:             "nvidia-gpu-driver-ubuntu22.04",

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -152,6 +152,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -170,6 +170,9 @@ spec:
           limits:
             cpu: 500m
             memory: 200Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -222,6 +222,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -285,6 +292,13 @@ spec:
         image: nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1-rhcos4.13
         imagePullPolicy: IfNotPresent
         name: nvidia-gdrcopy-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -337,6 +351,13 @@ spec:
         image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fecaebc1d51b28bc3548171907e4d91823a031d7a6a694ab686999be2b4d867
         imagePullPolicy: IfNotPresent
         name: openshift-driver-toolkit-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -152,6 +152,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -213,6 +220,13 @@ spec:
         image: nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1
         imagePullPolicy: IfNotPresent
         name: nvidia-gdrcopy-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -152,6 +152,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -213,6 +220,13 @@ spec:
         image: nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1
         imagePullPolicy: IfNotPresent
         name: nvidia-fs-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -152,6 +152,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -222,6 +222,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -284,6 +291,13 @@ spec:
         image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fecaebc1d51b28bc3548171907e4d91823a031d7a6a694ab686999be2b4d867
         imagePullPolicy: IfNotPresent
         name: openshift-driver-toolkit-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -154,6 +154,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -156,6 +156,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -230,6 +237,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         name: nvidia-peermem-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -154,6 +154,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -226,6 +233,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         name: nvidia-peermem-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-secret-env.yaml
+++ b/internal/state/testdata/golden/driver-secret-env.yaml
@@ -155,6 +155,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -210,6 +217,13 @@ spec:
         image: nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1
         imagePullPolicy: IfNotPresent
         name: nvidia-fs-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -247,6 +261,13 @@ spec:
         image: nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1
         imagePullPolicy: IfNotPresent
         name: nvidia-gdrcopy-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -193,6 +193,13 @@ spec:
         image: nvcr.io/nvidia/vgpu-manager:525.85.03-rhel8.0
         imagePullPolicy: IfNotPresent
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:
@@ -245,6 +252,13 @@ spec:
         image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7fecaebc1d51b28bc3548171907e4d91823a031d7a6a694ab686999be2b4d867
         imagePullPolicy: IfNotPresent
         name: openshift-driver-toolkit-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -145,6 +145,13 @@ spec:
         image: nvcr.io/nvidia/vgpu-manager:525.85.03-ubuntu22.04
         imagePullPolicy: IfNotPresent
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
@@ -152,6 +152,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -152,6 +152,13 @@ spec:
               - -c
               - rm -f /run/nvidia/validations/.driver-ctr-ready
         name: nvidia-driver-ctr
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         securityContext:
           privileged: true
           seLinuxOptions:

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -321,9 +321,8 @@ spec:
             mountPath: /etc/pki/ca-trust/extracted/pem
             readOnly: true
           {{- end}}
-        {{- with .Driver.Spec.Resources }}
-        resources:
-          {{ . | yaml | nindent 10 }}
+        {{- if .Driver.Spec.Resources }}
+        resources: {{ .Driver.Spec.Resources | yaml | nindent 10 }}
         {{- end }}
         {{- if not (eq .Driver.Spec.DriverType "vgpu-host-manager") }}
         startupProbe:
@@ -382,6 +381,9 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
+        {{- if .Driver.Spec.Resources }}
+        resources: {{ .Driver.Spec.Resources | yaml | nindent 10 }}
+        {{- end }}
         startupProbe:
           exec:
             command:
@@ -456,6 +458,9 @@ spec:
             {{- end}}
         {{- end }}
         {{- end }}
+        {{- if .Driver.Spec.Resources }}
+        resources: {{ .Driver.Spec.Resources | yaml | nindent 10 }}
+        {{- end }}
         startupProbe:
           exec:
             command:
@@ -521,6 +526,9 @@ spec:
             {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Driver.Spec.Resources }}
+        resources: {{ .Driver.Spec.Resources | yaml | nindent 10 }}
+        {{- end }}
         startupProbe:
           exec:
             command:
@@ -584,6 +592,9 @@ spec:
             mountPath: /sys/module/firmware_class/parameters/path
           - name: nv-firmware
             mountPath: /lib/firmware
+        {{- if .Driver.Spec.Resources }}
+        resources: {{ .Driver.Spec.Resources | yaml | nindent 10 }}
+        {{- end }}
       {{- end }}
       volumes:
         - name: run-nvidia


### PR DESCRIPTION
The resource requests / limits specified in the CRs only get configured with the main container and not any of the additional containers that can run as part of the driver pod. Below are the list of all other possible containers that can run in the driver pod:

OCP driver toolkit container
Runs only on OpenShift
NVIDIA peer-mem container
Runs only when `spec.driver.rdma.enabled=true` in the ClusterPolicy CR or `spec.rdma.enabled=true` in the NVIDIADriver CR
GDS driver container
Runs only when `spec.gds.enabled=true` in the ClusterPolicy CR or `spec.gds.enabled=true` in the NVIDIADriver CR
GDRCopy driver container
Runs only when `spec.gdrcopy.enabled=true` in the ClusterPolicy CR or `spec.gdrcopy.enabled=true `in the NVIDIADriver CR
The task is to update our controller code so that the resource requests / limits specified by users in the ClusterPolicy / NVIDIADriver CRs get applied to ALL containers in the driver pod, not just the main container.
