### PR TITLE
Upgrade Controller: filter node watch to only upgrade state label changes

### DIFF
--- a/controllers/state_manager_test.go
+++ b/controllers/state_manager_test.go
@@ -69,3 +69,120 @@ func TestGetRuntimeString(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidWorkloadConfig(t *testing.T) {
+	tests := []struct {
+		config string
+		want   bool
+	}{
+		{gpuWorkloadConfigContainer, true}, {gpuWorkloadConfigVMPassthrough, true}, {gpuWorkloadConfigVMVgpu, true},
+		{"invalid", false}, {"", false},
+	}
+	for _, tc := range tests {
+		if got := isValidWorkloadConfig(tc.config); got != tc.want {
+			t.Errorf("isValidWorkloadConfig(%q) = %v, want %v", tc.config, got, tc.want)
+		}
+	}
+}
+
+func TestHasOperandsDisabled(t *testing.T) {
+	tests := []struct {
+		labels map[string]string
+		want   bool
+	}{
+		{map[string]string{commonOperandsLabelKey: "false"}, true},
+		{map[string]string{commonOperandsLabelKey: commonOperandsLabelValue}, false},
+		{map[string]string{}, false},
+	}
+	for _, tc := range tests {
+		if got := hasOperandsDisabled(tc.labels); got != tc.want {
+			t.Errorf("hasOperandsDisabled(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestHasNFDLabels(t *testing.T) {
+	tests := []struct {
+		labels map[string]string
+		want   bool
+	}{
+		{map[string]string{nfdLabelPrefix + "cpu": "true"}, true},
+		{map[string]string{"other-label": "value"}, false},
+		{map[string]string{}, false},
+	}
+	for _, tc := range tests {
+		if got := hasNFDLabels(tc.labels); got != tc.want {
+			t.Errorf("hasNFDLabels(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestHasMIGManagerLabel(t *testing.T) {
+	tests := []struct {
+		labels map[string]string
+		want   bool
+	}{
+		{map[string]string{migManagerLabelKey: migManagerLabelValue}, true},
+		{map[string]string{"other": "value"}, false},
+	}
+	for _, tc := range tests {
+		if got := hasMIGManagerLabel(tc.labels); got != tc.want {
+			t.Errorf("hasMIGManagerLabel(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestHasCommonGPULabel(t *testing.T) {
+	tests := []struct {
+		labels map[string]string
+		want   bool
+	}{
+		{map[string]string{commonGPULabelKey: commonGPULabelValue}, true},
+		{map[string]string{commonGPULabelKey: "false"}, false},
+		{map[string]string{}, false},
+	}
+	for _, tc := range tests {
+		if got := hasCommonGPULabel(tc.labels); got != tc.want {
+			t.Errorf("hasCommonGPULabel(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestHasGPULabels(t *testing.T) {
+	tests := []struct {
+		labels map[string]string
+		want   bool
+	}{
+		{map[string]string{nfdLabelPrefix + "pci-10de.present": "true"}, true},
+		{map[string]string{nfdLabelPrefix + "pci-0302_10de.present": "true"}, true},
+		{map[string]string{nfdLabelPrefix + "pci-0300_10de.present": "true"}, true},
+		{map[string]string{nfdLabelPrefix + "pci-10de.present": "false"}, false},
+		{map[string]string{"other": "true"}, false},
+	}
+	for _, tc := range tests {
+		if got := hasGPULabels(tc.labels); got != tc.want {
+			t.Errorf("hasGPULabels(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestHasMIGCapableGPU(t *testing.T) {
+	tests := []struct {
+		labels map[string]string
+		want   bool
+	}{
+		{map[string]string{migCapableLabelKey: migCapableLabelValue}, true},
+		{map[string]string{migCapableLabelKey: "false"}, false},
+		{map[string]string{gpuProductLabelKey: "NVIDIA-A100"}, true},
+		{map[string]string{gpuProductLabelKey: "NVIDIA-H100"}, true},
+		{map[string]string{gpuProductLabelKey: "NVIDIA-A30"}, true},
+		{map[string]string{gpuProductLabelKey: "NVIDIA-T4"}, false},
+		{map[string]string{vgpuHostDriverLabelKey: "535.54"}, false},
+		{map[string]string{}, false},
+	}
+	for _, tc := range tests {
+		if got := hasMIGCapableGPU(tc.labels); got != tc.want {
+			t.Errorf("hasMIGCapableGPU(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Replace generic label change predicate with a specific predicate that only watches for `nvidia.com/gpu-driver-upgrade-state` label changes on nodes.

## Problem
The upgrade controller was using `TypedLabelChangedPredicate` which triggered reconciliation on ANY node label change, causing unnecessary reconciliations.

## Solution
Implement `upgradeStateLabelPredicate` that compares only the upgrade state label between old and new node objects, ignoring all other label changes.

## Testing
- Built and deployed to live cluster
- Verified changing non-upgrade labels (`test-label`, `nvidia.com/some-other-label`, etc.) does NOT trigger reconciliation
- Verified changing `nvidia.com/gpu-driver-upgrade-state` label DOES trigger immediate reconciliation
- Confirmed upgrade state machine still processes correctly through all states