### PR TITLE
Add GDRCopy validation to validator daemonset

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -2062,6 +2062,15 @@ func (gds *GPUDirectStorageSpec) IsEnabled() bool {
 	return *gds.Enabled
 }
 
+// IsGDRCopyEnabled returns true if GDRCopy is enabled through gpu-operator
+func (c *ClusterPolicySpec) IsGDRCopyEnabled() bool {
+	if c.GDRCopy == nil {
+		// GDRCopy is disabled by default
+		return false
+	}
+	return c.GDRCopy.IsEnabled()
+}
+
 // IsEnabled returns true if GDRCopy is enabled through gpu-operator
 func (gdrcopy *GDRCopySpec) IsEnabled() bool {
 	if gdrcopy.Enabled == nil {

--- a/assets/state-operator-validation/0500_daemonset.yaml
+++ b/assets/state-operator-validation/0500_daemonset.yaml
@@ -77,6 +77,27 @@ spec:
             - name: run-nvidia-validations
               mountPath: /run/nvidia/validations
               mountPropagation: Bidirectional
+        - name: gdrcopy-validation
+          image: "FILLED BY THE OPERATOR"
+          command: [ 'sh', '-c' ]
+          args: [ "nvidia-validator" ]
+          env:
+            - name: WITH_WAIT
+              value: "true"
+            - name: COMPONENT
+              value: gdrcopy
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+            seLinuxOptions:
+              level: "s0"
+          volumeMounts:
+            - name: run-nvidia-validations
+              mountPath: /run/nvidia/validations
+              mountPropagation: Bidirectional
         - name: toolkit-validation
           image: "FILLED BY THE OPERATOR"
           command: ['sh', '-c']

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2173,6 +2173,7 @@ func TransformValidator(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, 
 	components := []string{
 		"driver",
 		"nvidia-fs",
+		"gdrcopy",
 		"toolkit",
 		"cuda",
 		"plugin",
@@ -2332,6 +2333,12 @@ func TransformValidatorComponent(config *gpuv1.ClusterPolicySpec, podSpec *corev
 		case "nvidia-fs":
 			if config.GPUDirectStorage == nil || !config.GPUDirectStorage.IsEnabled() {
 				// remove  nvidia-fs init container from validator Daemonset if GDS is not enabled
+				podSpec.InitContainers = append(podSpec.InitContainers[:i], podSpec.InitContainers[i+1:]...)
+				return nil
+			}
+		case "gdrcopy":
+			if !config.IsGDRCopyEnabled() {
+				// remove gdrcopy init container from validator Daemonset if GDRCopy is not enabled
 				podSpec.InitContainers = append(podSpec.InitContainers[:i], podSpec.InitContainers[i+1:]...)
 				return nil
 			}


### PR DESCRIPTION
When GDRCopy is enabled, this ensures that the GDRCopy driver is loaded prior the the k8s-device-plugin from starting up.