### PR TITLE
[feat] : validate additional enabled drivers

### DIFF
--- a/assets/state-driver/0400_configmap.yaml
+++ b/assets/state-driver/0400_configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-driver-startup-probe
+  namespace: "FILLED BY THE OPERATOR"
+  labels:
+    app: nvidia-driver-daemonset
+    app.kubernetes.io/component: nvidia-driver
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"

--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -134,10 +134,14 @@ spec:
             mountPath: /sys/module/firmware_class/parameters/path
           - name: nv-firmware
             mountPath: /lib/firmware
+          - name: driver-startup-probe-script
+            mountPath: /usr/local/bin/startup-probe.sh
+            subPath: startup-probe.sh
         startupProbe:
           exec:
             command:
-              [sh, -c, '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready']
+            - sh
+            - /usr/local/bin/startup-probe.sh
           initialDelaySeconds: 60
           failureThreshold: 120
           successThreshold: 1
@@ -323,3 +327,7 @@ spec:
           hostPath:
             path: /run/nvidia/driver/lib/firmware
             type: DirectoryOrCreate
+        - name: driver-startup-probe-script
+          configMap:
+            name: nvidia-driver-startup-probe
+            defaultMode: 0755

--- a/assets/state-operator-validation/0500_daemonset.yaml
+++ b/assets/state-operator-validation/0500_daemonset.yaml
@@ -56,48 +56,6 @@ spec:
               mountPropagation: Bidirectional
             - name: host-dev-char
               mountPath: /host-dev-char
-        - name: nvidia-fs-validation
-          image: "FILLED BY THE OPERATOR"
-          command: ['sh', '-c']
-          args: ["nvidia-validator"]
-          env:
-            - name: WITH_WAIT
-              value: "true"
-            - name: COMPONENT
-              value: nvidia-fs
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          securityContext:
-            privileged: true
-            seLinuxOptions:
-              level: "s0"
-          volumeMounts:
-            - name: run-nvidia-validations
-              mountPath: /run/nvidia/validations
-              mountPropagation: Bidirectional
-        - name: gdrcopy-validation
-          image: "FILLED BY THE OPERATOR"
-          command: [ 'sh', '-c' ]
-          args: [ "nvidia-validator" ]
-          env:
-            - name: WITH_WAIT
-              value: "true"
-            - name: COMPONENT
-              value: gdrcopy
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          securityContext:
-            privileged: true
-            seLinuxOptions:
-              level: "s0"
-          volumeMounts:
-            - name: run-nvidia-validations
-              mountPath: /run/nvidia/validations
-              mountPropagation: Bidirectional
         - name: toolkit-validation
           image: "FILLED BY THE OPERATOR"
           command: ['sh', '-c']

