### PR TITLE
Remove kubernetes.io/master label warning

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -82,10 +82,6 @@ operator:
     version: 13.0.1-base-ubi9
     imagePullPolicy: IfNotPresent
   tolerations:
-  - key: "node-role.kubernetes.io/master"
-    operator: "Equal"
-    value: ""
-    effect: "NoSchedule"
   - key: "node-role.kubernetes.io/control-plane"
     operator: "Equal"
     value: ""
@@ -95,12 +91,6 @@ operator:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-              - key: "node-role.kubernetes.io/master"
-                operator: In
-                values: [""]
         - weight: 1
           preference:
             matchExpressions:
@@ -528,10 +518,6 @@ node-feature-discovery:
       # disable creation to avoid duplicate serviceaccount creation by master spec below
       create: false
     tolerations:
-    - key: "node-role.kubernetes.io/master"
-      operator: "Equal"
-      value: ""
-      effect: "NoSchedule"
     - key: "node-role.kubernetes.io/control-plane"
       operator: "Equal"
       value: ""


### PR DESCRIPTION
The node-role.kubernetes.io/master was deprecated in [Kubernetes 1.24](https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/). This PR will remove the tolerations and node affinity role for node-role.kubernetes.io/master so that when the gpu-operator is deployed, there will no longer be a warning.