### PR TITLE
[fix] : before reconciling, check if useNvidiaDriverCRD is enabled or not

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -1912,8 +1912,8 @@ func (d *DriverSpec) IsEnabled() bool {
 	return *d.Enabled
 }
 
-// UseNvdiaDriverCRDType returns true if the driver installation is managed by NVIDIADriver CRD type
-func (d *DriverSpec) UseNvdiaDriverCRDType() bool {
+// UseNvidiaDriverCRDType returns true if the driver installation is managed by NVIDIADriver CRD type
+func (d *DriverSpec) UseNvidiaDriverCRDType() bool {
 	if d.UseNvidiaDriverCRD == nil {
 		// default is false if not specified by user
 		return false

--- a/api/nvidia/v1alpha1/nvidiadriver_types.go
+++ b/api/nvidia/v1alpha1/nvidiadriver_types.go
@@ -476,7 +476,7 @@ const (
 type NVIDIADriverStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	// +kubebuilder:validation:Enum=ignored;ready;notReady
+	// +kubebuilder:validation:Enum=ignored;ready;notReady;disabled
 	// State indicates status of NVIDIADriver instance
 	State State `json:"state"`
 	// Namespace indicates a namespace in which the operator and driver are installed

--- a/bundle/manifests/nvidia.com_nvidiadrivers.yaml
+++ b/bundle/manifests/nvidia.com_nvidiadrivers.yaml
@@ -807,6 +807,7 @@ spec:
                 - ignored
                 - ready
                 - notReady
+                - disabled
                 type: string
             required:
             - state

--- a/config/crd/bases/nvidia.com_nvidiadrivers.yaml
+++ b/config/crd/bases/nvidia.com_nvidiadrivers.yaml
@@ -807,6 +807,7 @@ spec:
                 - ignored
                 - ready
                 - notReady
+                - disabled
                 type: string
             required:
             - state

--- a/controllers/nvidiadriver_controller_test.go
+++ b/controllers/nvidiadriver_controller_test.go
@@ -1,0 +1,195 @@
+/**
+# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
+	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
+	"github.com/NVIDIA/gpu-operator/internal/validator"
+)
+
+// FakeConditionUpdater implements conditions.Updater
+// It always returns CustomError if set
+type FakeConditionUpdater struct {
+	CustomError error
+}
+
+// SetConditionsError always returns CustomError if set
+func (f *FakeConditionUpdater) SetConditionsError(ctx context.Context, obj any, condType, msg string) error {
+	return f.CustomError
+}
+
+// SetConditionsReady always returns CustomError if set
+func (f *FakeConditionUpdater) SetConditionsReady(ctx context.Context, obj any, condType, msg string) error {
+	return f.CustomError
+}
+
+// FakeNodeSelectorValidator always returns CustomError if set
+type FakeNodeSelectorValidator struct {
+	CustomError error
+}
+
+// Validate always returns CustomError if set
+func (f *FakeNodeSelectorValidator) Validate(ctx context.Context, cr *nvidiav1alpha1.NVIDIADriver) error {
+	return f.CustomError
+}
+
+// newTestLogger creates a zap.Logger that writes to an in-memory buffer for testing
+func newTestLogger() (logr.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+
+	encoder := zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
+		MessageKey:   "msg",
+		LevelKey:     "level",
+		NameKey:      "logger",
+		CallerKey:    "caller",
+		EncodeLevel:  zapcore.CapitalLevelEncoder,
+		EncodeCaller: zapcore.ShortCallerEncoder,
+		EncodeName:   zapcore.FullNameEncoder,
+	})
+
+	core := zapcore.NewCore(encoder, zapcore.AddSync(buf), zapcore.DebugLevel)
+	zapLogger := zap.New(core)
+
+	return zapr.NewLogger(zapLogger), buf
+}
+
+// TestReconcile tests that reconciliation proceeds or skips based on the
+// ClusterPolicy and NVIDIADriver. Since Reconcile() does in-memory updates,
+// we just ensure it does not error out or the error is handled gracefully.
+func TestReconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiav1alpha1.AddToScheme(scheme))
+	require.NoError(t, gpuv1.AddToScheme(scheme))
+
+	tests := []struct {
+		name        string
+		useCRD      *bool
+		spec        nvidiav1alpha1.NVIDIADriverSpec
+		validator   validator.Validator
+		error       error
+		expectedLog string
+	}{
+		{
+			name:   "ClusterPolicy has driver CRD false → reconciliation skips driver",
+			useCRD: ptr.To(false),
+			validator: &FakeNodeSelectorValidator{
+				CustomError: errors.New("fake list error"),
+			},
+			error:       nil,
+			expectedLog: "useNvidiaDriverCRD is not enabled in ClusterPolicy",
+		},
+		{
+			name:   "ClusterPolicy has driver CRD true but validator errors",
+			useCRD: ptr.To(true),
+			validator: &FakeNodeSelectorValidator{
+				CustomError: errors.New("fake list error"),
+			},
+			error:       nil,
+			expectedLog: "nodeSelector validation failed",
+		},
+		{
+			name:   "driver CRD true, no validator errors, use precompiled drivers and GDS enabled",
+			useCRD: ptr.To(true),
+			spec: nvidiav1alpha1.NVIDIADriverSpec{
+				UsePrecompiled: ptr.To(true),
+				GPUDirectStorage: &nvidiav1alpha1.GPUDirectStorageSpec{
+					Enabled: ptr.To(true),
+				},
+			},
+			validator: &FakeNodeSelectorValidator{
+				CustomError: nil,
+			},
+			error:       nil,
+			expectedLog: "GPUDirect Storage driver (nvidia-fs) and/or GDRCopy driver is not supported along with pre-compiled NVIDIA drivers",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, buf := newTestLogger()
+			ctx := ctrl.LoggerInto(context.Background(), logger)
+			driver := &nvidiav1alpha1.NVIDIADriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-driver",
+					Namespace: "default",
+				},
+				Spec: tc.spec,
+			}
+
+			cp := &gpuv1.ClusterPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: gpuv1.ClusterPolicySpec{
+					Driver: gpuv1.DriverSpec{
+						UseNvidiaDriverCRD: tc.useCRD,
+					},
+				},
+			}
+
+			// Initialize fake client with ClusterPolicy (driver optional)
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cp, driver)
+			client := clientBuilder.Build()
+
+			updater := &FakeConditionUpdater{}
+
+			reconciler := &NVIDIADriverReconciler{
+				Client:                client,
+				Scheme:                scheme,
+				conditionUpdater:      updater,
+				nodeSelectorValidator: tc.validator,
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      driver.Name,
+					Namespace: driver.Namespace,
+				},
+			}
+
+			_, err := reconciler.Reconcile(ctx, req)
+
+			if tc.error != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.error.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			logs := buf.String()
+			if tc.expectedLog != "" {
+				require.Contains(t, logs, tc.expectedLog)
+			}
+		})
+	}
+}

--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -942,7 +942,7 @@ func (n *ClusterPolicyController) step() (gpuv1.State, error) {
 	//     before managing them. Clusterpolicy controller should not be creating /
 	//     updating / deleting objects owned by another controller.
 	if (n.stateNames[n.idx] == "state-driver" || n.stateNames[n.idx] == "state-vgpu-manager") &&
-		n.singleton.Spec.Driver.UseNvdiaDriverCRDType() {
+		n.singleton.Spec.Driver.UseNvidiaDriverCRDType() {
 		n.logger.Info("NVIDIADriver CRD is enabled, cleaning up all NVIDIA driver daemonsets owned by ClusterPolicy")
 		n.idx++
 		// Cleanup all driver daemonsets owned by ClusterPolicy.

--- a/controllers/upgrade_controller.go
+++ b/controllers/upgrade_controller.go
@@ -130,7 +130,7 @@ func (r *UpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	driverLabelKey := DriverLabelKey
 	driverLabelValue := DriverLabelValue
 
-	if clusterPolicy.Spec.Driver.UseNvdiaDriverCRDType() {
+	if clusterPolicy.Spec.Driver.UseNvidiaDriverCRDType() {
 		// app component label is added for all new driver daemonsets deployed by NVIDIADriver controller
 		driverLabelKey = AppComponentLabelKey
 		driverLabelValue = AppComponentLabelValue

--- a/deployments/gpu-operator/crds/nvidia.com_nvidiadrivers.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_nvidiadrivers.yaml
@@ -807,6 +807,7 @@ spec:
                 - ignored
                 - ready
                 - notReady
+                - disabled
                 type: string
             required:
             - state

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/NVIDIA/nvidia-container-toolkit v1.18.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-logr/logr v1.4.3
+	github.com/go-logr/zapr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift/api v0.0.0-20251021124544-a2cb0c5d994d
@@ -52,7 +53,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect


### PR DESCRIPTION
When running reconcile loop for nvidiadriver controller, we should check and make sure if useNvidiaDriverCRD is enabled or disabled in cluster-policy. If disabled, we should not do anything and just return for any nvidiaDriver CR installed in the cluster.

#### Logs from the cluster after the fix when useNvidiaDriverCRD is false and nvidiaDriver CR is created:
```
kubectl logs deploy/gpu-operator -n gpu-operator | grep -i "NvidiaDriver"
{"level":"info","ts":1764651827.1961918,"msg":"Starting EventSource","controller":"nvidia-driver-controller","source":"kind source: *v1alpha1.NVIDIADriver"}
{"level":"info","ts":1764651827.2976434,"msg":"Reconciling NVIDIADriver","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"02e56517-713d-4941-a56c-977de299a5e6"}
{"level":"info","ts":1764651827.2979498,"msg":"NVIDIADriver reconciliation skipped","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"02e56517-713d-4941-a56c-977de299a5e6","reason":"useNvidiaDriverCRD is not enabled in ClusterPolicy"}
```

#### Status of nvidiadriver:
```
kubectl get nvidiadriver
NAME                  STATUS     AGE
nvidiadriver-sample   disabled   2025-12-02T05:19:49Z
```

#### Once clusterpolicy is updated to use nvidiadriver cr, it correctly detects that and reconciles.
```
{"level":"info","ts":1764651827.1961918,"msg":"Starting EventSource","controller":"nvidia-driver-controller","source":"kind source: *v1alpha1.NVIDIADriver"}
...
{"level":"info","ts":1764651827.340151,"msg":"Reconciling NVIDIADriver","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"a48ef5db-fa17-45b1-a214-cc9d746011e1"}
{"level":"info","ts":1764651827.3403502,"msg":"NVIDIADriver reconciliation skipped","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"a48ef5db-fa17-45b1-a214-cc9d746011e1","reason":"useNvidiaDriverCRD is not enabled in ClusterPolicy"}
{"level":"info","ts":1764651919.4739022,"msg":"Reconciling NVIDIADriver","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"80599d7a-da38-4822-a7af-ad378d8dac43"}
{"level":"info","ts":1764651919.4753463,"msg":"Syncing system state","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"80599d7a-da38-4822-a7af-ad378d8dac43"}
{"level":"info","ts":1764651919.4753802,"msg":"Sync State","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"80599d7a-da38-4822-a7af-ad378d8dac43","Name":"state-driver","Description":"NVIDIA driver deployed in the cluster"}
{"level":"info","ts":1764651919.4754379,"logger":"state.state-driver","msg":"Cleaning up stale driver DaemonSets","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"80599d7a-da38-4822-a7af-ad378d8dac43"}
{"level":"info","ts":1764651919.4909735,"logger":"state.state-driver","msg":"Detected new node pool","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"80599d7a-da38-4822-a7af-ad378d8dac43","NodePool":{}}
{"level":"info","ts":1764651919.500201,"logger":"controllers.ClusterPolicy","msg":"NVIDIADriver CRD is enabled, cleaning up all NVIDIA driver daemonsets owned by ClusterPolicy"}
{"level":"info","ts":1764651919.504242,"logger":"state.state-driver","msg":"Rendering manifests for node pool","controller":"nvidia-driver-controller","object":{"name":"nvidiadriver-sample"},"namespace":"","name":"nvidiadriver-sample","reconcileID":"80599d7a-da38-4822-a7af-ad378d8dac43","NodePool":"ubuntu24.04"}
...
```

#### Status of nvidiadriver CR
```
kubectl get nvidiadriver
NAME                  STATUS   AGE
nvidiadriver-sample   ready    2025-12-02T05:19:49Z
```