### PR TITLE
fix: add missing namespace to serviceaccount

### DIFF
--- a/deployments/gpu-operator/templates/upgrade_crd.yaml
+++ b/deployments/gpu-operator/templates/upgrade_crd.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gpu-operator-upgrade-crd-hook-sa
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation


### PR DESCRIPTION


## Description

This missing namespace prevents the operator from being deployed with argocd and helmfile in some cases. ServiceAccounts are a namespaced resource so it's best to always specify it.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

