### PR TITLE
[gpu-feature-discovery] disable nodefeature API for openshift clusters

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -940,6 +940,12 @@ func TransformGPUDiscoveryPlugin(obj *appsv1.DaemonSet, config *gpuv1.ClusterPol
 		obj.Spec.Template.Spec.Containers[0].Args = config.GPUFeatureDiscovery.Args
 	}
 
+	// If we are on an OpenShift cluster, we disable the NodeFeature API as a node feature label source
+	// We can remove this once OpenShift's NFD instances start supporting the NodeFeature API
+	if len(n.openshift) > 0 {
+		setContainerEnv(&(obj.Spec.Template.Spec.Containers[0]), "USE_NODE_FEATURE_API", "false")
+	}
+
 	// set/append environment variables for exporter container
 	if len(config.GPUFeatureDiscovery.Env) > 0 {
 		for _, env := range config.GPUFeatureDiscovery.Env {


### PR DESCRIPTION
This change is needed to unblock GFD in OpenShift clusters. 

With the recent change in GFD where the NodeFeature API was [enabled](https://github.com/NVIDIA/k8s-device-plugin/pull/1504/files) by default, we observed that the latest GFD images were not writing the gpu feature labels to the node on OpenShift clusters. After further analysis, we found that the NFD that comes in OpenShift clusters still leverage gRPC as opposed to the `NodeFeature` Custom Resource