### PR TITLE
bump node-feature-discovery to v0.18.3

### DIFF
--- a/deployments/gpu-operator/Chart.lock
+++ b/deployments/gpu-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: node-feature-discovery
   repository: oci://registry.k8s.io/nfd/charts
-  version: 0.18.2
-digest: sha256:bdac9b82fd18d5a427bf182287702777dccaadf6c539974be82199f2d8958344
-generated: "2025-10-23T23:35:36.647835-07:00"
+  version: 0.18.3
+digest: sha256:1bce3b80da1e6d47a0befbaa6a2f758aeac6d20382e900f0c301f45020afbebc
+generated: "2026-01-23T15:08:56.617442-08:00"

--- a/deployments/gpu-operator/Chart.yaml
+++ b/deployments/gpu-operator/Chart.yaml
@@ -19,6 +19,6 @@ keywords:
 
 dependencies:
   - name: node-feature-discovery
-    version: 0.18.2
+    version: 0.18.3
     repository: oci://registry.k8s.io/nfd/charts
     condition: nfd.enabled

--- a/deployments/gpu-operator/charts/node-feature-discovery/Chart.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.18.2
+appVersion: v0.18.3
 description: 'Detects hardware features available on each node in a Kubernetes cluster,
   and advertises those features using node labels. '
 home: https://github.com/kubernetes-sigs/node-feature-discovery
@@ -12,4 +12,4 @@ name: node-feature-discovery
 sources:
 - https://github.com/kubernetes-sigs/node-feature-discovery
 type: application
-version: 0.18.2
+version: 0.18.3


### PR DESCRIPTION
Details for the new NFD release can be found [here](https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.18.3)
