### PR TITLE
Add update verb for nodes in vgpu & vfio manager clusterroles

### DIFF
--- a/assets/state-vfio-manager/0210_clusterrole.yaml
+++ b/assets/state-vfio-manager/0210_clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/assets/state-vgpu-manager/0210_clusterrole.yaml
+++ b/assets/state-vgpu-manager/0210_clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
This is required by the k8s-driver-manager init container which applies labels to nodes. Without this change, the init container is failing with the below error:
```
time=2025-10-15T17:01:19Z level=fatal msg=failed to evict GPU operator components: failed to update labels of node cnt-server-2: nodes "cnt-server-2" is forbidden: User "system:serviceaccount:gpu-operator:nvidia-vgpu-manager" cannot update resource "nodes" in API group "" at the cluster scope
```