### PR TITLE
Refactor transformForRuntime to accept container pointer; add kata-manager test

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1327,7 +1327,7 @@ func TransformToolkit(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n 
 
 	// configure runtime
 	runtime := n.runtime.String()
-	err = transformForRuntime(obj, config, runtime, mainContainerName)
+	err = transformForRuntime(obj, config, runtime, mainContainer)
 	if err != nil {
 		return fmt.Errorf("error transforming toolkit daemonset : %w", err)
 	}
@@ -1335,16 +1335,10 @@ func TransformToolkit(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n 
 	return nil
 }
 
-func transformForRuntime(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, runtime string, containerName string) error {
-	var mainContainer *corev1.Container
-	for i, ctr := range obj.Spec.Template.Spec.Containers {
-		if ctr.Name == containerName {
-			mainContainer = &obj.Spec.Template.Spec.Containers[i]
-			break
-		}
-	}
+func transformForRuntime(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, runtime string, container *corev1.Container) error {
+	mainContainer := container
 	if mainContainer == nil {
-		return fmt.Errorf("failed to find main container %q", containerName)
+		return fmt.Errorf("failed to find container for runtime transform")
 	}
 
 	setContainerEnv(mainContainer, "RUNTIME", runtime)
@@ -1405,7 +1399,7 @@ func transformForRuntime(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec,
 	// Note that we probably want to implement drop-in file support in the
 	// kata manager in any case -- in which case it will be good to use a
 	// similar implementation.
-	if dropInConfigFile != "" && containerName != "nvidia-kata-manager" {
+	if dropInConfigFile != "" && mainContainer.Name != "nvidia-kata-manager" {
 		sourceConfigFileName := path.Base(dropInConfigFile)
 		sourceConfigDir := path.Dir(dropInConfigFile)
 		containerConfigDir := DefaultRuntimeDropInConfigTargetDir
@@ -1984,7 +1978,8 @@ func TransformKataManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec
 	// mount containerd config and socket
 	// setup mounts for runtime config file
 	runtime := n.runtime.String()
-	err = transformForRuntime(obj, config, runtime, "nvidia-kata-manager")
+	// kata manager is the only container in this daemonset
+	err = transformForRuntime(obj, config, runtime, &obj.Spec.Template.Spec.Containers[0])
 	if err != nil {
 		return fmt.Errorf("error transforming kata-manager daemonset : %w", err)
 	}

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -376,6 +376,31 @@ func TestTransformForRuntime(t *testing.T) {
 					},
 				}),
 		},
+			// Cover the kata-manager naming case
+			{
+				description: "containerd skips drop-in for kata manager",
+				runtime:     gpuv1.Containerd,
+				input: NewDaemonset().
+					WithContainer(corev1.Container{Name: "nvidia-kata-manager"}),
+				expectedOutput: NewDaemonset().
+					WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), newHostPathType(corev1.HostPathDirectoryOrCreate)).
+					WithHostPathVolume("containerd-socket", filepath.Dir(DefaultContainerdSocketFile), nil).
+					WithContainer(corev1.Container{
+						Name: "nvidia-kata-manager",
+						Env: []corev1.EnvVar{
+							{Name: "RUNTIME", Value: gpuv1.Containerd.String()},
+							{Name: "CONTAINERD_RUNTIME_CLASS", Value: DefaultRuntimeClass},
+							{Name: "RUNTIME_CONFIG", Value: filepath.Join(DefaultRuntimeConfigTargetDir, filepath.Base(DefaultContainerdConfigFile))},
+							{Name: "CONTAINERD_CONFIG", Value: filepath.Join(DefaultRuntimeConfigTargetDir, filepath.Base(DefaultContainerdConfigFile))},
+							{Name: "RUNTIME_SOCKET", Value: filepath.Join(DefaultRuntimeSocketTargetDir, filepath.Base(DefaultContainerdSocketFile))},
+							{Name: "CONTAINERD_SOCKET", Value: filepath.Join(DefaultRuntimeSocketTargetDir, filepath.Base(DefaultContainerdSocketFile))},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "containerd-config", MountPath: DefaultRuntimeConfigTargetDir},
+							{Name: "containerd-socket", MountPath: DefaultRuntimeSocketTargetDir},
+						},
+					}),
+			},
 	}
 
 	cp := &gpuv1.ClusterPolicySpec{Operator: gpuv1.OperatorSpec{RuntimeClass: DefaultRuntimeClass}}

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -381,7 +381,8 @@ func TestTransformForRuntime(t *testing.T) {
 	cp := &gpuv1.ClusterPolicySpec{Operator: gpuv1.OperatorSpec{RuntimeClass: DefaultRuntimeClass}}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			err := transformForRuntime(tc.input.DaemonSet, cp, tc.runtime.String(), "test-ctr")
+			// pass pointer to the target container
+			err := transformForRuntime(tc.input.DaemonSet, cp, tc.runtime.String(), &tc.input.Spec.Template.Spec.Containers[0])
 			require.NoError(t, err)
 			require.EqualValues(t, tc.expectedOutput, tc.input)
 		})


### PR DESCRIPTION
- Change signature to `transformForRuntime(obj, config, runtime, *corev1.Container)` to avoid name-based lookup.
- Update callers in controllers/object_controls.go (Toolkit, Kata manager) to pass the resolved container pointer.
- Adjust existing tests to new signature.
- Add test ensuring `nvidia-kata-manager` skips drop-in config while setting top-level config and socket.