### PR TITLE
Tighten / remove nodes/proxy GET permission for NFD in the helm chart

### DIFF
--- a/deployments/gpu-operator/charts/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/charts/node-feature-discovery/templates/clusterrole.yaml
@@ -82,7 +82,7 @@ rules:
 - apiGroups:
     - ""
   resources:
-    - nodes/proxy
+    - nodes/configz
   verbs:
     - get
 - apiGroups:
@@ -117,12 +117,6 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes/proxy
-  verbs:
-  - get
 - apiGroups:
   - topology.node.k8s.io
   resources:


### PR DESCRIPTION
## Description

Update `nodes/proxy` GET permission for NFD component in the helm chart. I take great reference from PR https://github.com/kubernetes-sigs/node-feature-discovery-operator/pull/266

Fixing https://github.com/NVIDIA/gpu-operator/issues/2074
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)


