### PR TITLE
update renovate rules to bump dcgm-exporter images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -80,6 +80,14 @@
     {
       "matchPaths": ["deployments/gpu-operator/values.yaml"],
       "matchPackageNames": [
+        "nvcr.io/nvidia/k8s/dcgm-exporter"
+      ],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-distroless$",
+      "separateMajorMinor": false
+    },
+    {
+      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": [
        "nvcr.io/nvidia/cuda"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-base-ubi9$",


### PR DESCRIPTION
Renovate is updating the dcgm-exporter images back to ubuntu tag from distroless

https://github.com/NVIDIA/gpu-operator/pull/1774

This PR should ensure that the distroless variants continue to be used through image version bumps