### PR TITLE
Add extended diagnostics support to must-gather.sh using debug container for dmidecode/lspci collection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,6 +43,9 @@ Collecting full debug bundle (optional):
 curl -o must-gather.sh -L https://raw.githubusercontent.com/NVIDIA/gpu-operator/main/hack/must-gather.sh
 chmod +x must-gather.sh
 ./must-gather.sh
+
+# For extended diagnostics (includes system/PCI info):
+ENABLE_EXTENDED_DIAGNOSTICS=true ./must-gather.sh
 ```
 **NOTE**: please refer to the [must-gather](https://raw.githubusercontent.com/NVIDIA/gpu-operator/main/hack/must-gather.sh) script for debug data collected.
 

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,18 @@ build-image:
 # This includes https://github.com/openshift-psap/ci-artifacts
 docker-image: OUT_IMAGE ?= $(IMAGE_NAME):$(IMAGE_TAG)
 
+##### Debug Container #####
+DEBUG_CONTAINER_IMAGE ?= ghcr.io/nvidia/gpu-operator-debug
+DEBUG_CONTAINER_TAG ?= latest
+
+.PHONY: build-debug-container push-debug-container
+
+build-debug-container:
+	$(DOCKER) build -t $(DEBUG_CONTAINER_IMAGE):$(DEBUG_CONTAINER_TAG) hack/debug-container/
+
+push-debug-container: build-debug-container
+	$(DOCKER) push $(DEBUG_CONTAINER_IMAGE):$(DEBUG_CONTAINER_TAG)
+
 install-tools:
 	@echo Installing tools from tools.go
 	export GOBIN=$(PROJECT_DIR)/bin && \

--- a/hack/debug-container/Dockerfile
+++ b/hack/debug-container/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dmidecode \
+    pciutils \
+    && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/bin/sh"]
+


### PR DESCRIPTION
## Description

Adds optional extended diagnostics to `must-gather.sh` using a lightweight debug container. Enables complete `nvidia-bug-report` collection including `dmidecode` and `lspci` without adding these tools to the driver container (addressing CVE compliance concerns). This feature is opt-in only; when enabled, users are shown a warning about the external debug container and privileged access requirements before collection begins.

## Usage

#### Standard (existing behavior)
./must-gather.sh

#### Extended diagnostics
ENABLE_EXTENDED_DIAGNOSTICS=true ./must-gather.sh

## Testing

**Environment:** K8s v1.28+, Tesla T4 GPU, `ghcr.io/nvidia/gpu-operator-debug:latest`

1) Ran ./must-gather.sh without flags and verified standard nvidia-bug-report collection works unchanged. Confirmed no extended diagnostics section is added in default mode.
2) Ran with ENABLE_EXTENDED_DIAGNOSTICS=true and verified the debug container (ghcr.io/nvidia/gpu-operator-debug:latest) attaches successfully via kubectl debug.
3) dmidecode output: Confirmed BIOS/system information is captured and appended to the bug report.
4) lspci output: Confirmed verbose PCI device information is captured.
5) Verified Makefile targets build and push the debug image to ghcr.io/nvidia/gpu-operator-debug:latest (public), and confirmed custom image override works for air-gapped environments.



**Sample output verification:**
```
$ zcat nvidia-bug-report_*.log.gz | grep -A3 "EXTENDED DIAGNOSTICS"
*** EXTENDED DIAGNOSTICS (from debug container) ***
```

```
$ zcat nvidia-bug-report_*.log.gz | grep "NVIDIA Corporation"
65:00.0 3D controller: NVIDIA Corporation TU104GL [Tesla T4] (rev a1)
```

```
$ zcat nvidia-bug-report_*.log.gz | grep "BIOS Information" -A2
BIOS Information
    Vendor: American Megatrends Inc.
    Version: 3.3**File size:** Standard 591KB → Extended 596KB (+5KB diagnostics)
```