### PR TITLE
[fix] : avoid setting empty value for migmanager config's name

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -596,7 +596,9 @@ spec:
     {{- end }}
     {{- if .Values.migManager.config }}
     config:
+      {{- if .Values.migManager.config.name }}
       name: {{ .Values.migManager.config.name }}
+      {{- end }}
       default: {{ .Values.migManager.config.default | quote }}
     {{- end }}
     {{- if .Values.migManager.gpuClientsConfig }}


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This PR avoids rendering migManager config's name if it is set to empty. Default value for it based on CRD specification is [default-mig-parted-config](https://github.com/NVIDIA/gpu-operator/blob/v25.10.1/api/nvidia/v1/clusterpolicy_types.go#L1427)

Currently, on helm template, it gets rendered as:
```
$ helm template nvidiagpu  -n gpu-operator --create-namespace nvidia/gpu-operator --version v25.10.1 -f values.yaml | grep -A8 migManager
  migManager:
    enabled: true
    repository: nvcr.io/nvidia/cloud-native
    image: k8s-mig-manager
    version: "v0.13.1"
    imagePullPolicy: IfNotPresent
    config:
      name:                    <---- value is empty here
      default: "all-disabled"
```

If Argocd is used to install gpu-operator via helm, it sometimes causes sync diffs on subsequent sync runs as the applied value gets updated to default value and the new rendered value is empty/null.
<img width="1098" height="237" alt="Screenshot 2025-12-17 at 3 56 52 PM" src="https://github.com/user-attachments/assets/dd9d2a46-a81b-427e-9883-6b3cc39588d8" />


This PR avoids setting name if its empty and hence argocd doesn't find the value changed on subsequent syncs as the key is not rendered if its empty.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

- [ ] Unit tests (`make coverage`)
- [x] Manual cluster testing (describe below)
- [ ] N/A or Other (docs, CI config, etc.)

**Test details:**
Manually tested the change by rendering the updated helm chart. It correctly skips the key. Example:

```
helm template nvidiagpu  -n gpu-operator --create-namespace deployments/gpu-operator/ -f values.yaml | grep -A8 migManager
  migManager:
    enabled: true
    repository: nvcr.io/nvidia/cloud-native
    image: k8s-mig-manager
    version: "v0.13.1"
    imagePullPolicy: IfNotPresent
    config:
      default: "all-disabled"
    gpuClientsConfig:
```