### PR TITLE
fix: add concurrency group for ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,10 @@ on:
       - main
       - release-*
 
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ### Configuration checks ###
   helm-lint:


### PR DESCRIPTION
Adding concurrency group helps in preventing multiple concurrent workflow runs for the same PR. When a new commit is added to the PR, old workflow runs still running for the PR should get cancelled as they are no longer relevant and it should start again. This PR adds concurrency group with `cancel-in-progress` set which makes sure stale workflow runs gets cancelled and we don't waste GHA cycles for runs/steps which don't matter as the code has been updated.