### PR TITLE
update tests/e2e/go.mod to be in sync with the main go module

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/gpu-operator/tests/e2e
 
-go 1.25.0
+go 1.25.3
 
 require (
 	github.com/NVIDIA/gpu-operator v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
This PR fixes the `make check` failure observed after #2061 was merged

See [here](https://github.com/NVIDIA/gpu-operator/actions/runs/21370340268/job/61513122210) for more information