### PR TITLE
[state-toolkit] expose the namespace as an envar for the main toolkit container

### DIFF
--- a/assets/state-container-toolkit/0500_daemonset.yaml
+++ b/assets/state-container-toolkit/0500_daemonset.yaml
@@ -71,6 +71,10 @@ spec:
           value: "void"
         - name: TOOLKIT_PID_FILE
           value: "/run/nvidia/toolkit/toolkit.pid"
+        - name: NRI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         imagePullPolicy: IfNotPresent
         name: nvidia-container-toolkit-ctr
         securityContext:


### PR DESCRIPTION
This change allows the namespace to be retrieved by the toolkit container at runtime when instantiating the NRI plugin server