### PR TITLE
Add permissions for nodefeatures in GFD's role object

### DIFF
--- a/assets/gpu-feature-discovery/0200_role.yaml
+++ b/assets/gpu-feature-discovery/0200_role.yaml
@@ -12,3 +12,13 @@ rules:
   - use
   resourceNames:
   - privileged
+- apiGroups:
+  - "nfd.k8s-sigs.io"
+  resources:
+  - "nodefeatures"
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update

--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -847,6 +847,16 @@ spec:
           - watch
           - update
           - delete
+        - apiGroups:
+          - "nfd.k8s-sigs.io"
+          resources:
+          - "nodefeatures"
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
       deployments:
       - name: gpu-operator
         spec:

--- a/deployments/gpu-operator/templates/role.yaml
+++ b/deployments/gpu-operator/templates/role.yaml
@@ -82,3 +82,13 @@ rules:
   - watch
   - update
   - delete
+- apiGroups:
+  - "nfd.k8s-sigs.io"
+  resources:
+  - "nodefeatures"
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update


### PR DESCRIPTION
These permissions are required when GFD is configured to use the Node Feature API instead of feature files.