### PR TITLE
use PATCH to update node labels instead of UPDATE

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -492,6 +492,8 @@ func (n *ClusterPolicyController) labelGPUNodes() (bool, int, error) {
 	gpuNodesTotal := 0
 	for _, node := range list.Items {
 		node := node
+
+		nodeOriginal := node.DeepCopy()
 		// get node labels
 		labels := node.GetLabels()
 		if !clusterHasNFDLabels {
@@ -566,7 +568,7 @@ func (n *ClusterPolicyController) labelGPUNodes() (bool, int, error) {
 
 		// update node with the latest labels
 		if updateLabels {
-			err = n.client.Update(ctx, &node)
+			err = n.client.Patch(ctx, &node, client.MergeFrom(nodeOriginal))
 			if err != nil {
 				return false, 0, fmt.Errorf("unable to label node %s for the GPU Operator deployment, err %s",
 					node.Name, err.Error())


### PR DESCRIPTION
This fixes an issue seen in the ClusterPolicy reconciler when it attempts to update node labels on a cluster. 

```
Status:
  Conditions:
    Last Transition Time:  2025-08-08T01:45:52Z
    Message:               
    Reason:                Error
    Status:                False
    Type:                  Ready
    Last Transition Time:  2025-08-08T01:45:52Z
    Message:               failed to initialize ClusterPolicy controller: unable to label node 4u2g-0506 for the GPU Operator deployment, err Operation cannot be fulfilled on nodes "4u2g-0506": the object has been modified; please apply your changes to the latest version and try again
    Reason:                ReconcileFailed
    Status:                True
 ```
 
 Moving from UPDATE to PATCH should fix this issue, as PATCH is the method used under the hood with the `kubectl label node...` command and PATCH is better at handling concurrent updates in general
 