### PR TITLE
add repository location for SUSE products

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -194,11 +194,13 @@ var rootUID = ptr.To(int64(0))
 
 // RepoConfigPathMap indicates standard OS specific paths for repository configuration files
 var RepoConfigPathMap = map[string]string{
-	"centos": "/etc/yum.repos.d",
-	"debian": "/etc/apt/sources.list.d",
-	"ubuntu": "/etc/apt/sources.list.d",
-	"rhcos":  "/etc/yum.repos.d",
-	"rhel":   "/etc/yum.repos.d",
+	"centos":   "/etc/yum.repos.d",
+	"debian":   "/etc/apt/sources.list.d",
+	"ubuntu":   "/etc/apt/sources.list.d",
+	"rhcos":    "/etc/yum.repos.d",
+	"rhel":     "/etc/yum.repos.d",
+	"sles":     "/etc/zypp/repos.d",
+	"sl-micro": "/etc/zypp/repos.d",
 }
 
 // CertConfigPathMap indicates standard OS specific paths for ssl keys/certificates.

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -1479,3 +1479,19 @@ func TestCertConfigPathMap(t *testing.T) {
 		require.Equal(t, expectedPath, path, "Incorrect path for OS %s", os)
 	}
 }
+
+func TestRepoConfigPathMap(t *testing.T) {
+	expected := map[string]string{
+		"ubuntu":   "/etc/apt/sources.list.d",
+		"rhcos":    "/etc/yum.repos.d",
+		"rhel":     "/etc/yum.repos.d",
+		"sles":     "/etc/zypp/repos.d",
+		"sl-micro": "/etc/zypp/repos.d",
+	}
+
+	for os, path := range expected {
+		val, ok := RepoConfigPathMap[os]
+		require.True(t, ok, "Expected %s to be in RepoConfigPathMap", os)
+		require.Equal(t, path, val, "Expected path for %s to be %s", os, path)
+	}
+}

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -32,11 +32,13 @@ import (
 
 // RepoConfigPathMap indicates standard OS specific paths for repository configuration files
 var RepoConfigPathMap = map[string]string{
-	"centos": "/etc/yum.repos.d",
-	"debian": "/etc/apt/sources.list.d",
-	"ubuntu": "/etc/apt/sources.list.d",
-	"rhcos":  "/etc/yum.repos.d",
-	"rhel":   "/etc/yum.repos.d",
+	"centos":   "/etc/yum.repos.d",
+	"debian":   "/etc/apt/sources.list.d",
+	"ubuntu":   "/etc/apt/sources.list.d",
+	"rhcos":    "/etc/yum.repos.d",
+	"rhel":     "/etc/yum.repos.d",
+	"sles":     "/etc/zypp/repos.d",
+	"sl-micro": "/etc/zypp/repos.d",
 }
 
 // CertConfigPathMap indicates standard OS specific paths for ssl keys/certificates.


### PR DESCRIPTION
## Description

Add SUSE repositories location to the operator

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Unit test added and manually tested on k3s cluster

