### PR TITLE
remove unused transform methods in object_control.go

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -997,14 +997,8 @@ func TransformDCGMExporterService(obj *corev1.Service, config *gpuv1.ClusterPoli
 
 // TransformDriver transforms Nvidia driver daemonset with required config as per ClusterPolicy
 func TransformDriver(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n ClusterPolicyController) error {
-	// update validation container
-	err := transformValidationInitContainer(obj, config)
-	if err != nil {
-		return err
-	}
-
 	// update driver-manager initContainer
-	err = transformDriverManagerInitContainer(obj, &config.Driver.Manager, config.Driver.GPUDirectRDMA)
+	err := transformDriverManagerInitContainer(obj, &config.Driver.Manager, config.Driver.GPUDirectRDMA)
 	if err != nil {
 		return err
 	}
@@ -2416,12 +2410,6 @@ func TransformValidatorComponent(config *gpuv1.ClusterPolicySpec, podSpec *corev
 
 // TransformNodeStatusExporter transforms the node-status-exporter daemonset with required config as per ClusterPolicy
 func TransformNodeStatusExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n ClusterPolicyController) error {
-	// update validation container
-	err := transformValidationInitContainer(obj, config)
-	if err != nil {
-		return err
-	}
-
 	// update image
 	image, err := gpuv1.ImagePath(&config.NodeStatusExporter)
 	if err != nil {


### PR DESCRIPTION
This PR removes unnecessary invocations of the `transformValidationInitContainer` method. The driver and node-status-exporter daemonsets don't have an `*validation` init containers, so the aforementioned transform method can be removed