### PR TITLE
ensure /lib/modules is available for driver container on SUSE products

### DIFF
--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -209,6 +209,28 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 				additionalCfgs.Volumes = append(additionalCfgs.Volumes, subscriptionVol)
 			}
 		}
+
+		// Mount /lib/modules for SLES/SL-Micro
+		if pool.osRelease == "sles" || pool.osRelease == "sl-micro" {
+			logger.Info("Mounting /lib/modules into the driver container", "OS", pool.osRelease)
+			libModulesVolMount := corev1.VolumeMount{
+				Name:      "lib-modules",
+				MountPath: "/run/host/lib/modules",
+				ReadOnly:  true,
+			}
+			additionalCfgs.VolumeMounts = append(additionalCfgs.VolumeMounts, libModulesVolMount)
+
+			libModulesVol := corev1.Volume{
+				Name: "lib-modules",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/lib/modules",
+						Type: ptr.To(corev1.HostPathDirectory),
+					},
+				},
+			}
+			additionalCfgs.Volumes = append(additionalCfgs.Volumes, libModulesVol)
+		}
 	}
 
 	// mount any custom kernel module configuration parameters at /drivers


### PR DESCRIPTION
This will ensure driver container built by SUSE has access to host kernel modules.

## Description

This is needed for upcoming flavor of driver container for SLES which can use underlying host kernel modules without the need to have the entire kernel part of the driver container.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Unit test added and tested on a k3s cluster running SLES 15 SP7

