### PR TITLE
Fix chart's devicePlugin.config fields evaluated to objects instead of strings when empty

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -471,7 +471,7 @@ spec:
     {{- end }}
     {{- if .Values.devicePlugin.config.name }}
     config:
-      name: {{ .Values.devicePlugin.config.name }}
+      name: {{ .Values.devicePlugin.config.name | quote }}
       default: {{ .Values.devicePlugin.config.default | quote }}
     {{- end }}
   dcgm:


### PR DESCRIPTION
Since these fields are not quoted when templated, using any special value such as `null`, or an empty string may result in them being evaluated as objects. 

This causes an error when evaluating against the CRD definition while applying the object.
As there may be more fields with the same behavior, I would probably expand this PR if needed.

While I agree that these fields shouldn't be empty, not quoting those values anyway may lead to issues and misunderstandings.

## Testing process

- Create a test values file with an empty value for the config name, and a special name.
```YAML
devicePlugin:
  config:
    name: "null"
    create: true
    default: ""
```

### Pre-fix:
- Observe that the `devicePlugin.config` fields are not formatted correctly
```Bash
 nefast@sapphire $ helm template nvidia-gpu-operator . -f test.yaml | grep devicePlugin -A 10
  devicePlugin:
    enabled: true
    repository: nvcr.io/nvidia
    image: k8s-device-plugin
    version: "v0.18.1"
    imagePullPolicy: IfNotPresent
    config:
      name: null
      default: 
```

### Post-fix:
- Observe that the `devicePlugin.config` fields are templated properly and that it passes server validation
```Bash
nefast@sapphire $ helm template nvidia-gpu-operator . -f test.yaml | grep devicePlugin -A 8
  devicePlugin:
    enabled: true
    repository: nvcr.io/nvidia
    image: k8s-device-plugin
    version: "v0.18.1"
    imagePullPolicy: IfNotPresent
    config:
      name: "null"
      default: ""
```

Closes #1993