### PR TITLE
check bundle/ and deployments/ dirs for CRD syncs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ validate-helm-values: cmds
 
 validate-generated-assets: manifests generate generate-clientset sync-crds
 	@echo "- Verifying that the generated code and manifests are in-sync..."
-	@git diff --exit-code -- api config
+	@git diff --exit-code -- api config bundle deployments
 
 COVERAGE_FILE := coverage.out
 unit-test: build

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -687,7 +687,7 @@ spec:
                       configMapName:
                         description: 'Deprecated: ConfigMapName has been deprecated
                           in favour of SecretName. Please use secrets to handle the
-                          LicensingConfig more securely'
+                          licensing server configuration more securely'
                         type: string
                       nlsEnabled:
                         description: NLSEnabled indicates if NVIDIA Licensing System

--- a/bundle/manifests/nvidia.com_nvidiadrivers.yaml
+++ b/bundle/manifests/nvidia.com_nvidiadrivers.yaml
@@ -235,8 +235,8 @@ spec:
                 properties:
                   name:
                     description: 'Deprecated: ConfigMapName has been deprecated in
-                      favour of SecretName. Please use secrets to handle the LicensingConfig
-                      more securely'
+                      favour of SecretName. Please use secrets to handle the licensing
+                      server configuration more securely'
                     type: string
                   nlsEnabled:
                     description: NLSEnabled indicates if NVIDIA Licensing System is

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -687,7 +687,7 @@ spec:
                       configMapName:
                         description: 'Deprecated: ConfigMapName has been deprecated
                           in favour of SecretName. Please use secrets to handle the
-                          LicensingConfig more securely'
+                          licensing server configuration more securely'
                         type: string
                       nlsEnabled:
                         description: NLSEnabled indicates if NVIDIA Licensing System

--- a/deployments/gpu-operator/crds/nvidia.com_nvidiadrivers.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_nvidiadrivers.yaml
@@ -235,8 +235,8 @@ spec:
                 properties:
                   name:
                     description: 'Deprecated: ConfigMapName has been deprecated in
-                      favour of SecretName. Please use secrets to handle the LicensingConfig
-                      more securely'
+                      favour of SecretName. Please use secrets to handle the licensing
+                      server configuration more securely'
                     type: string
                   nlsEnabled:
                     description: NLSEnabled indicates if NVIDIA Licensing System is


### PR DESCRIPTION
This PR fixes the out-of-sync CRD manifests in the helm and OLM bundle directories. It turns out that the `make check` job wasn't checking uncommitted diffs in the directories mentioned earlier, so the `main` branch had stale CRD manifests for a while.

h/t @karthikvetrivel for calling this out!