### PR TITLE
Add GitHub issue templates for RFEs and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+---
+name: Feature request
+about: Submit a feature request
+title: "[Feature]: "
+labels: ["feature", "lifecycle/frozen"]
+---
+
+<!-- A clear and concise description of the feature request. Please outline the motivation for the proposal. Is your feature request related to a specific problem? e.g., *"I'm working on X and would like Y to be possible"*. If this is related to another GitHub issue, please link it here too. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Question
+about: Ask a question
+title: "[Question]: "
+labels: ["question"]
+---
+
+<!-- Ask question(s) related to GPU Operator -->


### PR DESCRIPTION
## Description

This PR adds two GitHub issue templates, one for feature requests and one for questions. I purposely kept these templates as minimal as possible. The primary benefit of adding such templates is that labels, like `feature` or `question`, get automatically added to issues created with the corresponding template.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

I created dummy issues using these templates on my fork:
https://github.com/cdesiniotis/gpu-operator/issues/8
https://github.com/cdesiniotis/gpu-operator/issues/9

