### PR TITLE
fix: update digest lookup to use versioned RepoTags instead of latest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,31 +27,31 @@
   "recreateWhen": "always",
   "separateMultipleMajor": false,
   "separateMinorPatch": false,
+  "pruneStaleBranches": true,
+  "rebaseWhen": "always",
+
   "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
-      ],
-      "matchStrings": [
-        "[-\\s]*value:\\s*\"?(?<depName>[^:\"]+)(?::(?<currentValue>[^@\"]+))?@(?<currentDigest>sha256:[a-f0-9]{64})\"?",
-        "[-\\s]*image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]{64})",
-        "- name: (?<suffix>[\\w-]+)[-\\s]*image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]{64})"
-      ],
-      "versioningTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-      "datasourceTemplate": "docker"
-    },
     {
       "customType": "regex",
       "managerFilePatterns": [
         "deployments/gpu-operator/values.yaml"
       ],
       "matchStrings": [
-       "[-\\s]*repository:\\s*(?<repo>\\S+)\\s*\\n(?:\\s*#.*\\n|\\s*\\n)*[-\\s]*image:\\s*(?<image>\\S+)\\s*\\n(?:\\s*#.*\\n|\\s*\\n)*[-\\s]*version:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+        "[-\\s]*repository:\\s*(?<repo>\\S+)\\s*\\n(?:\\s*#.*\\n|\\s*\\n)*[-\\s]*image:\\s*(?<image>\\S+)\\s*\\n(?:\\s*#.*\\n|\\s*\\n)*[-\\s]*version:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
       ],
       "depNameTemplate": "{{repo}}/{{image}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
+      ],
+      "matchStrings": [
+        "(?:value|image):\\s*[\"']?(?<depName>[^:\"'\\s]+):(?<currentValue>[^@\"'\\s]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker"
     },
     {
       "customType": "regex",
@@ -132,18 +132,32 @@
     {
       "matchFileNames": ["deployments/gpu-operator/values.yaml"],
       "matchPackageNames": [
-       "nvcr.io/nvidia/cuda"
+        "nvcr.io/nvidia/cuda"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-base-ubi9$",
       "separateMajorMinor": false
+    },
+    {
+      "description": "Keep only the base gdrcopy version as the OS suffix is added at runtime",
+      "matchFileNames": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": ["nvcr.io/nvidia/cloud-native/gdrdrv"],
+      "extractVersion": "^(?<version>v?\\d+\\.\\d+(?:\\.\\d+)?)(?:-.*)?$",
+      "versioning": "loose"
+    },
+    {
+      "matchFileNames": ["bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"],
+      "matchPackageNames": ["nvcr.io/nvidia/cloud-native/gdrdrv"],
+      "enabled": false
     },
     {
       "matchPackageNames": ["nvcr.io/nvidia/driver"],
       "enabled": false
     },
     {
-      "matchDatasources": ["*"],
-      "groupName": "{{depName}}"
+      "matchDatasources": ["docker"],
+      "groupName": "{{depName}}",
+      "branchTopic": "{{depName}}",
+      "commitMessageTopic": "{{depName}}"
     },
     {
       "description": "Group all Go toolchain version bumps",


### PR DESCRIPTION
Biggest risk in config: 
 1, values.yaml and CSV are managed independently, so renovate can update one without keeping the other in sync.
 2. Same tag, new digest, If the tag  still exists, but upstream re-pushes that same tag to a different image, Renovate may keep the tag the same and only change the digest in csv file 

Current Issue:
Renovate always pulls the digest from the latest tag, which results in a SHA difference.
However, the version in the `values.yaml `file is not updated in this scenario, so the digest in the manifests becomes mismatched and stale.

Solution:
Open a PR only when the RepoTags value in values.yaml changes.
Then search for that exact digest in
`bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml`
instead of using the digest from latest.

check open PRs: 
[https://github.com/shivakunv/gpu-operator/pulls](https://github.com/shivakunv/gpu-operator/pulls)