### PR TITLE
Use main-latest as appVersion in Helm chart

### DIFF
--- a/deployments/gpu-operator/Chart.yaml
+++ b/deployments/gpu-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: gpu-operator
 version: v1.0.0-devel
 kubeVersion: ">= 1.16.0-0"
 description: NVIDIA GPU Operator creates/configures/manages GPUs atop Kubernetes
-appVersion: "devel-ubi8"
+appVersion: "main-latest"
 icon: https://assets.nvidiagrid.net/ngc/logos/GPUoperator.png
 sources:
 - https://github.com/NVIDIA/gpu-operator


### PR DESCRIPTION
The current appVersion is outdated. This change ensures a top-of-tree helm install will always fetch the latest gpu-operator image.