### PR TITLE
Renovate: combine tag and digest of same package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -88,6 +88,10 @@
     {
       "matchPackageNames": ["nvcr.io/nvidia/driver"],
       "enabled": false
+    },
+    {
+      "matchDatasources": ["*"],
+      "groupName": "{{depName}}"
     }
   ]
 }


### PR DESCRIPTION
Added groupName to ensure one PR per package

This will resolve issue of bumping of digest and tag( version) separately : refer these 2 PRs  

  https://github.com/NVIDIA/gpu-operator/pull/1632

  https://github.com/NVIDIA/gpu-operator/pull/1638/files


