### PR TITLE
new privileges for sandbox-device-plugin

### DIFF
--- a/assets/state-sandbox-device-plugin/0200_role.yaml
+++ b/assets/state-sandbox-device-plugin/0200_role.yaml
@@ -12,3 +12,22 @@ rules:
   - use
   resourceNames:
   - privileged
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/assets/state-sandbox-device-plugin/0500_daemonset.yaml
+++ b/assets/state-sandbox-device-plugin/0500_daemonset.yaml
@@ -61,6 +61,17 @@ spec:
         - image: "FILLED BY THE OPERATOR"
           imagePullPolicy: IfNotPresent
           name: nvidia-sandbox-device-plugin-ctr
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION

## Description

sandbox-device-plugin will launch the GFD job within the sandbox env, so we need new privileges for it to do so
Changes:
- add CRUD privileges for jobs to Role
- add NODE_NAME/POD_NAMESPACE info so that the device plugin can launch job on its own node

GFD launch PR in sandbox-device-plugin: https://github.com/NVIDIA/sandbox-device-plugin/pull/30

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Manual testing on cluster

