### PR TITLE
[fix] : allow concurrent runs on push to main and release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ on:
       - release-*
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/heads/pull-request/') && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Disabling concurrent for main branch was causing CI to skip pushing OLM bundles for each commit to main branch as some runs were getting cancelled if multiple PRs were merged to main in a short span of time.

This PR disables concurrent runs only for pull requests and allows concurrent runs for pushes to main and release branches. 

When triggered via push to a branch named `pull-request/*`, we have:
workflow name: `CI`
github.ref: `refs/heads/pull-request/<number>`

In this case, the group will become `CI-refs/heads/pull-request/<number>` and will remain the same for any commit to the PR. Hence, there will only be one GHA running at any time for that PR.

When triggered via push to main or release*:
workflow name: `CI`
github.run_id: `<unique num>`

In this case, the group will become `CI-<unique num>` and hence multiple runs can run together for main and release branches.