### PR TITLE
[NFD] point to the registry.k8s.io OCI registry

### DIFF
--- a/deployments/gpu-operator/Chart.lock
+++ b/deployments/gpu-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: node-feature-discovery
-  repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+  repository: oci://registry.k8s.io/nfd/charts
   version: 0.18.2
-digest: sha256:38080b652a47ca788bba2ee5bf2fb34311a290645e80b942da12ea22d61fafb2
-generated: "2025-10-21T11:59:40.12235-07:00"
+digest: sha256:bdac9b82fd18d5a427bf182287702777dccaadf6c539974be82199f2d8958344
+generated: "2025-10-23T23:35:36.647835-07:00"

--- a/deployments/gpu-operator/Chart.yaml
+++ b/deployments/gpu-operator/Chart.yaml
@@ -19,6 +19,6 @@ keywords:
 
 dependencies:
   - name: node-feature-discovery
-    version: v0.18.2
-    repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    version: 0.18.2
+    repository: oci://registry.k8s.io/nfd/charts
     condition: nfd.enabled


### PR DESCRIPTION
Use the Official K8s OCI registry to pull the NFD helm charts as `https://kubernetes-sigs.github.io/node-feature-discovery/charts` has been marked as legacy.

Source: https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.18.0