### PR TITLE
Add hybrid comment and label-based cherry-pick workflow

### DIFF
--- a/.github/scripts/add-labels-from-comment.js
+++ b/.github/scripts/add-labels-from-comment.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2025 NVIDIA CORPORATION
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = async ({ github, context, core }) => {
+  const commentBody = context.payload.comment.body;
+  const prNumber = context.payload.issue.number;
+
+  core.info(`Processing comment: ${commentBody}`);
+
+  // Parse comment for /cherry-pick branches
+  const cherryPickPattern = /^\/cherry-pick\s+(.+)$/m;
+  const match = commentBody.match(cherryPickPattern);
+
+  if (!match) {
+    core.warning('Comment does not match /cherry-pick pattern');
+    return { success: false, message: 'Invalid format' };
+  }
+
+  // Extract all release branches (space-separated)
+  const branchesText = match[1].trim();
+  const branchPattern = /release-\d+\.\d+(?:\.\d+)?/g;
+  const branches = branchesText.match(branchPattern) || [];
+
+  if (branches.length === 0) {
+    core.warning('No valid release branches found in comment');
+    await github.rest.reactions.createForIssueComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: context.payload.comment.id,
+      content: 'confused'
+    });
+    return { success: false, message: 'No valid branches found' };
+  }
+
+  core.info(`Found branches: ${branches.join(', ')}`);
+
+  // Add labels to PR
+  const labels = branches.map(branch => `cherry-pick/${branch}`);
+  
+  try {
+    await github.rest.issues.addLabels({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      labels: labels
+    });
+    core.info(`Added labels: ${labels.join(', ')}`);
+  } catch (error) {
+    core.error(`Failed to add labels: ${error.message}`);
+    await github.rest.reactions.createForIssueComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: context.payload.comment.id,
+      content: '-1'
+    });
+    return { success: false, message: error.message };
+  }
+
+  // React with checkmark emoji
+  await github.rest.reactions.createForIssueComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    comment_id: context.payload.comment.id,
+    content: '+1'
+  });
+
+  // Check if PR is already merged
+  const { data: pullRequest } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber
+  });
+
+  if (pullRequest.merged) {
+    core.info('PR is already merged - triggering backport immediately');
+    
+    // Set branches in environment and trigger backport
+    process.env.BRANCHES_JSON = JSON.stringify(branches);
+    
+    // Run backport script
+    const backportScript = require('./backport.js');
+    const results = await backportScript({ github, context, core });
+    
+    return { 
+      success: true, 
+      message: `Labels added and backport triggered for: ${branches.join(', ')}`,
+      backportResults: results
+    };
+  } else {
+    core.info('PR not yet merged - labels added, backport will trigger on merge');
+    return { 
+      success: true, 
+      message: `Labels added for: ${branches.join(', ')}. Backport will trigger on merge.`
+    };
+  }
+};
+

--- a/.github/scripts/backport.js
+++ b/.github/scripts/backport.js
@@ -29,7 +29,6 @@ const { data: pullRequest } = await github.rest.pulls.get({
 
 const prTitle = pullRequest.title;
 const prAuthor = pullRequest.user.login;
-const isMerged = pullRequest.merged;
 
 // Get all commits from the PR
 const { data: commits } = await github.rest.pulls.listCommits({
@@ -115,18 +114,13 @@ for (const targetBranch of branches) {
     // Create pull request
     const commitList = commits.map(c => `- \`${c.sha.substring(0, 7)}\` ${c.commit.message.split('\n')[0]}`).join('\n');
     
-    // Build PR body based on conflict status and merge status
+    // Build PR body based on conflict status
     let prBody = `🤖 **Automated backport of #${prNumber} to \`${targetBranch}\`**\n\n`;
-    
-    // Add merge status indicator
-    if (!isMerged) {
-      prBody += `⚠️ **Note:** The source PR #${prNumber} is not yet merged. This backport was created from the current state of the PR and may need updates if more commits are added before merge.\n\n`;
-    }
     
     if (hasConflicts) {
       prBody += `⚠️ **This PR has merge conflicts that need manual resolution.**
 
-Original PR: #${prNumber} ${isMerged ? '(merged)' : '(not yet merged)'}
+Original PR: #${prNumber}
 Original Author: @${prAuthor}
 
 **Cherry-picked commits (${commits.length}):**
@@ -154,7 +148,7 @@ git push --force-with-lease origin ${backportBranch}
     } else {
       prBody += `✅ Cherry-pick completed successfully with no conflicts.
 
-Original PR: #${prNumber} ${isMerged ? '(merged)' : '(not yet merged)'}
+Original PR: #${prNumber}
 Original Author: @${prAuthor}
 
 **Cherry-picked commits (${commits.length}):**

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -17,6 +17,8 @@ name: Cherry-Pick
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -24,12 +26,14 @@ permissions:
   issues: write
 
 jobs:
-  backport:
-    name: Backport PR
+  add-labels:
+    name: Add Cherry-Pick Labels from Comment
     runs-on: ubuntu-latest
     # Run on /cherry-pick comments on PRs
     if: |
-      github.event.issue.pull_request && startsWith(github.event.comment.body, '/cherry-pick')
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request && 
+      startsWith(github.event.comment.body, '/cherry-pick')
     
     steps:
       - name: Checkout repository
@@ -38,7 +42,35 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract target branches from PR comments
+      - name: Configure git
+        run: |
+          git config user.name "nvidia-backport-bot"
+          git config user.email "noreply@nvidia.com"
+
+      - name: Add labels and handle backport
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = require('./.github/scripts/add-labels-from-comment.js');
+            return await run({ github, context, core });
+
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    # Run when PR is merged and has cherry-pick labels
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'cherry-pick/')
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract target branches from PR labels
         id: extract-branches
         uses: actions/github-script@v8
         with:


### PR DESCRIPTION
## Summary

Improves cherry-pick/backport system that supports both comment-based and label-based workflows, with automatic handling of pre-merge and post-merge scenarios.

## Changes

### New Functionality
- **Comment-based label addition**: Users can post `/cherry-pick release-X.Y release-Z.W` to automatically add `cherry-pick/*` labels
- **Automatic feedback**: Bot reacts with 👍 on success, 😕 for invalid format, 👎 for errors
- **Trigger mechanism**: 
  - Pre-merge: Labels added, backport triggers on merge
  - Post-merge: Labels added and backport triggers immediately
- Labels can still be added via GitHub UI


Example usage here: https://github.com/karthikvetrivel/gpu-operator/pull/35


1. Developer posts: `/cherry-pick release-23.1 release-24.0`
2. Bot adds labels and reacts with 👍
3. PR gets reviewed and merged
4. Bot automatically creates backport PRs to both branches
5. Backport PRs link back to original PR


By adding labels, the workflow doesn't run on every PR merge. Moreover, this **allows backporting on PRs that are already closed**, which is not possible with other off-the-shelf cherry-pick worflows.