### PR TITLE
Integrate bot for cherry-picking / backporting commits to release branches

### DIFF
--- a/.github/scripts/extract-branches.js
+++ b/.github/scripts/extract-branches.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 NVIDIA CORPORATION
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 module.exports = async ({ github, context, core }) => {
   let branches = [];
 
@@ -12,8 +28,8 @@ module.exports = async ({ github, context, core }) => {
   // Check PR body
   if (context.payload.pull_request?.body) {
     const prBody = context.payload.pull_request.body;
-    // Enforce release-X.Y or release-X.Y.Z
-    const bodyMatches = prBody.matchAll(/\/cherry-pick\s+(release-\d+\.\d+(?:\.\d+)?)/g);
+    // Strict ASCII, anchored; allow X.Y or X.Y.Z
+    const bodyMatches = prBody.matchAll(/^\/cherry-pick\s+(release-\d+\.\d+(?:\.\d+)?)/gmi);
     branches.push(...Array.from(bodyMatches, m => m[1]));
   }
 
@@ -25,7 +41,7 @@ module.exports = async ({ github, context, core }) => {
   });
 
   for (const comment of comments.data) {
-    const commentMatches = comment.body.matchAll(/\/cherry-pick\s+(release-\d+\.\d+(?:\.\d+)?)/g);
+    const commentMatches = comment.body.matchAll(/^\/cherry-pick\s+(release-\d+\.\d+(?:\.\d+)?)/gmi);
     branches.push(...Array.from(commentMatches, m => m[1]));
   }
 

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract target branches from PR comments
         id: extract-branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.github/scripts/extract-branches.js');
@@ -56,12 +56,10 @@ jobs:
 
       - name: Backport to release branches
         id: backport
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           BRANCHES_JSON: ${{ steps.extract-branches.outputs.result }}
         with:
           script: |
             const run = require('./.github/scripts/backport.js');
             return await run({ github, context, core });
-
-


### PR DESCRIPTION
## Usage

Add a `/cherry-pick` comment to your PR specifying target release branches:

```
/cherry-pick release-25.3
/cherry-pick release-24.9
```

**When to add the comment:**
- Before merge: Bot acknowledges and automatically backports after PR is merged
- After merge: Bot immediately starts backporting

## What Happens

1. ✅ Bot creates a new PR for each target branch
2. 🏷️ Applies labels: `backport` + `auto-backport` (clean) or `needs-manual-resolution` (conflicts)
3. 💬 Posts a comment with link to each backport PR

## Example

Example of a PR where you specify the target release branch: 

<img width="1276" height="1528" alt="unknown" src="https://github.com/user-attachments/assets/a0a919c5-1cbd-49bb-8273-f7d45ae03836" />


Example of new PR opened:

<img width="605" height="430" alt="Screenshot 2025-10-08 at 1 46 32 PM" src="https://github.com/user-attachments/assets/725b59d9-0071-4ac8-ac29-706ea4c89e72" />


## Conflict Handling

If cherry-pick has conflicts:
- PR is created in **draft mode** with `needs-manual-resolution` label
- Follow instructions in the backport PR description to resolve conflicts

## Branch Naming

Release branches must follow the pattern: `release-X.Y`

Examples: `release-25.3`, `release-24.9.1`, `release-23.9`

## Example

```
Original PR #1234 merged to main
  ↓
/cherry-pick release-25.3 comment
  ↓
Bot creates PR #1235: [release-25.3] Original PR title
```

