### PR TITLE
[docker-build] ensure provenance is disabled during image builds

### DIFF
--- a/native-only.mk
+++ b/native-only.mk
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 PUSH_ON_BUILD ?= false
+ATTACH_ATTESTATIONS ?= false
 DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64
 DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD) --provenance=$(ATTACH_ATTESTATIONS) --sbom=$(ATTACH_ATTESTATIONS)
 


### PR DESCRIPTION
The GitHub runners have now started using a newer version of docker-ce where `--provenance` is enabled by default. This results in the native-arch image build creating a docker manifest list instead of a single image. This causes issues in our multiarch builds as we need to create a docker manifest out of the two images built for the amd64 and arm64 architectures.

With this fix, we should no longer see errors like the one below:
```
$ docker manifest create \
    ${OPERATOR_MULTIARCH_IMAGE} \
    ${OPERATOR_IMAGE_AMD} \
    ${OPERATOR_IMAGE_ARM}
ghcr.io/nvidia/gpu-operator:d8d2842a-amd64 is a manifest list
```