### PR TITLE
Add env variable to signal skip vfio-pci unbind

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2105,6 +2105,13 @@ func TransformVFIOManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec
 		return fmt.Errorf("failed to transform k8s-driver-manager initContainer for VFIO Manager: %v", err)
 	}
 
+	// Used to determine if GPUs are already bound to vfio-pci (avoids disrupting active VM workloads)
+	// Set to gpuWorkloadConfigVMPassthrough since VFIO Manager only runs on vm-passthrough nodes.
+	driverManagerContainer := findContainerByName(obj.Spec.Template.Spec.InitContainers, "k8s-driver-manager")
+	if driverManagerContainer != nil {
+		setContainerEnv(driverManagerContainer, "GPU_WORKLOAD_CONFIG", gpuWorkloadConfigVMPassthrough)
+	}
+
 	// update image
 	image, err := gpuv1.ImagePath(&config.VFIOManager)
 	if err != nil {


### PR DESCRIPTION
Relevant PR: https://github.com/NVIDIA/k8s-driver-manager/pull/146

## Description

Pass `GPU_WORKLOAD_CONFIG` environment variable to `k8s-driver-manager` init container in `vfio-manager` DaemonSet to prevent unnecessary GPU unbind/rebind operations during rolling updates. 

### Problem

During rolling updates of the `vfio-manager` DaemonSet, `k8s-driver-manager `unconditionally unbinds all GPUs from vfio-pci on startup. When the desired state is already vfio-pci binding, this causes unnecessary disruption to active VM workloads using GPU passthrough (KubeVirt, Kata Containers).

### Design Rationale

We know that **vfio-manager only runs on vm-passthrough nodes**: The DaemonSet's nodeSelector requires `nvidia.com/gpu.deploy.vfio-manager: "true"`, which is only set for `gpuWorkloadConfigVMPassthrough` nodes. This is true regardless of whether the workload config comes from an explicit node label or `sandboxWorkloads.defaultWorkload`.  

## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [X] Lint checks passing (`make lint`)
- [X] Generated assets in-sync (`make validate-generated-assets`)
- [X] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths