### PR TITLE
[refactor] Remove duplicated VGPU constants from controllers and use internal/consts package

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -77,18 +77,6 @@ const (
 	TrustedCABundleMountDir = "/etc/pki/ca-trust/extracted/pem"
 	// TrustedCACertificate indicates injected CA certificate name
 	TrustedCACertificate = "tls-ca-bundle.pem"
-	// VGPULicensingConfigMountPath indicates target mount path for vGPU licensing configuration file
-	VGPULicensingConfigMountPath = "/drivers/gridd.conf"
-	// VGPULicensingFileName is the vGPU licensing configuration filename
-	VGPULicensingFileName = "gridd.conf"
-	// NLSClientTokenMountPath inidicates the target mount path for NLS client config token file (.tok)
-	NLSClientTokenMountPath = "/drivers/ClientConfigToken/client_configuration_token.tok"
-	// NLSClientTokenFileName is the NLS client config token filename
-	NLSClientTokenFileName = "client_configuration_token.tok"
-	// VGPUTopologyConfigMountPath indicates target mount path for vGPU topology daemon configuration file
-	VGPUTopologyConfigMountPath = "/etc/nvidia/nvidia-topologyd.conf"
-	// VGPUTopologyConfigFileName is the vGPU topology daemon configuration filename
-	VGPUTopologyConfigFileName = "nvidia-topologyd.conf"
 	// DefaultRuntimeClass represents "nvidia" RuntimeClass
 	DefaultRuntimeClass = "nvidia"
 	// DriverInstallPathVolName represents volume name for driver install path provided to toolkit
@@ -3331,23 +3319,23 @@ func applyLicensingConfig(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec
 	podSpec := &obj.Spec.Template.Spec
 
 	// add new volume mount
-	licensingConfigVolMount := corev1.VolumeMount{Name: "licensing-config", ReadOnly: true, MountPath: VGPULicensingConfigMountPath, SubPath: VGPULicensingFileName}
+	licensingConfigVolMount := corev1.VolumeMount{Name: "licensing-config", ReadOnly: true, MountPath: consts.VGPULicensingConfigMountPath, SubPath: consts.VGPULicensingFileName}
 	driverContainer.VolumeMounts = append(driverContainer.VolumeMounts, licensingConfigVolMount)
 
 	// gridd.conf always mounted
 	licenseItemsToInclude := []corev1.KeyToPath{
 		{
-			Key:  VGPULicensingFileName,
-			Path: VGPULicensingFileName,
+			Key:  consts.VGPULicensingFileName,
+			Path: consts.VGPULicensingFileName,
 		},
 	}
 	// client config token only mounted when NLS is enabled
 	if config.Driver.LicensingConfig.IsNLSEnabled() {
 		licenseItemsToInclude = append(licenseItemsToInclude, corev1.KeyToPath{
-			Key:  NLSClientTokenFileName,
-			Path: NLSClientTokenFileName,
+			Key:  consts.NLSClientTokenFileName,
+			Path: consts.NLSClientTokenFileName,
 		})
-		nlsTokenVolMount := corev1.VolumeMount{Name: "licensing-config", ReadOnly: true, MountPath: NLSClientTokenMountPath, SubPath: NLSClientTokenFileName}
+		nlsTokenVolMount := corev1.VolumeMount{Name: "licensing-config", ReadOnly: true, MountPath: consts.NLSClientTokenMountPath, SubPath: consts.NLSClientTokenFileName}
 		driverContainer.VolumeMounts = append(driverContainer.VolumeMounts, nlsTokenVolMount)
 	}
 
@@ -3448,7 +3436,7 @@ func transformDriverContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 
 	// set virtual topology daemon configuration if specified for vGPU driver
 	if config.Driver.VirtualTopology != nil && config.Driver.VirtualTopology.Config != "" {
-		topologyConfigVolMount := corev1.VolumeMount{Name: "topology-config", ReadOnly: true, MountPath: VGPUTopologyConfigMountPath, SubPath: VGPUTopologyConfigFileName}
+		topologyConfigVolMount := corev1.VolumeMount{Name: "topology-config", ReadOnly: true, MountPath: consts.VGPUTopologyConfigMountPath, SubPath: consts.VGPUTopologyConfigFileName}
 		driverContainer.VolumeMounts = append(driverContainer.VolumeMounts, topologyConfigVolMount)
 
 		topologyConfigVolumeSource := corev1.VolumeSource{
@@ -3458,8 +3446,8 @@ func transformDriverContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 				},
 				Items: []corev1.KeyToPath{
 					{
-						Key:  VGPUTopologyConfigFileName,
-						Path: VGPUTopologyConfigFileName,
+						Key:  consts.VGPUTopologyConfigFileName,
+						Path: consts.VGPUTopologyConfigFileName,
 					},
 				},
 			},

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
+	"github.com/NVIDIA/gpu-operator/internal/consts"
 )
 
 var mockClientMap map[string]client.Client
@@ -2910,8 +2911,8 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 					{
 						Name:      "licensing-config",
 						ReadOnly:  true,
-						MountPath: VGPULicensingConfigMountPath,
-						SubPath:   VGPULicensingFileName,
+						MountPath: consts.VGPULicensingConfigMountPath,
+						SubPath:   consts.VGPULicensingFileName,
 					},
 				},
 			}).WithInitContainer(corev1.Container{
@@ -2925,8 +2926,8 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 						SecretName: "test-secret",
 						Items: []corev1.KeyToPath{
 							{
-								Key:  VGPULicensingFileName,
-								Path: VGPULicensingFileName,
+								Key:  consts.VGPULicensingFileName,
+								Path: consts.VGPULicensingFileName,
 							},
 						},
 					},
@@ -2964,8 +2965,8 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 					{
 						Name:      "licensing-config",
 						ReadOnly:  true,
-						MountPath: VGPULicensingConfigMountPath,
-						SubPath:   VGPULicensingFileName,
+						MountPath: consts.VGPULicensingConfigMountPath,
+						SubPath:   consts.VGPULicensingFileName,
 					},
 				},
 			}).WithInitContainer(corev1.Container{
@@ -2981,8 +2982,8 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 						},
 						Items: []corev1.KeyToPath{
 							{
-								Key:  VGPULicensingFileName,
-								Path: VGPULicensingFileName,
+								Key:  consts.VGPULicensingFileName,
+								Path: consts.VGPULicensingFileName,
 							},
 						},
 					},


### PR DESCRIPTION
This PR removes duplicated VGPU-related constants (VGPULicensingConfigMountPath, VGPULicensingFileName, NLSClientTokenMountPath, NLSClientTokenFileName, VGPUTopologyConfigMountPath, VGPUTopologyConfigFileName) from the controllers package. All references now use the constants from the internal/consts package, establishing a single source of truth.