### PR TITLE
[refactor] Replace custom pointer helpers with k8s.io/utils/ptr.To()

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
@@ -201,7 +202,7 @@ const (
 )
 
 // rootUID represents user 0
-var rootUID = utils.Int64Ptr(0)
+var rootUID = ptr.To(int64(0))
 
 // RepoConfigPathMap indicates standard OS specific paths for repository configuration files
 var RepoConfigPathMap = map[string]string{
@@ -222,12 +223,6 @@ var CertConfigPathMap = map[string]string{
 	"rhel":   "/etc/pki/ca-trust/extracted/pem",
 }
 
-func newHostPathType(pathType corev1.HostPathType) *corev1.HostPathType {
-	hostPathType := new(corev1.HostPathType)
-	*hostPathType = pathType
-	return hostPathType
-}
-
 // MountPathToVolumeSource maps a container mount path to a VolumeSource
 type MountPathToVolumeSource map[string]corev1.VolumeSource
 
@@ -240,19 +235,19 @@ var SubscriptionPathMap = map[string](MountPathToVolumeSource){
 		"/run/secrets/etc-pki-entitlement": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/pki/entitlement",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/run/secrets/redhat.repo": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/yum.repos.d/redhat.repo",
-				Type: newHostPathType(corev1.HostPathFile),
+				Type: ptr.To(corev1.HostPathFile),
 			},
 		},
 		"/run/secrets/rhsm": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/rhsm",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 	},
@@ -260,19 +255,19 @@ var SubscriptionPathMap = map[string](MountPathToVolumeSource){
 		"/run/secrets/etc-pki-entitlement": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/pki/entitlement",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/run/secrets/redhat.repo": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/yum.repos.d/redhat.repo",
-				Type: newHostPathType(corev1.HostPathFile),
+				Type: ptr.To(corev1.HostPathFile),
 			},
 		},
 		"/run/secrets/rhsm": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/rhsm",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 	},
@@ -280,13 +275,13 @@ var SubscriptionPathMap = map[string](MountPathToVolumeSource){
 		"/etc/zypp/credentials.d": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/zypp/credentials.d",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/etc/SUSEConnect": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/SUSEConnect",
-				Type: newHostPathType(corev1.HostPathFileOrCreate),
+				Type: ptr.To(corev1.HostPathFileOrCreate),
 			},
 		},
 	},
@@ -294,13 +289,13 @@ var SubscriptionPathMap = map[string](MountPathToVolumeSource){
 		"/etc/zypp/credentials.d": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/zypp/credentials.d",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/etc/SUSEConnect": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/SUSEConnect",
-				Type: newHostPathType(corev1.HostPathFileOrCreate),
+				Type: ptr.To(corev1.HostPathFileOrCreate),
 			},
 		},
 	},
@@ -1385,7 +1380,7 @@ func transformForRuntime(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec,
 		volMountConfig := corev1.VolumeMount{Name: volMountConfigName, MountPath: containerConfigDir}
 		container.VolumeMounts = append(container.VolumeMounts, volMountConfig)
 
-		configVol := corev1.Volume{Name: volMountConfigName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: sourceConfigDir, Type: newHostPathType(corev1.HostPathDirectoryOrCreate)}}}
+		configVol := corev1.Volume{Name: volMountConfigName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: sourceConfigDir, Type: ptr.To(corev1.HostPathDirectoryOrCreate)}}}
 		obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, configVol)
 	}
 
@@ -1407,7 +1402,7 @@ func transformForRuntime(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec,
 		volMountConfig := corev1.VolumeMount{Name: volMountConfigName, MountPath: containerConfigDir}
 		container.VolumeMounts = append(container.VolumeMounts, volMountConfig)
 
-		configVol := corev1.Volume{Name: volMountConfigName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: sourceConfigDir, Type: newHostPathType(corev1.HostPathDirectoryOrCreate)}}}
+		configVol := corev1.Volume{Name: volMountConfigName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: sourceConfigDir, Type: ptr.To(corev1.HostPathDirectoryOrCreate)}}}
 		obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, configVol)
 	}
 
@@ -1964,7 +1959,7 @@ func TransformKataManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec
 	artifactsVolMount := corev1.VolumeMount{Name: "kata-artifacts", MountPath: artifactsDir}
 	obj.Spec.Template.Spec.Containers[0].VolumeMounts = append(obj.Spec.Template.Spec.Containers[0].VolumeMounts, artifactsVolMount)
 
