### PR TITLE
use the recommended git config for  GitHub Actions Bot

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "nvidia-backport-bot"
-          git config user.email "noreply@nvidia.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Add labels and handle backport
         uses: actions/github-script@v8


### PR DESCRIPTION
As per this [post](https://github.com/orgs/community/discussions/119597), this is the recommended `git config` for automated commits performed by a GitHub actions bot.

With the current git config, we have observed commit authors that we don't recognise in the cherry-picked commits. 
Examples:

- https://github.com/NVIDIA/gpu-operator/pull/1874/commits/bf76559b1a8d302458f983130c5b5df9f8f4f194
- https://github.com/NVIDIA/gpu-operator/pull/1872/commits/18a8b6666b8cee65148e602ca90bd05ab0b7317a

<img width="1678" height="505" alt="Screenshot 2025-11-07 at 6 01 44 PM" src="https://github.com/user-attachments/assets/695a99c6-0d08-42ef-a897-d2cd924895a8" />
