### PR TITLE
helm: add support for extra Manifests

### DIFF
--- a/deployments/gpu-operator/templates/extra-objects.yaml
+++ b/deployments/gpu-operator/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -510,6 +510,10 @@ ccManager:
       value: "0x2339,0x2331,0x2330,0x2324,0x2322,0x233d"
   resources: {}
 
+# Array of extra K8s manifests to deploy
+# Supports use of custom Helm templates
+extraObjects: []
+
 node-feature-discovery:
   priorityClassName: system-node-critical
   gc:


### PR DESCRIPTION
Adds support for extra Manifest in the helm chart.

Use case: in air gap mode, I need to create a repo-config configmap. This change allows me to define the configmap directly in the chart.

similar implementation is present in [argocd](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml#L709), [prometheus](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L5390), [ESO ](https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml#L201) etc...