### PR TITLE
Run nvidia-smi after modules are loaded in driver ds startup probe

### DIFF
--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -137,7 +137,7 @@ spec:
         startupProbe:
           exec:
             command:
-              [sh, -c, 'nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready']
+              [sh, -c, '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready']
           initialDelaySeconds: 60
           failureThreshold: 120
           successThreshold: 1

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -168,7 +168,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -182,7 +182,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -238,7 +238,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -168,7 +168,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -168,7 +168,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -168,7 +168,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -238,7 +238,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -170,7 +170,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -172,7 +172,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -170,7 +170,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-secret-env.yaml
+++ b/internal/state/testdata/golden/driver-secret-env.yaml
@@ -171,7 +171,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
@@ -168,7 +168,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -168,7 +168,7 @@ spec:
             command:
             - sh
             - -c
-            - nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready
+            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -331,7 +331,7 @@ spec:
         startupProbe:
           exec:
             command:
-              [sh, -c, 'nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready']
+              [sh, -c, '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready']
           initialDelaySeconds: {{ .Driver.Spec.StartupProbe.InitialDelaySeconds }}
           failureThreshold: {{ .Driver.Spec.StartupProbe.FailureThreshold }}
           successThreshold: {{ .Driver.Spec.StartupProbe.SuccessThreshold }}


### PR DESCRIPTION
This commit eliminates the race condition where the startup probe in the driver daemonset runs after the kernel modules are built (and installed) but before the modules are loaded into the kernel. In this case, the invocation of nvidia-smi (by the startup probe) is what is actually loading the nvidia kernel module and not the modprobe we perform in our driver container scripts. As a result, the nvidia driver will be loaded with a default configuration -- none of the custom kernel module parameters provided by users (via a configmap) or set by our driver container will get applied.