### PR TITLE
[improvement] : fix minor issues with templates

### DIFF
--- a/deployments/gpu-operator/templates/cleanup_crd.yaml
+++ b/deployments/gpu-operator/templates/cleanup_crd.yaml
@@ -41,7 +41,7 @@ spec:
             - --filepath=/opt/gpu-operator/nvidia.com_clusterpolicies.yaml
             - --filepath=/opt/gpu-operator/nvidia.com_nvidiadrivers.yaml
         {{- if .Values.nfd.enabled }}
-            - --filepath=/opt/gpu-operator/nfd-api-crds.yaml;
+            - --filepath=/opt/gpu-operator/nfd-api-crds.yaml
         {{- end }}
       restartPolicy: OnFailure
 {{- end }}

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -141,7 +141,6 @@ spec:
       env: []
       {{- end }}
     {{- end }}
-
   mig:
     {{- if .Values.mig.strategy }}
     strategy: {{ .Values.mig.strategy }}
@@ -150,7 +149,9 @@ spec:
     enabled: {{ .Values.psa.enabled }}
   cdi:
     enabled: {{ .Values.cdi.enabled }}
+    {{- if .Values.cdi.default }}
     default: {{ .Values.cdi.default }}
+    {{- end }}
   driver:
     enabled: {{ .Values.driver.enabled }}
     useNvidiaDriverCRD: {{ .Values.driver.nvidiaDriverCRD.enabled }}
@@ -411,7 +412,7 @@ spec:
     resources: {{ toYaml .Values.ccManager.resources | nindent 6 }}
     {{- end }}
     {{- if .Values.ccManager.env }}
-    env: {{ toYaml .Values.vfioManager.env | nindent 6 }}
+    env: {{ toYaml .Values.ccManager.env | nindent 6 }}
     {{- end }}
     {{- if .Values.ccManager.args }}
     args: {{ toYaml .Values.ccManager.args | nindent 6 }}


### PR DESCRIPTION
This PR fixes:
1. Remove extra `;` at end of filepath as it can cause issue with filepath
2. `default` under cdi is deprecated and usually not specified. We don't need to set it if its not there. Currently, on rendered yaml, it is rendered as empty which then gets set as `false` due to default value. We can avoid rendering it when its not set.
3. Incorrect env values were getting set for ccManager. Updated the template to use right values.