### PR TITLE
Bump terminationGracePeriodSeconds to 120 for vGPU Manager daemonset

### DIFF
--- a/assets/state-vgpu-manager/0500_daemonset.yaml
+++ b/assets/state-vgpu-manager/0500_daemonset.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: nvidia-vgpu-manager-daemonset
     spec:
+      terminationGracePeriodSeconds: 120
       nodeSelector:
         nvidia.com/gpu.deploy.vgpu-manager: "true"
       tolerations:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -330,6 +330,7 @@ spec:
         nvidia.com/gpu.deploy.vgpu-manager: "true"
       priorityClassName: system-node-critical
       serviceAccountName: nvidia-vgpu-manager-openshift
+      terminationGracePeriodSeconds: 120
       tolerations:
       - effect: NoSchedule
         key: nvidia.com/gpu

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -238,6 +238,7 @@ spec:
         nvidia.com/gpu.deploy.vgpu-manager: "true"
       priorityClassName: system-node-critical
       serviceAccountName: nvidia-vgpu-manager-ubuntu22.04
+      terminationGracePeriodSeconds: 120
       tolerations:
       - effect: NoSchedule
         key: nvidia.com/gpu

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -59,6 +59,9 @@ spec:
         {{- .Driver.Spec.Labels | yaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if eq .Driver.Spec.DriverType "vgpu-host-manager" }}
+      terminationGracePeriodSeconds: 120
+      {{- end }}
       nodeSelector:
         {{- if eq .Driver.Spec.DriverType "vgpu-host-manager" }}
         nvidia.com/gpu.deploy.vgpu-manager: "true"


### PR DESCRIPTION
This ensures the vGPU Manager has enough time to finish its cleanup logic when the pod is terminated. This fixes an issue observed on a HGX node (with 8 GPUs) where the vGPU Manager was killed before it finished disabling VFs on all 8 GPUs.