### PR TITLE
Fix shared state bug causing incorrect driver images in multi-node-pool clusters

### DIFF
--- a/internal/state/driver.go
+++ b/internal/state/driver.go
@@ -545,7 +545,7 @@ func getDriverSpec(cr *nvidiav1alpha1.NVIDIADriver, nodePool nodePool) (*driverS
 	nvidiaDriverName := getDriverName(cr, nodePool.getOS())
 	nvidiaDriverAppName := getDriverAppName(cr, nodePool)
 
-	spec := &cr.Spec
+	spec := cr.Spec.DeepCopy()
 	imagePath, err := getDriverImagePath(spec, nodePool)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver image path: %v", err)


### PR DESCRIPTION
Solves #1622 

When a cluster has nodes with different OS/kernel versions (multiple node pools), the GPU operator creates separate DaemonSets for each pool. However, DaemonSets were being assigned incorrect driver container images - the image tags didn't match the kernel/OS versions in the DaemonSet names. 

### Root Cause 

`getDriverSpec()` was using `spec := &cr.Spec` instead of creating a deep copy. This caused all node pools to share the same `NVIDIADriverSpec` pointer in memory. When processing multiple node pools in a loop, mutations (like setting NodeSelector) from later iterations overwrote values from earlier iterations, leading to inconsistent DaemonSet configurations.