### PR TITLE
add Certificate location for SUSE products

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -206,11 +206,13 @@ var RepoConfigPathMap = map[string]string{
 // Where OCP mounts proxy certs on RHCOS nodes:
 // https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/authentication/ocp-certificates#proxy-certificates_ocp-certificates
 var CertConfigPathMap = map[string]string{
-	"centos": "/etc/pki/ca-trust/extracted/pem",
-	"debian": "/usr/local/share/ca-certificates",
-	"ubuntu": "/usr/local/share/ca-certificates",
-	"rhcos":  "/etc/pki/ca-trust/extracted/pem",
-	"rhel":   "/etc/pki/ca-trust/extracted/pem",
+	"centos":   "/etc/pki/ca-trust/extracted/pem",
+	"debian":   "/usr/local/share/ca-certificates",
+	"ubuntu":   "/usr/local/share/ca-certificates",
+	"rhcos":    "/etc/pki/ca-trust/extracted/pem",
+	"rhel":     "/etc/pki/ca-trust/extracted/pem",
+	"sles":     "/etc/pki/trust/anchors",
+	"sl-micro": "/etc/pki/trust/anchors",
 }
 
 // MountPathToVolumeSource maps a container mount path to a VolumeSource

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -1461,3 +1461,21 @@ func TestParseOSReleaseFromFile(t *testing.T) {
 		require.True(t, os.IsNotExist(err))
 	})
 }
+
+func TestCertConfigPathMap(t *testing.T) {
+	expectedPaths := map[string]string{
+		"centos":   "/etc/pki/ca-trust/extracted/pem",
+		"debian":   "/usr/local/share/ca-certificates",
+		"ubuntu":   "/usr/local/share/ca-certificates",
+		"rhcos":    "/etc/pki/ca-trust/extracted/pem",
+		"rhel":     "/etc/pki/ca-trust/extracted/pem",
+		"sles":     "/etc/pki/trust/anchors",
+		"sl-micro": "/etc/pki/trust/anchors",
+	}
+
+	for os, expectedPath := range expectedPaths {
+		path, ok := CertConfigPathMap[os]
+		require.True(t, ok, "OS %s not found in CertConfigPathMap", os)
+		require.Equal(t, expectedPath, path, "Incorrect path for OS %s", os)
+	}
+}

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -44,11 +44,13 @@ var RepoConfigPathMap = map[string]string{
 // Where OCP mounts proxy certs on RHCOS nodes:
 // https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/authentication/ocp-certificates#proxy-certificates_ocp-certificates
 var CertConfigPathMap = map[string]string{
-	"centos": "/etc/pki/ca-trust/extracted/pem",
-	"debian": "/usr/local/share/ca-certificates",
-	"ubuntu": "/usr/local/share/ca-certificates",
-	"rhcos":  "/etc/pki/ca-trust/extracted/pem",
-	"rhel":   "/etc/pki/ca-trust/extracted/pem",
+	"centos":   "/etc/pki/ca-trust/extracted/pem",
+	"debian":   "/usr/local/share/ca-certificates",
+	"ubuntu":   "/usr/local/share/ca-certificates",
+	"rhcos":    "/etc/pki/ca-trust/extracted/pem",
+	"rhel":     "/etc/pki/ca-trust/extracted/pem",
+	"sles":     "/etc/pki/trust/anchors",
+	"sl-micro": "/etc/pki/trust/anchors",
 }
 
 // MountPathToVolumeSource maps a container mount path to a VolumeSource


### PR DESCRIPTION
## Description

Add support to specify additional certificates for SUSE products

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

It was tested on k3s cluster with nvidia hardware

