### PR TITLE
fix: Restart vgpu-device-manager pods when workload config changes

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -44,6 +44,7 @@ const (
 	commonOperandsLabelValue            = "true"
 	migManagerLabelKey                  = "nvidia.com/gpu.deploy.mig-manager"
 	migManagerLabelValue                = "true"
+	vgpuDeviceManagerLabelKey           = "nvidia.com/gpu.deploy.vgpu-device-manager"
 	migCapableLabelKey                  = "nvidia.com/mig.capable"
 	migCapableLabelValue                = "true"
 	migConfigLabelKey                   = "nvidia.com/mig.config"


### PR DESCRIPTION
## Problem
`nvidia-vgpu-device-manager` pods were not restarting when node workload  config label changed from `vm-passthrough` to `vm-vgpu`, even with `sandboxWorkloads.enabled=true`.

## Solution
Add workload config hash annotation to the DaemonSet pod template. When workload configs change, the hash changes, causing Kubernetes to detect a spec change and trigger a rolling update.

This approach is inspired by `TransformKataManager`, which uses a similar hash-based mechanism to trigger pod restarts when Kata config changes.

## Changes
- Compute hash of node workload configs in `TransformVGPUDeviceManager`
- Set hash as pod template annotation (inspired by KataManager pattern)
- Add test verifying hash changes trigger restart