### PR TITLE
[nvidia-validator] fix typo in --driver-install-dir-ctr-path flag

### DIFF
--- a/cmd/nvidia-validator/main.go
+++ b/cmd/nvidia-validator/main.go
@@ -355,7 +355,7 @@ func main() {
 			Value:       defaultDriverInstallDirCtrPath,
 			Usage:       "the path where the NVIDIA driver install dir is mounted in the container",
 			Destination: &driverInstallDirCtrPathFlag,
-			Sources:     cli.EnvVars("DISABLE_DEV_CHAR_SYMLINK_CREATION"),
+			Sources:     cli.EnvVars("DRIVER_INSTALL_DIR_CTR_PATH"),
 		},
 	}
 


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/NVIDIA/gpu-operator/commit/be4311f4747cc10fb1c5e2bb88bf552f8f29b98e