### PR TITLE
add nfd rules for additional nvidia drivers on nodes

### DIFF
--- a/deployments/gpu-operator/templates/nodefeaturerules.yaml
+++ b/deployments/gpu-operator/templates/nodefeaturerules.yaml
@@ -103,5 +103,36 @@ spec:
             matchExpressions:
               nvidia.com/gpu.family: {op: In, value: ["hopper"]}
               tdx.enabled: {op: IsTrue}
+---
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: nvidia-kernel-modules
+spec:
+  rules:
+    - name: kernel-module-gdrdrv
+      labels:
+        nvidia.com/gdrcopy.capable: "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            gdrdrv:
+              op: Exists
+    - name: kernel-module-nvidia_fs
+      labels:
+        nvidia.com/gds.capable: "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            nvidia_fs:
+              op: Exists
+    - name: kernel-module-nvidia_peermem
+      labels:
+        nvidia.com/peermem.capable: "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            nvidia_peermem:
+              op: Exists
 {{- end }}
 


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This PR adds additional nodefeaturerules which will label the node about the additional nvidia drivers installed on the node.
With nvidiaDriver CR, we would like to have the ability to target workloads to certain nodes which has the additional driver installed. This PR adds nodefeaturerules which will add labels to nodes based on the drivers status.
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->
Deployed a cluster with the following nfd rules and having gdrcopy and gds true. Here is the output of node labels after install:
```
k get node 2u2g-gen-0409 -o json | jq .metadata.labels | grep "gpu.driver."
  "nvidia.com/gpu-driver-upgrade-state": "upgrade-done",
  "nvidia.com/gdrcopy.capable": "true",
  "nvidia.com/gds.capable": "true",
```
