### PR TITLE
fix: allow workflow to run with no branches identified + support PR updates

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -15,8 +15,6 @@
 name: Cherry-Pick
 
 on:
-  pull_request_target:
-    types: [closed]
   issue_comment:
     types: [created]
 
@@ -29,10 +27,9 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
-    # Run on merged PRs OR on /cherry-pick comments
+    # Run on /cherry-pick comments on PRs
     if: |
-      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/cherry-pick'))
+      github.event.issue.pull_request && startsWith(github.event.comment.body, '/cherry-pick')
     
     steps:
       - name: Checkout repository
@@ -50,12 +47,14 @@ jobs:
             return await run({ github, context, core });
 
       - name: Configure git
+        if: steps.extract-branches.outputs.result != '[]'
         run: |
           git config user.name "nvidia-backport-bot"
           git config user.email "noreply@nvidia.com"
 
       - name: Backport to release branches
         id: backport
+        if: steps.extract-branches.outputs.result != '[]'
         uses: actions/github-script@v8
         env:
           BRANCHES_JSON: ${{ steps.extract-branches.outputs.result }}


### PR DESCRIPTION
The cherrypick GitHub Action was running unconditionally on every PR merge. I initially thought this was fine but it caused unnecessary workflow runs and also led to failures. Failures are the bigger issue of the two. 

# Allow Cherry-Pick Bot to Backport PRs From Just Comments

Now, we can create backports at any point in the review process by using the `/cherry-pick` comment. This prevents running the GHA workflow on every merge and instead only when a user comments `/cherry-pick`

## Changes

- Remove `pull_request_target` trigger, use only `/cherry-pick` comments
- Remove merge validation to support backporting open PRs
- Add merge status warnings in backport PR descriptions
- Skip gracefully instead of failing when no branches specified

## Use Case

Run `/cherry-pick release-v1.0` on an open PR to create a backport early. The bot warns if the source PR isn't merged yet.