### PR TITLE
Add cluster upgrade support by including MOFED dependency in RDMA scenarios

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1109,7 +1109,9 @@ func TransformDriver(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n C
 	}
 
 	// add nodeSelector for MOFED wait label when GPUDirect RDMA is enabled
-	if config.Driver.GPUDirectRDMA != nil && config.Driver.GPUDirectRDMA.IsEnabled() {
+	if config.Driver.GPUDirectRDMA != nil &&
+		config.Driver.GPUDirectRDMA.IsEnabled() &&
+		!config.Driver.GPUDirectRDMA.IsHostMOFED() {
 		if obj.Spec.Template.Spec.NodeSelector == nil {
 			obj.Spec.Template.Spec.NodeSelector = make(map[string]string)
 		}

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1108,6 +1108,13 @@ func TransformDriver(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n C
 		setContainerEnv(driverToolkitContainer, "DRIVER_CONFIG_DIGEST", configDigest)
 	}
 
+	// add nodeSelector for MOFED wait label when GPUDirect RDMA is enabled
+	if config.Driver.GPUDirectRDMA != nil && config.Driver.GPUDirectRDMA.IsEnabled() {
+		if obj.Spec.Template.Spec.NodeSelector == nil {
+			obj.Spec.Template.Spec.NodeSelector = make(map[string]string)
+		}
+		obj.Spec.Template.Spec.NodeSelector["network.nvidia.com/operator.mofed.wait"] = "false"
+	}
 	return nil
 }
 


### PR DESCRIPTION
This commit adds the proper GPU driver wait for the MOFED driver to be ready so RDMA APIs are available when driver is recompiled. This ensures the operator supports cluster upgrades, i.e., kernel version upgrades. 