### PR TITLE
Update helm templates so that default GDS config gets rendered even i…

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -605,7 +605,7 @@ spec:
     {{- if .Values.nodeStatusExporter.args }}
     args: {{ toYaml .Values.nodeStatusExporter.args | nindent 6 }}
     {{- end }}
-  {{- if .Values.gds.enabled }}
+  {{- if .Values.gds }}
   gds:
     enabled: {{ .Values.gds.enabled }}
     {{- if .Values.gds.repository }}


### PR DESCRIPTION
…f disabled

This ensures that default GDS configuration (e.g. image, version) are added to the ClusterPolicy object even if GDS is disabled. This aligns with how other operand configuration is rendered in the helm chart.

Before this change, no `gds` struct is added to ClusterPolicy. After this change, rendering the helm chart results in the following configuration being added to ClusterPolicy:
```
gds:
    enabled: false
    repository: nvcr.io/nvidia/cloud-native
    image: nvidia-fs
    version: "2.26.6"
    imagePullPolicy: IfNotPresent
```