### PR TITLE
refactor driverRenderData to only include fields needed for template render

### DIFF
--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -645,8 +645,7 @@ func getMinimalDriverRenderData() *driverRenderData {
 			OSVersion:        "ubuntu22.04",
 		},
 		Runtime: &driverRuntimeSpec{
-			Namespace:         "test-operator",
-			KubernetesVersion: "1.28.0",
+			Namespace: "test-operator",
 		},
 		HostRoot: "",
 	}

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -29,13 +29,12 @@ type SyncingSource source.SyncingSource
 // driverSpec is a wrapper of NVIDIADriverSpec with an additional ImagePath field
 // which is to be populated with the fully-qualified image path.
 type driverSpec struct {
-	Spec              *nvidiav1alpha1.NVIDIADriverSpec
-	AppName           string
-	Name              string
-	ImagePath         string
-	ManagerImagePath  string
-	OCPToolkitEnabled bool
-	OSVersion         string
+	Spec             *nvidiav1alpha1.NVIDIADriverSpec
+	AppName          string
+	Name             string
+	ImagePath        string
+	ManagerImagePath string
+	OSVersion        string
 }
 
 // gdsDriverSpec is a wrapper of GPUDirectStorageSpec with an additional ImagePath field


### PR DESCRIPTION
This PR removes fields from the `driverRenderData` struct that aren't used to render the templated YAMLs. This PR also removes unused code