### PR TITLE
[dcgm-exporter] Support exposing metrics on hostNetwork

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -931,6 +931,13 @@ type DCGMExporterSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	HostPID *bool `json:"hostPID,omitempty"`
 
+	// HostNetwork allows the DCGM-Exporter daemon set to expose metrics port on the host's network namespace.
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Enable hostNetwork for NVIDIA DCGM Exporter"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
+
 	// Optional: HPC job mapping configuration for NVIDIA DCGM Exporter
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
@@ -1968,6 +1975,15 @@ func (e *DCGMExporterSpec) IsHostPIDEnabled() bool {
 		return false
 	}
 	return *e.HostPID
+}
+
+// IsHostNetworkEnabled returns true if hostNetwork is enabled for DCGM Exporter
+func (e *DCGMExporterSpec) IsHostNetworkEnabled() bool {
+	if e.HostNetwork == nil {
+		// default is false if not specified by user
+		return false
+	}
+	return *e.HostNetwork
 }
 
 // IsHPCJobMappingEnabled returns true if HPC job mapping is enabled for DCGM Exporter

--- a/api/nvidia/v1/zz_generated.deepcopy.go
+++ b/api/nvidia/v1/zz_generated.deepcopy.go
@@ -404,6 +404,11 @@ func (in *DCGMExporterSpec) DeepCopyInto(out *DCGMExporterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HPCJobMapping != nil {
 		in, out := &in.HPCJobMapping, &out.HPCJobMapping
 		*out = new(DCGMExporterHPCJobMappingConfig)

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -339,6 +339,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostNetwork:
+                    description: HostNetwork allows the DCGM-Exporter daemon set to
+                      expose metrics port on the host's network namespace.
+                    type: boolean
                   hostPID:
                     description: HostPID allows the DCGM-Exporter daemon set to access
                       the host's PID namespace

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -339,6 +339,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostNetwork:
+                    description: HostNetwork allows the DCGM-Exporter daemon set to
+                      expose metrics port on the host's network namespace.
+                    type: boolean
                   hostPID:
                     description: HostPID allows the DCGM-Exporter daemon set to access
                       the host's PID namespace

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1696,7 +1696,14 @@ func TransformDCGMExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 		if remoteEngine != "" && strings.HasPrefix(remoteEngine, "localhost") {
 			// enable hostNetwork for communication with external DCGM using localhost
 			obj.Spec.Template.Spec.HostNetwork = true
+			obj.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 		}
+	}
+	// set hostNetwork if specified for DCGM Exporter (if it is already enabled above,
+	// do not touch the value)
+	if config.DCGMExporter.IsHostNetworkEnabled() {
+		obj.Spec.Template.Spec.HostNetwork = true
+		obj.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	setRuntimeClassName(&obj.Spec.Template.Spec, config, n.runtime)

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -339,6 +339,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostNetwork:
+                    description: HostNetwork allows the DCGM-Exporter daemon set to
+                      expose metrics port on the host's network namespace.
+                    type: boolean
                   hostPID:
                     description: HostPID allows the DCGM-Exporter daemon set to access
                       the host's PID namespace

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -539,6 +539,9 @@ spec:
     {{- if .Values.dcgmExporter.hostPID }}
     hostPID: {{ .Values.dcgmExporter.hostPID }}
     {{- end }}
+    {{- if .Values.dcgmExporter.hostNetwork }}
+    hostNetwork: {{ .Values.dcgmExporter.hostNetwork }}
+    {{- end }}
     {{- if .Values.dcgmExporter.hpcJobMapping }}
     hpcJobMapping: {{ toYaml .Values.dcgmExporter.hpcJobMapping | nindent 6 }}
     {{- end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -283,6 +283,7 @@ dcgmExporter:
   env: []
   resources: {}
   hostPID: false
+  hostNetwork: false
   # HPC job mapping configuration for correlating GPU metrics with HPC workload manager jobs
   # This is used by HPC workload managers like Slurm to label GPU metrics with job IDs
   # hpcJobMapping:


### PR DESCRIPTION
Add support to toggle `hostNetwork` field of pod spec for dcgm-exporter daemonset pod spec, 
allowing dcgm-exporter pods to be scraped by say prometheus-server that runs outside of the 
bounds of the k8s cluster overlay network (and still be able to reach dcgm-exporter pods,
i.e. scraping each daemonset pod's port on the node - this is easier to reason and deal with
compared to say scraping a NodePort service ports on each node).

Fixes #1086