### PR TITLE
Configure dependabot for tests/e2e Go module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,21 @@ updates:
 
   - package-ecosystem: "gomod"
     target-branch: main
+    directory: "/tests/e2e"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      k8sio:
+        patterns:
+          - k8s.io/*
+        exclude-patterns:
+          - k8s.io/klog/*
+
+  - package-ecosystem: "gomod"
+    target-branch: main
     directory: "/tools"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependencies in `tests/e2e` module also need to be updated regularly.