### PR TITLE
Quote `migManager.config.default` to prevent null string render in Helm chart

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -593,7 +593,7 @@ spec:
     {{- if .Values.migManager.config }}
     config:
       name: {{ .Values.migManager.config.name }}
-      default: {{ .Values.migManager.config.default }}
+      default: {{ .Values.migManager.config.default | quote }}
     {{- end }}
     {{- if .Values.migManager.gpuClientsConfig }}
     gpuClientsConfig: {{ toYaml .Values.migManager.gpuClientsConfig | nindent 6 }}


### PR DESCRIPTION
Current behavior:

```yaml
apiVersion: nvidia.com/v1
kind: ClusterPolicy
metadata:
  name: cluster-policy
spec:
  migManager:
    config:
      default:           <- null value
```

Desired behavior:

```yaml
apiVersion: nvidia.com/v1
kind: ClusterPolicy
metadata:
  name: cluster-policy
spec:
  migManager:
    config:
      default: ""        <- empty string value
```

Closes https://github.com/NVIDIA/gpu-operator/issues/1784