### PR TITLE
Add ability to pass 'dnsConfig' and 'securityContext' attributes in the 'operator' deployment resource.

### DIFF
--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -78,6 +78,17 @@ spec:
         ports:
           - name: metrics
             containerPort: 8080
+    {{- if .Values.operator.dnsPolicy }}
+      dnsPolicy: {{ .Values.operator.dnsPolicy }}
+      {{- end }}
+    {{- with .Values.operator.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.operator.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -115,6 +115,9 @@ operator:
     requests:
       cpu: 200m
       memory: 100Mi
+  dnsPolicy: ""
+  dnsConfig: {}
+  securityContext: {}
   # metrics:
   #   serviceMonitor:
   #     interval: 15s


### PR DESCRIPTION
Fixes #2070 

## Description

- Add ability to pass 'dnsConfig' and 'securityContext' attributes in the 'operator' deployment resource.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Tested out by rendering out all options ( Fields set, fields unset, rendering both options ) 