-	artifactsVol := corev1.Volume{Name: "kata-artifacts", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: artifactsDir, Type: newHostPathType(corev1.HostPathDirectoryOrCreate)}}}
+	artifactsVol := corev1.Volume{Name: "kata-artifacts", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: artifactsDir, Type: ptr.To(corev1.HostPathDirectoryOrCreate)}}}
 	obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, artifactsVol)
 
 	// Compute hash of kata manager config and add an annotation with the value.

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -377,8 +377,8 @@ func TestTransformForRuntime(t *testing.T) {
 			input: NewDaemonset().
 				WithContainer(corev1.Container{Name: "test-ctr"}),
 			expectedOutput: NewDaemonset().
-				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", filepath.Dir(DefaultContainerdSocketFile), nil).
 				WithContainer(corev1.Container{
 					Name: "test-ctr",
@@ -410,8 +410,8 @@ func TestTransformForRuntime(t *testing.T) {
 					},
 				}),
 			expectedOutput: NewDaemonset().
-				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", filepath.Dir(DefaultContainerdSocketFile), nil).
 				WithContainer(corev1.Container{
 					Name: "test-ctr",
@@ -444,8 +444,8 @@ func TestTransformForRuntime(t *testing.T) {
 					},
 				}),
 			expectedOutput: NewDaemonset().
-				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", filepath.Dir(DefaultContainerdSocketFile), nil).
 				WithContainer(corev1.Container{
 					Name: "test-ctr",
@@ -472,8 +472,8 @@ func TestTransformForRuntime(t *testing.T) {
 			runtime:     gpuv1.CRIO,
 			input:       NewDaemonset().WithContainer(corev1.Container{Name: "test-ctr"}),
 			expectedOutput: NewDaemonset().
-				WithHostPathVolume("crio-config", "/etc/crio", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("crio-drop-in-config", "/etc/crio/crio.conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("crio-config", "/etc/crio", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("crio-drop-in-config", "/etc/crio/crio.conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithContainer(corev1.Container{
 					Name: "test-ctr",
 					Env: []corev1.EnvVar{
@@ -496,7 +496,7 @@ func TestTransformForRuntime(t *testing.T) {
 			input: NewDaemonset().
 				WithContainer(corev1.Container{Name: "nvidia-kata-manager"}),
 			expectedOutput: NewDaemonset().
-				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", filepath.Dir(DefaultContainerdConfigFile), ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", filepath.Dir(DefaultContainerdSocketFile), nil).
 				WithContainer(corev1.Container{
 					Name: "nvidia-kata-manager",
@@ -519,7 +519,7 @@ func TestTransformForRuntime(t *testing.T) {
 			runtime:     gpuv1.Docker,
 			input:       NewDaemonset().WithContainer(corev1.Container{Name: "test-ctr"}),
 			expectedOutput: NewDaemonset().
-				WithHostPathVolume("docker-config", filepath.Dir(DefaultDockerConfigFile), newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("docker-config", filepath.Dir(DefaultDockerConfigFile), ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("docker-socket", filepath.Dir(DefaultDockerSocketFile), nil).
 				WithContainer(corev1.Container{
 					Name: "test-ctr",
@@ -840,8 +840,8 @@ func TestTransformToolkit(t *testing.T) {
 						{Name: "containerd-socket", MountPath: "/runtime/sock-dir/"},
 					},
 				}).
-				WithHostPathVolume("containerd-config", "/etc/containerd", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", "/etc/containerd", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", "/run/containerd", nil).
 				WithPullSecret("pull-secret"),
 		},
@@ -919,8 +919,8 @@ func TestTransformToolkit(t *testing.T) {
 						{Name: "containerd-socket", MountPath: "/runtime/sock-dir/"},
 					},
 				}).
-				WithHostPathVolume("containerd-config", "/var/lib/rancher/k3s/agent/etc/containerd", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", "/var/lib/rancher/k3s/agent/etc/containerd", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-drop-in-config", "/etc/containerd/conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", "/run/k3s/containerd", nil).
 				WithPullSecret("pull-secret"),
 		},
@@ -957,8 +957,8 @@ func TestTransformToolkit(t *testing.T) {
 						{Name: "crio-drop-in-config", MountPath: "/runtime/config-dir.d/"},
 					},
 				}).
-				WithHostPathVolume("crio-config", "/etc/crio", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("crio-drop-in-config", "/etc/crio/crio.conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)),
+				WithHostPathVolume("crio-config", "/etc/crio", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("crio-drop-in-config", "/etc/crio/crio.conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)),
 		},
 		{
 			description: "transform nvidia-container-toolkit-ctr container, cri-o runtime, cdi disabled",
@@ -993,8 +993,8 @@ func TestTransformToolkit(t *testing.T) {
 						{Name: "crio-drop-in-config", MountPath: "/runtime/config-dir.d/"},
 					},
 				}).
-				WithHostPathVolume("crio-config", "/etc/crio", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("crio-drop-in-config", "/etc/crio/crio.conf.d", newHostPathType(corev1.HostPathDirectoryOrCreate)),
+				WithHostPathVolume("crio-config", "/etc/crio", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("crio-drop-in-config", "/etc/crio/crio.conf.d", ptr.To(corev1.HostPathDirectoryOrCreate)),
 		},
 	}
 
@@ -1120,8 +1120,8 @@ func TestTransformMPSControlDaemon(t *testing.T) {
 			daemonset: NewDaemonset().
 				WithInitContainer(corev1.Container{Name: "mps-control-daemon-mounts"}).
 				WithContainer(corev1.Container{Name: "mps-control-daemon-ctr"}).
-				WithHostPathVolume("mps-root", "/run/nvidia/mps", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("mps-shm", "/run/nvidia/mps/shm", newHostPathType(corev1.HostPathDirectoryOrCreate)),
+				WithHostPathVolume("mps-root", "/run/nvidia/mps", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("mps-shm", "/run/nvidia/mps/shm", ptr.To(corev1.HostPathDirectoryOrCreate)),
 			clusterPolicySpec: &gpuv1.ClusterPolicySpec{
 				DevicePlugin: gpuv1.DevicePluginSpec{
 					Repository:       "nvcr.io",
@@ -1146,8 +1146,8 @@ func TestTransformMPSControlDaemon(t *testing.T) {
 						{Name: "NVIDIA_MIG_MONITOR_DEVICES", Value: "all"},
 					},
 				}).
-				WithHostPathVolume("mps-root", "/var/mps", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("mps-shm", "/var/mps/shm", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("mps-root", "/var/mps", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("mps-shm", "/var/mps/shm", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithPullSecret("secret").
 				WithRuntimeClassName("nvidia"),
 		},
@@ -1540,7 +1540,7 @@ func TestTransformKataManager(t *testing.T) {
 					{Name: "containerd-config", MountPath: "/runtime/config-dir/"},
 					{Name: "containerd-socket", MountPath: "/runtime/sock-dir/"},
 				},
-			}).WithPullSecret("pull-secret").WithPodAnnotations(map[string]string{"nvidia.com/kata-manager.last-applied-hash": "1929911998"}).WithHostPathVolume("kata-artifacts", "/var/lib/kata", newHostPathType(corev1.HostPathDirectoryOrCreate)).WithHostPathVolume("containerd-config", "/etc/containerd", newHostPathType(corev1.HostPathDirectoryOrCreate)).WithHostPathVolume("containerd-socket", "/run/containerd", nil),
+			}).WithPullSecret("pull-secret").WithPodAnnotations(map[string]string{"nvidia.com/kata-manager.last-applied-hash": "1929911998"}).WithHostPathVolume("kata-artifacts", "/var/lib/kata", ptr.To(corev1.HostPathDirectoryOrCreate)).WithHostPathVolume("containerd-config", "/etc/containerd", ptr.To(corev1.HostPathDirectoryOrCreate)).WithHostPathVolume("containerd-socket", "/run/containerd", nil),
 		},
 		{
 			description: "transform kata manager with custom container runtime socket",
@@ -1594,8 +1594,8 @@ func TestTransformKataManager(t *testing.T) {
 				},
 			}).WithPullSecret("pull-secret").
 				WithPodAnnotations(map[string]string{"nvidia.com/kata-manager.last-applied-hash": "1929911998"}).
-				WithHostPathVolume("kata-artifacts", "/var/lib/kata", newHostPathType(corev1.HostPathDirectoryOrCreate)).
-				WithHostPathVolume("containerd-config", "/var/lib/rancher/k3s/agent/etc/containerd", newHostPathType(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("kata-artifacts", "/var/lib/kata", ptr.To(corev1.HostPathDirectoryOrCreate)).
+				WithHostPathVolume("containerd-config", "/var/lib/rancher/k3s/agent/etc/containerd", ptr.To(corev1.HostPathDirectoryOrCreate)).
 				WithHostPathVolume("containerd-socket", "/run/k3s/containerd", nil),
 		},
 	}

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -33,10 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
 	"github.com/NVIDIA/gpu-operator/internal/render"
-	"github.com/NVIDIA/gpu-operator/internal/utils"
 )
 
 const (
@@ -105,7 +105,7 @@ func TestDriverRenderRDMA(t *testing.T) {
 	renderData.AdditionalConfigs = getSampleAdditionalConfigs()
 
 	renderData.GPUDirectRDMA = &nvidiav1alpha1.GPUDirectRDMASpec{
-		Enabled: utils.BoolPtr(true),
+		Enabled: ptr.To(true),
 	}
 
 	objs, err := stateDriver.renderer.RenderObjects(
@@ -138,8 +138,8 @@ func TestDriverRDMAHostMOFED(t *testing.T) {
 	renderData.AdditionalConfigs = getSampleAdditionalConfigs()
 
 	renderData.GPUDirectRDMA = &nvidiav1alpha1.GPUDirectRDMASpec{
-		Enabled:      utils.BoolPtr(true),
-		UseHostMOFED: utils.BoolPtr(true),
+		Enabled:      ptr.To(true),
+		UseHostMOFED: ptr.To(true),
 	}
 
 	objs, err := stateDriver.renderer.RenderObjects(
@@ -266,7 +266,7 @@ func TestDriverGDS(t *testing.T) {
 	renderData.GDS = &gdsDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1",
 		Spec: &nvidiav1alpha1.GPUDirectStorageSpec{
-			Enabled:          utils.BoolPtr(true),
+			Enabled:          ptr.To(true),
 			ImagePullSecrets: []string{"ngc-secrets"},
 		},
 	}
@@ -304,7 +304,7 @@ func TestDriverGDRCopy(t *testing.T) {
 	renderData.GDRCopy = &gdrcopyDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1",
 		Spec: &nvidiav1alpha1.GDRCopySpec{
-			Enabled:          utils.BoolPtr(true),
+			Enabled:          ptr.To(true),
 			ImagePullSecrets: []string{"ngc-secrets"},
 		},
 	}
@@ -361,7 +361,7 @@ func TestDriverGDRCopyOpenShift(t *testing.T) {
 	renderData.GDRCopy = &gdrcopyDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1-rhcos4.13",
 		Spec: &nvidiav1alpha1.GDRCopySpec{
-			Enabled:          utils.BoolPtr(true),
+			Enabled:          ptr.To(true),
 			ImagePullSecrets: []string{"ngc-secret"},
 		},
 	}
@@ -469,7 +469,7 @@ func TestDriverPrecompiled(t *testing.T) {
 	require.True(t, ok)
 
 	renderData := getMinimalDriverRenderData()
-	renderData.Driver.Spec.UsePrecompiled = utils.BoolPtr(true)
+	renderData.Driver.Spec.UsePrecompiled = ptr.To(true)
 	renderData.Driver.Name = "nvidia-gpu-driver-ubuntu22.04"
 	renderData.Driver.AppName = "nvidia-gpu-driver-ubuntu22.04-646cdfdb96"
 	renderData.Driver.ImagePath = "nvcr.io/nvidia/driver:535-5.4.0-150-generic-ubuntu22.04"
@@ -703,7 +703,7 @@ func getSampleAdditionalConfigs() *additionalConfigs {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/opt/config/test-host-path",
-						Type: newHostPathType(corev1.HostPathDirectoryOrCreate),
+						Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 					},
 				},
 			},
@@ -712,7 +712,7 @@ func getSampleAdditionalConfigs() *additionalConfigs {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/opt/config/test-host-path-ro",
-						Type: newHostPathType(corev1.HostPathDirectoryOrCreate),
+						Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 					},
 				},
 			},
@@ -799,7 +799,7 @@ func TestDriverVGPULicensingSecret(t *testing.T) {
 
 	renderData.Driver.Spec.LicensingConfig = &nvidiav1alpha1.DriverLicensingConfigSpec{
 		SecretName: "licensing-config-secret",
-		NLSEnabled: utils.BoolPtr(true),
+		NLSEnabled: ptr.To(true),
 	}
 
 	renderData.AdditionalConfigs = &additionalConfigs{
@@ -868,13 +868,13 @@ func TestDriverSecretEnv(t *testing.T) {
 	renderData.GDS = &gdsDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1",
 		Spec: &nvidiav1alpha1.GPUDirectStorageSpec{
-			Enabled: utils.BoolPtr(true),
+			Enabled: ptr.To(true),
 		},
 	}
 	renderData.GDRCopy = &gdrcopyDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1",
 		Spec: &nvidiav1alpha1.GDRCopySpec{
-			Enabled: utils.BoolPtr(true),
+			Enabled: ptr.To(true),
 		},
 	}
 

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
@@ -60,19 +61,19 @@ var SubscriptionPathMap = map[string]MountPathToVolumeSource{
 		"/run/secrets/etc-pki-entitlement": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/pki/entitlement",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/run/secrets/redhat.repo": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/yum.repos.d/redhat.repo",
-				Type: newHostPathType(corev1.HostPathFile),
+				Type: ptr.To(corev1.HostPathFile),
 			},
 		},
 		"/run/secrets/rhsm": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/rhsm",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 	},
@@ -80,19 +81,19 @@ var SubscriptionPathMap = map[string]MountPathToVolumeSource{
 		"/run/secrets/etc-pki-entitlement": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/pki/entitlement",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/run/secrets/redhat.repo": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/yum.repos.d/redhat.repo",
-				Type: newHostPathType(corev1.HostPathFile),
+				Type: ptr.To(corev1.HostPathFile),
 			},
 		},
 		"/run/secrets/rhsm": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/rhsm",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 	},
@@ -100,13 +101,13 @@ var SubscriptionPathMap = map[string]MountPathToVolumeSource{
 		"/etc/zypp/credentials.d": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/zypp/credentials.d",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/etc/SUSEConnect": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/SUSEConnect",
-				Type: newHostPathType(corev1.HostPathFileOrCreate),
+				Type: ptr.To(corev1.HostPathFileOrCreate),
 			},
 		},
 	},
@@ -114,23 +115,16 @@ var SubscriptionPathMap = map[string]MountPathToVolumeSource{
 		"/etc/zypp/credentials.d": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/zypp/credentials.d",
-				Type: newHostPathType(corev1.HostPathDirectory),
+				Type: ptr.To(corev1.HostPathDirectory),
 			},
 		},
 		"/etc/SUSEConnect": corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/SUSEConnect",
-				Type: newHostPathType(corev1.HostPathFileOrCreate),
+				Type: ptr.To(corev1.HostPathFileOrCreate),
 			},
 		},
 	},
-}
-
-// TODO: make this a public utils method
-func newHostPathType(pathType corev1.HostPathType) *corev1.HostPathType {
-	hostPathType := new(corev1.HostPathType)
-	*hostPathType = pathType
-	return hostPathType
 }
 
 func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alpha1.NVIDIADriver, info clusterinfo.Interface, pool nodePool) (*additionalConfigs, error) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -57,16 +57,6 @@ func GetFilesWithSuffix(baseDir string, suffixes ...string) ([]string, error) {
 	return files, nil
 }
 
-// BoolPtr returns a pointer to the bool value passed in.
-func BoolPtr(v bool) *bool {
-	return &v
-}
-
-// Int64Ptr returns a pointer to the int64 passed in.
-func Int64Ptr(v int64) *int64 {
-	return &v
-}
-
 // GetObjectHash invokes Sum32 Hash function to return hash value of an unstructured Object
 func GetObjectHash(obj interface{}) string {
 	hasher := fnv.New32a()


### PR DESCRIPTION
Replace custom utility functions (`BoolPtr()`, `Int64Ptr()`, `newHostPathType()`) with the standard `ptr.To()` from `k8s.io/utils/ptr` package.