### PR TITLE
Fix: sed portability and compatibility issue for the bundle commitSha image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -444,7 +444,7 @@ jobs:
           echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
       - name: Update bundle CSV
         run: |
-          sed -i '' -e 's|ghcr.io/nvidia/gpu-operator:[^ "]*|ghcr.io/nvidia/gpu-operator:${{ env.COMMIT_SHORT_SHA }}|g' bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+          sed -i -e 's|ghcr.io/nvidia/gpu-operator:[^ "]*|ghcr.io/nvidia/gpu-operator:${{ env.COMMIT_SHORT_SHA }}|g' bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
           echo "Bundle CSV updated successfully"
       - name: Build bundle-image
         env:


### PR DESCRIPTION
[https://github.com/NVIDIA/gpu-operator/actions/runs/20362800010/job/58514956441 ](https://github.com/NVIDIA/gpu-operator/actions/runs/20362800010/job/58514956441 ): The CI pipeline failed after merging to main: #1898 from NVIDIA/bundlecommitsha : Tag git commit sha with bundle image

[https://github.com/NVIDIA/gpu-operator/actions/runs/20364821808/job/58518239572](https://github.com/NVIDIA/gpu-operator/actions/runs/20364821808/job/58518239572) : Pipeline was reproduced

[https://github.com/NVIDIA/gpu-operator/actions/runs/20364821808/job/58518239572](https://github.com/NVIDIA/gpu-operator/actions/runs/20365258210/job/58519870725): Pipeline passed with the new change
 
Please refer to the links below for details on the bug and compatibility issues with sed:
1. [https://www.baeldung.com/linux/sed-error-no-such-file-or-directory](https://www.baeldung.com/linux/sed-error-no-such-file-or-directory)
2. [https://stackoverflow.com/questions/67086574/no-such-file-or-directory-when-using-sed-in-combination-with-find](https://stackoverflow.com/questions/67086574/no-such-file-or-directory-when-using-sed-in-combination-with-find)

`sed -i '' -e 's|ghcr.io/nvidia/gpu-operator:[^ "]*|ghcr.io/nvidia/gpu-operator:${{ env.COMMIT_SHORT_SHA }}|g' bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml `: This command works only on Mac OS.

`sed -i'' -e 's|ghcr.io/nvidia/gpu-operator:[^ "]*|ghcr.io/nvidia/gpu-operator:${{ env.COMMIT_SHORT_SHA }}|g' bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml `: This works for both MacOS and Linux, creates a backup file with a -e extension on macOS

`sed -i -e 's|ghcr.io/nvidia/gpu-operator:[^ "]*|ghcr.io/nvidia/gpu-operator:${{ env.COMMIT_SHORT_SHA }}|g' bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml `: This works only on Linux, not Mac OS.
