### PR TITLE
fix: eliminate hardcoded command names(move to distroless)

### DIFF
--- a/assets/state-cc-manager/0500_daemonset.yaml
+++ b/assets/state-cc-manager/0500_daemonset.yaml
@@ -27,7 +27,6 @@ spec:
         - name: nvidia-cc-manager
           image: "FILLED BY THE OPERATOR"
           imagePullPolicy: IfNotPresent
-          command: ["k8s-cc-manager"]
           env:
           - name: NODE_NAME
             valueFrom:
@@ -56,7 +55,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.cc-manager-ctr-ready"]
+                command: ["/bin/rm", "-f", "/run/nvidia/validations/.cc-manager-ctr-ready"]
       terminationGracePeriodSeconds: 30
       volumes:
         - name: host-sys

--- a/assets/state-sandbox-device-plugin/0500_daemonset.yaml
+++ b/assets/state-sandbox-device-plugin/0500_daemonset.yaml
@@ -61,7 +61,6 @@ spec:
         - image: "FILLED BY THE OPERATOR"
           imagePullPolicy: IfNotPresent
           name: nvidia-sandbox-device-plugin-ctr
-          command: ["nvidia-kubevirt-gpu-device-plugin"]
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
## Description

Some of the operands viz. cc-manager and sandbox device plugin have their commands hardcoded. This causes problems, e.g. when we move to python or make a command name change for any reason. Instead, we want to let the Dockerfile specify the entrypoint. This is needed for moving to distroless. Also, updated the preStop hook not to use shell, consistent with distroless.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Manual testing on a cluster. Verified preStop lifecycle hook as well.

