### PR TITLE
[bugfix] : don't render nvidiadriver CR if driver is disabled

### DIFF
--- a/deployments/gpu-operator/templates/nvidiadriver.yaml
+++ b/deployments/gpu-operator/templates/nvidiadriver.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.driver.enabled }}
 {{- if and .Values.driver.nvidiaDriverCRD.enabled .Values.driver.nvidiaDriverCRD.deployDefaultCR }}
 apiVersion: nvidia.com/v1alpha1
 kind: NVIDIADriver
@@ -123,4 +124,5 @@ spec:
     args: {{ toYaml .Values.gdrcopy.args | nindent 6 }}
     {{- end  }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
fixes https://github.com/NVIDIA/gpu-operator/issues/1795

If driver is disabled, we should not render default config for nvidiaDriver. This PR adds that check.