--- a/cmd/nvidia-validator/main_test.go
+++ b/cmd/nvidia-validator/main_test.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func Test_isValidComponent(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      bool
+	}{
+		{
+			name:      "valid driver component",
+			component: "driver",
+			want:      true,
+		},
+		{
+			name:      "valid cuda component",
+			component: "cuda",
+			want:      true,
+		},
+		{
+			name:      "valid plugin component",
+			component: "plugin",
+			want:      true,
+		},
+		{
+			name:      "valid toolkit component",
+			component: "toolkit",
+			want:      true,
+		},
+		{
+			name:      "valid nvidia-fs component using constant",
+			component: NVIDIAFS,
+			want:      true,
+		},
+		{
+			name:      "valid gdrcopy component using constant",
+			component: GDRCOPY,
+			want:      true,
+		},
+		{
+			name:      "valid nvidia-peermem component using constant",
+			component: NVIDIAPEERMEM,
+			want:      true,
+		},
+		{
+			name:      "valid mofed component",
+			component: "mofed",
+			want:      true,
+		},
+		{
+			name:      "valid vgpu-manager component",
+			component: "vgpu-manager",
+			want:      true,
+		},
+		{
+			name:      "valid vgpu-devices component",
+			component: "vgpu-devices",
+			want:      true,
+		},
+		{
+			name:      "valid cc-manager component",
+			component: "cc-manager",
+			want:      true,
+		},
+		{
+			name:      "invalid empty component",
+			component: "",
+			want:      false,
+		},
+		{
+			name:      "invalid unknown component",
+			component: "unknown",
+			want:      false,
+		},
+		{
+			name:      "invalid random string",
+			component: "foobar",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Temporarily set componentFlag for the test
+			originalComponent := componentFlag
+			componentFlag = tt.component
+			defer func() { componentFlag = originalComponent }()
+
+			got := isValidComponent()
+			if got != tt.want {
+				t.Errorf("isValidComponent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_validateAdditionalDriverComponents(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusFileData string
+		createFile     bool
+		wantErr        bool
+	}{
+		{
+			name:       "status file does not exist",
+			createFile: false,
+			wantErr:    true,
+		},
+		{
+			name: "all features disabled",
+			statusFileData: `GDRCOPY_ENABLED: false
+GDS_ENABLED: false
+GPU_DIRECT_RDMA_ENABLED: false`,
+			createFile: true,
+			wantErr:    false,
+		},
+		{
+			name: "GDRCOPY enabled",
+			statusFileData: `GDRCOPY_ENABLED: true
+GDS_ENABLED: false
+GPU_DIRECT_RDMA_ENABLED: false`,
+			createFile: true,
+			wantErr:    true, // will fail validation without actual kernel module
+		},
+		{
+			name: "GDS (nvidia-fs) enabled",
+			statusFileData: `GDRCOPY_ENABLED: false
+GDS_ENABLED: true
+GPU_DIRECT_RDMA_ENABLED: false`,
+			createFile: true,
+			wantErr:    true, // will fail validation without actual kernel module
+		},
+		{
+			name: "GPU_DIRECT_RDMA (nvidia-peermem) enabled",
+			statusFileData: `GDRCOPY_ENABLED: false
+GDS_ENABLED: false
+GPU_DIRECT_RDMA_ENABLED: true`,
+			createFile: true,
+			wantErr:    true, // will fail validation without actual kernel module
+		},
+		{
+			name: "all features enabled",
+			statusFileData: `GDRCOPY_ENABLED: true
+GDS_ENABLED: true
+GPU_DIRECT_RDMA_ENABLED: true`,
+			createFile: true,
+			wantErr:    true, // will fail validation without actual kernel modules
+		},
+		{
+			name: "unknown feature flag is ignored",
+			statusFileData: `GDRCOPY_ENABLED: false
+GDS_ENABLED: false
+GPU_DIRECT_RDMA_ENABLED: false
+UNKNOWN_FEATURE: true`,
+			createFile: true,
+			wantErr:    false,
+		},
+		{
+			name:           "invalid YAML format",
+			statusFileData: `invalid yaml content {{{`,
+			createFile:     true,
+			wantErr:        true,
+		},
+		{
+			name:           "empty status file",
+			statusFileData: ``,
+			createFile:     true,
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for the test
+			tmpDir := t.TempDir()
+			testStatusFile := tmpDir + "/.driver-ctr-ready"
+
+			// Create the status file if needed
+			if tt.createFile {
+				err := os.WriteFile(testStatusFile, []byte(tt.statusFileData), 0600)
+				if err != nil {
+					t.Fatalf("Failed to create test status file: %v", err)
+				}
+			}
+
+			err := validateAdditionalDriverComponents(context.Background(), testStatusFile)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateAdditionalDriverComponents() expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateAdditionalDriverComponents() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2349,18 +2349,6 @@ func TransformValidatorComponent(config *gpuv1.ClusterPolicySpec, podSpec *corev
 					setContainerEnv(&(podSpec.InitContainers[i]), env.Name, env.Value)
 				}
 			}
-		case "nvidia-fs":
-			if config.GPUDirectStorage == nil || !config.GPUDirectStorage.IsEnabled() {
-				// remove  nvidia-fs init container from validator Daemonset if GDS is not enabled
-				podSpec.InitContainers = append(podSpec.InitContainers[:i], podSpec.InitContainers[i+1:]...)
-				return nil
-			}
-		case "gdrcopy":
-			if !config.IsGDRCopyEnabled() {
-				// remove gdrcopy init container from validator Daemonset if GDRCopy is not enabled
-				podSpec.InitContainers = append(podSpec.InitContainers[:i], podSpec.InitContainers[i+1:]...)
-				return nil
-			}
 		case "cc-manager":
 			if !config.CCManager.IsEnabled() {
 				// remove  cc-manager init container from validator Daemonset if it is not enabled
@@ -3433,6 +3421,15 @@ func transformDriverContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 	}
 	if config.Driver.ReadinessProbe != nil {
 		setContainerProbe(driverContainer, config.Driver.ReadinessProbe, Readiness)
+	}
+
+	if config.GDRCopy != nil && config.GDRCopy.IsEnabled() {
+		// set env indicating gdrcopy is enabled
+		setContainerEnv(driverContainer, GDRCopyEnabledEnvName, "true")
+	}
+	if config.GPUDirectStorage != nil && config.GPUDirectStorage.IsEnabled() {
+		// set env indicating gds is enabled
+		setContainerEnv(driverContainer, GDSEnabledEnvName, "true")
 	}
 
 	if config.Driver.GPUDirectRDMA != nil && config.Driver.GPUDirectRDMA.IsEnabled() {

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -2191,45 +2191,6 @@ func TestTransformValidatorComponent(t *testing.T) {
 			}),
 		},
 		{
-			description: "nvidia-fs validation",
-			pod:         NewPod().WithInitContainer(corev1.Container{Name: "nvidia-fs-validation"}),
-			cpSpec: &gpuv1.ClusterPolicySpec{
-				Validator: gpuv1.ValidatorSpec{
-					Repository:      "nvcr.io/nvidia/cloud-native",
-					Image:           "gpu-operator-validator",
-					Version:         "v1.0.0",
-					ImagePullPolicy: "IfNotPresent",
-				},
-				GPUDirectStorage: &gpuv1.GPUDirectStorageSpec{Enabled: newBoolPtr(true)},
-			},
-			component: "nvidia-fs",
-			expectedPod: NewPod().WithInitContainer(corev1.Container{
-				Name:            "nvidia-fs-validation",
-				Image:           "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v1.0.0",
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: rootUID,
-				},
-			}),
-		},
-		{
-			description: "nvidia-fs validation is removed when gds is disabled",
-			pod: NewPod().
-				WithInitContainer(corev1.Container{Name: "nvidia-fs-validation"}).
-				WithInitContainer(corev1.Container{Name: "dummy"}),
-			cpSpec: &gpuv1.ClusterPolicySpec{
-				Validator: gpuv1.ValidatorSpec{
-					Repository:      "nvcr.io/nvidia/cloud-native",
-					Image:           "gpu-operator-validator",
-					Version:         "v1.0.0",
-					ImagePullPolicy: "IfNotPresent",
-				},
-				GPUDirectStorage: &gpuv1.GPUDirectStorageSpec{Enabled: newBoolPtr(false)},
-			},
-			component:   "nvidia-fs",
-			expectedPod: NewPod().WithInitContainer(corev1.Container{Name: "dummy"}),
-		},
-		{
 			description: "cc-manager validation",
 			pod:         NewPod().WithInitContainer(corev1.Container{Name: "cc-manager-validation"}),
 			cpSpec: &gpuv1.ClusterPolicySpec{
@@ -2642,6 +2603,16 @@ func TestTransformDriver(t *testing.T) {
 						},
 					},
 				}},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "GDRCOPY_ENABLED",
+						Value: "true",
+					},
+					{
+						Name:  "GDS_ENABLED",
+						Value: "true",
+					},
+				},
 			}).WithContainer(corev1.Container{
 				Name:  "nvidia-fs",
 				Image: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.20.5-",
@@ -3122,6 +3093,16 @@ func TestTransformDriverWithResources(t *testing.T) {
 				Resources: corev1.ResourceRequirements{
 					Requests: resources.Requests,
 					Limits:   resources.Limits,
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "GDRCOPY_ENABLED",
+						Value: "true",
+					},
+					{
+						Name:  "GDS_ENABLED",
+						Value: "true",
+					},
 				},
 			}).WithContainer(corev1.Container{
 				Name:  "nvidia-fs",

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -167,8 +209,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -201,6 +242,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /opt/config/test-file
           name: test-cm
           readOnly: true
@@ -316,6 +360,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: test-file

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -181,8 +223,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -215,6 +256,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
       hostPID: true
       imagePullSecrets:
       - name: secret-a
@@ -335,6 +379,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
   updateStrategy:
     type: OnDelete
 ---

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-openshift
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-openshift-79d6bd954f
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
@@ -198,6 +240,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: GDRCOPY_ENABLED
+          value: "true"
         - name: OPENSHIFT_VERSION
           value: "4.13"
         - name: HTTP_PROXY
@@ -237,8 +281,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -271,6 +314,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /opt/config/test-file
           name: test-cm
           readOnly: true
@@ -486,6 +532,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: test-file

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -142,6 +184,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: GDRCOPY_ENABLED
+          value: "true"
         image: nvcr.io/nvidia/driver:525.85.03-ubuntu22.04
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -167,8 +211,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -201,6 +244,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /opt/config/test-file
           name: test-cm
           readOnly: true
@@ -368,6 +414,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: test-file

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -142,6 +184,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: GDS_ENABLED
+          value: "true"
         image: nvcr.io/nvidia/driver:525.85.03-ubuntu22.04
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -167,8 +211,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -201,6 +244,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /opt/config/test-file
           name: test-cm
           readOnly: true
@@ -368,6 +414,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: test-file

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -167,8 +209,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -201,6 +242,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
       hostPID: true
       initContainers:
       - args:
@@ -307,6 +351,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
   updateStrategy:
     type: OnDelete
 ---

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-openshift
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-openshift-79d6bd954f
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
@@ -237,8 +279,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -271,6 +312,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /mnt/shared-nvidia-driver-toolkit
           name: shared-nvidia-driver-toolkit
         - mountPath: /etc/pki/ca-trust/extracted/pem
@@ -424,6 +468,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - emptyDir: {}
         name: shared-nvidia-driver-toolkit
       - configMap:

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-646cdfdb96
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -169,8 +211,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -203,6 +244,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
       hostPID: true
       initContainers:
       - args:
@@ -310,6 +354,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
   updateStrategy:
     type: OnDelete
 ---

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -171,8 +213,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -205,6 +246,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /opt/config/test-file
           name: test-cm
           readOnly: true
@@ -390,6 +434,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: test-file

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -169,8 +211,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -203,6 +244,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /opt/config/test-file
           name: test-cm
           readOnly: true
@@ -384,6 +428,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: test-file

--- a/internal/state/testdata/golden/driver-secret-env.yaml
+++ b/internal/state/testdata/golden/driver-secret-env.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -142,6 +184,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: GDS_ENABLED
+          value: "true"
+        - name: GDRCOPY_ENABLED
+          value: "true"
         envFrom:
         - secretRef:
             name: test-secret-env
@@ -170,8 +216,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -204,6 +249,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
       - args:
         - until [ -d /run/nvidia/driver/usr/src ] && lsmod | grep nvidia; do echo  Waiting
           for nvidia-driver to be installed...; sleep 10; done; exec nvidia-gds-driver
@@ -398,6 +446,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
   updateStrategy:
     type: OnDelete
 ---

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-vgpu-manager-openshift
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-vgpu-manager-openshift-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-vgpu-host-manager
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
@@ -235,6 +277,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /mnt/shared-nvidia-driver-toolkit
           name: shared-nvidia-driver-toolkit
       - args:
@@ -392,6 +437,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - emptyDir: {}
         name: shared-nvidia-driver-toolkit
   updateStrategy:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-vgpu-manager-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-vgpu-manager-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-vgpu-host-manager
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -187,6 +229,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
       hostPID: true
       initContainers:
       - args:
@@ -300,6 +345,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
   updateStrategy:
     type: OnDelete
 ---

--- a/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -167,8 +209,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -201,6 +242,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /drivers/gridd.conf
           name: licensing-config
           subPath: gridd.conf
@@ -313,6 +357,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - name: licensing-config
         secret:
           items:

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -89,6 +89,48 @@ subjects:
   name: nvidia-gpu-driver-ubuntu22.04
   namespace: test-operator
 ---
+apiVersion: v1
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"
+kind: ConfigMap
+metadata:
+  labels:
+    app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
+    app.kubernetes.io/component: nvidia-driver
+  name: nvidia-driver-startup-probe
+  namespace: test-operator
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -167,8 +209,7 @@ spec:
           exec:
             command:
             - sh
-            - -c
-            - '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready'
+            - /usr/local/bin/startup-probe.sh
           failureThreshold: 120
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -201,6 +242,9 @@ spec:
           name: sysfs-memory-online
         - mountPath: /lib/firmware
           name: nv-firmware
+        - mountPath: /usr/local/bin/startup-probe.sh
+          name: driver-startup-probe-script
+          subPath: startup-probe.sh
         - mountPath: /drivers/gridd.conf
           name: licensing-config
           subPath: gridd.conf
@@ -313,6 +357,10 @@ spec:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate
         name: nv-firmware
+      - configMap:
+          defaultMode: 493
+          name: nvidia-driver-startup-probe
+        name: driver-startup-probe-script
       - configMap:
           items:
           - key: gridd.conf

--- a/manifests/state-driver/0400_configmap.yaml
+++ b/manifests/state-driver/0400_configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-driver-startup-probe
+  namespace: {{ .Runtime.Namespace }}
+  labels:
+    app: {{ .Driver.AppName }}
+    {{- if eq .Driver.Spec.DriverType "vgpu-host-manager" }}
+    app.kubernetes.io/component: "nvidia-vgpu-host-manager"
+    {{- else }}
+    app.kubernetes.io/component: "nvidia-driver"
+    {{- end }}
+data:
+  startup-probe.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALIDATIONS_DIR="/run/nvidia/validations"
+    READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+
+    mkdir -p "${VALIDATIONS_DIR}"
+
+    if [ ! -f /sys/module/nvidia/refcnt ]; then
+      echo "NVIDIA kernel module not loaded"
+      exit 1
+    fi
+
+    if ! nvidia-smi; then
+      echo "nvidia-smi failed"
+      exit 1
+    fi
+
+    GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+    GDS_ENABLED="${GDS_ENABLED:-false}"
+    GDRCOPY_ENABLED="${GDRCOPY_ENABLED:-false}"
+
+    TMP_FILE="${READY_FILE}.tmp"
+
+    {
+      echo "GDRCOPY_ENABLED: ${GDRCOPY_ENABLED}"
+      echo "GDS_ENABLED: ${GDS_ENABLED}"
+      echo "GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED}"
+    } > "$TMP_FILE"
+
+    mv "$TMP_FILE" "$READY_FILE"

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -226,6 +226,14 @@ spec:
           value: "true"
         {{- end }}
       {{- end }}
+      {{- if and (.GDS) (deref .GDS.Spec.Enabled) }}
+        - name: GDS_ENABLED
+          value: "true"
+      {{- end }}
+      {{- if and (.GDRCopy) (deref .GDRCopy.Spec.Enabled) }}
+        - name: GDRCOPY_ENABLED
+          value: "true"
+      {{- end }}
       {{- if and (.Openshift) (.Runtime.OpenshiftVersion) }}
         - name: OPENSHIFT_VERSION
           value: {{ .Runtime.OpenshiftVersion | quote }}
@@ -303,6 +311,9 @@ spec:
             mountPath: /sys/devices/system/memory/auto_online_blocks
           - name: nv-firmware
             mountPath: /lib/firmware
+          - name: driver-startup-probe-script
+            mountPath: /usr/local/bin/startup-probe.sh
+            subPath: startup-probe.sh
           {{- if and .AdditionalConfigs .AdditionalConfigs.VolumeMounts }}
           {{- range .AdditionalConfigs.VolumeMounts }}
           - name: {{ .Name }}
@@ -331,7 +342,8 @@ spec:
         startupProbe:
           exec:
             command:
-              [sh, -c, '[ -f /sys/module/nvidia/refcnt ] && nvidia-smi && touch /run/nvidia/validations/.driver-ctr-ready']
+            - sh
+            - /usr/local/bin/startup-probe.sh
           initialDelaySeconds: {{ .Driver.Spec.StartupProbe.InitialDelaySeconds }}
           failureThreshold: {{ .Driver.Spec.StartupProbe.FailureThreshold }}
           successThreshold: {{ .Driver.Spec.StartupProbe.SuccessThreshold }}
@@ -662,6 +674,10 @@ spec:
           hostPath:
             path: /run/nvidia/driver/lib/firmware
             type: DirectoryOrCreate
+        - name: driver-startup-probe-script
+          configMap:
+            name: nvidia-driver-startup-probe
+            defaultMode: 0755
         {{- if and .AdditionalConfigs .AdditionalConfigs.Volumes }}
         {{- range .AdditionalConfigs.Volumes }}
         {{- if and .ConfigMap .ConfigMap.Items }}


### PR DESCRIPTION
## Dependencies
Depends on: https://github.com/NVIDIA/k8s-device-plugin/pull/1550

## Description

<!-- Brief description of the change, including context or motivation -->
### Problem
GPU Operator supports deploying multiple driver versions within a single Kubernetes cluster through the use of multiple NvidiaDriver custom resources (CRs). However, despite supporting multiple driver instances, the GPU Operator currently deploys only a single, cluster-wide NVIDIA Container Toolkit DaemonSet and a single NVIDIA Device Plugin DaemonSet.
This architecture introduces a limitation when different NvidiaDriver CRs enable different driver-dependent features - such as GPUDirect Storage (GDS), GDRCopy, or other optional components. Because the Container Toolkit and Device Plugin are deployed once per cluster and configured uniformly, they cannot be tailored to account for feature differences across driver instances. As a result, nodes running drivers with differing enabled features cannot be correctly or independently supported.

### Proposed solution
During reconciliation in the GPU Operator, we will inject additional driver-enablement environment variables into the nvidia-driver container based on the ClusterPolicy or NvidiaDriver CR selected for the node. The driver container will then persist these variables to the host filesystem on which it runs.
With this mechanism, each node will record a node-local view of enabled additional drivers, accurately reflecting the features configured for that node via its ClusterPolicy or NvidiaDriver CR.

We are updating the gpu-operator's driver validation logic where it will now wait for all enabled drivers to be installed first before proceeding.

Nvidia device-plugin is already resilient to missing devices or drivers and does not crash if a particular device is not present on the node. We are now updating device-plugin to always attempt discovery for all supported devices and driver features.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

- [x] Unit tests (`make coverage`)
- [x] Manual cluster testing (describe below)
- [ ] N/A or Other (docs, CI config, etc.)

**Test details:**
Manual testing done to validate the changes.

#### To test with clusterpolicy, following values.yaml was used:
```
driver:
  enabled: true
  nvidiaDriverCRD:
    enabled: false
    deployDefaultCR: false
  kernelModuleType: open
  repository: nvcr.io/nvidia
  image: driver
  version: 580.105.08
  imagePullPolicy: Always
  rdma:
    enabled: false
    useHostMofed: false
gds:
  enabled: true
  repository: nvcr.io/nvidia/cloud-native
  image: nvidia-fs
  version: "2.26.6"
  imagePullPolicy: IfNotPresent
gdrcopy:
  enabled: true
  repository: nvcr.io/nvidia/cloud-native
  image: gdrdrv
  version: "v2.5.1"
  imagePullPolicy: Always
operator:
  repository: rahulsharm810
  image: gpu-operator
  version: nvd3
  imagePullPolicy: Always
devicePlugin:
  repository: docker.io/rahulsharm810
  image: k8s-device-plugin
  version: nvd2
  imagePullPolicy: Always
cdi:
  enabled: false
validator:
  repository: rahulsharm810
  image: gpu-operator
  version: nvd3
  imagePullPolicy: Always
```

Pods after install:
```
root@test:~# kgpo
NAME                                                       READY   STATUS      RESTARTS   AGE
gpu-feature-discovery-rdcrd                                1/1     Running     0          8m54s
gpu-operator-6457b8f76d-ldm8g                              1/1     Running     0          9m20s
nvidia-container-toolkit-daemonset-v72cb                   1/1     Running     0          8m54s
nvidia-cuda-validator-6hgln                                0/1     Completed   0          6m36s
nvidia-dcgm-exporter-6f86g                                 1/1     Running     0          8m54s
nvidia-device-plugin-daemonset-7pslg                       1/1     Running     0          8m54s
nvidia-driver-daemonset-kltm9                              3/3     Running     0          9m1s
nvidia-mig-manager-62vnq                                   1/1     Running     0          8m54s
nvidia-operator-validator-7fscv                            1/1     Running     0          8m54s
nvidiagpu-node-feature-discovery-gc-6d484cd547-sfgd5       1/1     Running     0          9m20s
nvidiagpu-node-feature-discovery-master-7d466cdd75-mg6nq   1/1     Running     0          9m20s
nvidiagpu-node-feature-discovery-worker-ltv95              1/1     Running     0          9m20s
root@test:~# cat /run/nvidia/driver/.additional-drivers-flags
GDRCOPY_ENABLED: true
GDS_ENABLED: true
GPU_DIRECT_RDMA_ENABLED: false
root@test:~#
```

#### Testing with nvidiadriver CR:

values.yaml file:
```
driver:
  enabled: true
  nvidiaDriverCRD:
    enabled: false
    deployDefaultCR: false
operator:
  repository: rahulsharm810
  image: gpu-operator
  version: nvd2
  imagePullPolicy: Always
devicePlugin:
  repository: docker.io/rahulsharm810
  image: k8s-device-plugin
  version: nvd2
  imagePullPolicy: Always
cdi:
  enabled: false
validator:
  repository: rahulsharm810
  image: gpu-operator
  version: nvd2
  imagePullPolicy: Always
```

nvidiadriver CRD installed using:
```
kind: NVIDIADriver
metadata:
  name: demo-test
spec:
  driverType: gpu
  gdrcopy:
    enabled: true
    repository: nvcr.io/nvidia/cloud-native
    image: gdrdrv
    version: v2.5.1
    imagePullPolicy: IfNotPresent
    imagePullSecrets: []
    env: []
    args: []
  kernelModuleType: open
  rdma:
    enabled: false
    useHostMofed: false
  gds:
    enabled: false
    repository: nvcr.io/nvidia/cloud-native
    image: nvidia-fs
    version: "2.26.6"
    imagePullPolicy: IfNotPresent
  startupProbe:
    failureThreshold: 120
    initialDelaySeconds: 60
    periodSeconds: 10
    timeoutSeconds: 60
  image: driver
  repository: nvcr.io/nvidia
  imagePullPolicy: Always
  version: 580.105.08
  usePrecompiled: false
```

Status after install:
```
root@test:~# kgpo
NAME                                                       READY   STATUS      RESTARTS   AGE
gpu-feature-discovery-j8nlg                                1/1     Running     0          34m
gpu-operator-6457b8f76d-vtzbj                              1/1     Running     0          36m
nvidia-container-toolkit-daemonset-9hzvt                   1/1     Running     0          34m
nvidia-cuda-validator-8h769                                0/1     Completed   0          33m
nvidia-dcgm-exporter-2rzzf                                 1/1     Running     0          34m
nvidia-device-plugin-daemonset-v7fzj                       1/1     Running     0          34m
nvidia-gpu-driver-ubuntu24.04-6585477fb6-c4pm2             2/2     Running     0          35m
nvidia-mig-manager-s7m5q                                   1/1     Running     0          32m
nvidia-operator-validator-4sr4t                            1/1     Running     0          34m
nvidiagpu-node-feature-discovery-gc-6d484cd547-bc8k6       1/1     Running     0          36m
nvidiagpu-node-feature-discovery-master-7d466cdd75-vfqg2   1/1     Running     0          36m
nvidiagpu-node-feature-discovery-worker-cx8r9              1/1     Running     0          36m
root@test:~# cat /run/nvidia/driver/.additional-drivers-flags
GDRCOPY_ENABLED: true
GDS_ENABLED: false
GPU_DIRECT_RDMA_ENABLED: false
root@test:~#
```

CDI was enabled/disabled in both the tests to make sure it works with/without CDI.