### PR TITLE
Tag bundle image with current commit sha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -438,11 +438,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set environment variables
+        id: vars
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+      - name: Update bundle CSV
+        run: |
+          sed -i '' -e 's|ghcr.io/nvidia/gpu-operator:[^ "]*|ghcr.io/nvidia/gpu-operator:${{ env.COMMIT_SHORT_SHA }}|g' bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+          echo "Bundle CSV updated successfully"
       - name: Build bundle-image
         env:
-          BUNDLE_IMAGE: "ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:${{ github.ref_name }}-latest"
+          IMAGE_NAME: "ghcr.io/nvidia/gpu-operator/gpu-operator-bundle"
           VERSION: ""
           DEFAULT_CHANNEL: "stable"
           CHANNELS: "stable"
         run: |
-          make push-bundle-image
+          make push-bundle-image BUNDLE_IMAGE=${IMAGE_NAME}:${{ github.ref_name }}-latest
+          make push-bundle-image BUNDLE_IMAGE=${IMAGE_NAME}:${{ env.COMMIT_SHORT_SHA }}


### PR DESCRIPTION
Currently, the GPU Operator image configured in the bundle is ghcr.io/nvidia/gpu-operator:main-latest (see [here](https://github.com/NVIDIA/gpu-operator/blob/833f83b71dece80b00922e9d1df102df1fee4241/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml#L882)). This can be problematic for two reasons. First, it is difficult to deduce which commit SHA the operator image / OLM bundle was built from. Therefore, it is difficult to infer which commit SHA introduced a test failure. Second, the gpu-operator deployment runs with `imagePullPolicy=IfNotPresent` by default. This means if the gpu-operator image (with the main-latest) tag is already cached on the node, the latest image may not be pulled / tested. To address these shortcomings, we should generate an OLM bundle that is using SHA-tagged images of gpu-operator.
We should update the GitHub Actions job that builds + pushes an OLM bundle image as follows:

1) Before building the bundle image, it should update all gpu-operator image tags in the CSV file to refer to the commit SHA. E.g. ghcr.io/nvidia/gpu-operator:commit-short-sha
2) When pushing the OLM bundle image, we should push two tags – one tag will be main-latest and the other will be commit-short-sha