### PR TITLE
Revert "updated DCGM exporter to distroless"

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
     - name: gpu-operator-image
       image: ghcr.io/nvidia/gpu-operator:main-latest
     - name: dcgm-exporter-image
-      image: nvcr.io/nvidia/k8s/dcgm-exporter@sha256:a11db8b8dd314728c0657d581fc9df9233bde95b313a2d9fe0720730d4fcaff1
+      image: nvcr.io/nvidia/k8s/dcgm-exporter@sha256:66af937cf0b8f7a637bcb761f5899b10c0c59a5efd4b1b5d43228a938fb10d87
     - name: dcgm-image
       image: nvcr.io/nvidia/cloud-native/dcgm@sha256:d42cd2afe032d9bfcb101cc2f739683b123a6c744f2732f221362a3cac776806
     - name: container-toolkit-image
@@ -915,7 +915,7 @@ spec:
                   - name: "DCGM_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/dcgm@sha256:d42cd2afe032d9bfcb101cc2f739683b123a6c744f2732f221362a3cac776806"
                   - name: "DCGM_EXPORTER_IMAGE"
-                    value: "nvcr.io/nvidia/k8s/dcgm-exporter@sha256:a11db8b8dd314728c0657d581fc9df9233bde95b313a2d9fe0720730d4fcaff1"
+                    value: "nvcr.io/nvidia/k8s/dcgm-exporter@sha256:66af937cf0b8f7a637bcb761f5899b10c0c59a5efd4b1b5d43228a938fb10d87"
                   - name: "DEVICE_PLUGIN_IMAGE"
                     value: "nvcr.io/nvidia/k8s-device-plugin@sha256:3c54348fe5a57e5700e7d8068e7531d2ef2d5f3ccb70c8f6bac0953432527abd"
                   - name: "DRIVER_IMAGE"

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -288,7 +288,7 @@ dcgmExporter:
   enabled: true
   repository: nvcr.io/nvidia/k8s
   image: dcgm-exporter
-  version: 4.4.1-4.5.2-distroless
+  version: 4.4.1-4.5.2-ubuntu22.04
   imagePullPolicy: IfNotPresent
   env: []
   resources: {}


### PR DESCRIPTION
This reverts commit c8063d470a1449a6c97c53ab16e4fdefdae29b95.

e2e tests started failing on main starting from this commit. dcgm-exporter container is failing consistently after this change. Will need to debug further and address in a follow-up.