### PR TITLE
Add pod label enrichment support to DCGM Exporter

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -949,6 +949,13 @@ type DCGMExporterSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="HPC Job Mapping Configuration"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	HPCJobMapping *DCGMExporterHPCJobMappingConfig `json:"hpcJobMapping,omitempty"`
+
+	// Optional: Pod metrics enrichment configuration for DCGM Exporter
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Pod Metrics Configuration"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	PodMetrics *DCGMExporterPodMetricsConfig `json:"podMetrics,omitempty"`
 }
 
 // DCGMExporterHPCJobMappingConfig defines HPC job mapping configuration for NVIDIA DCGM Exporter
@@ -967,6 +974,18 @@ type DCGMExporterHPCJobMappingConfig struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Job Mapping Directory"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	Directory string `json:"directory,omitempty"`
+}
+
+// DCGMExporterPodMetricsConfig defines pod metrics enrichment configuration for DCGM Exporter
+type DCGMExporterPodMetricsConfig struct {
+	// EnablePodLabels enables Kubernetes pod labels in metrics.
+	// When enabled, metrics will include labels from pods using GPUs.
+	// This requires cluster-wide read permissions to pods.
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Enable Pod Labels in Metrics"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	EnablePodLabels *bool `json:"enablePodLabels,omitempty"`
 }
 
 // DCGMExporterMetricsConfig defines metrics to be collected by NVIDIA DCGM Exporter
@@ -2013,6 +2032,14 @@ func (e *DCGMExporterSpec) GetHPCJobMappingDirectory() string {
 		return ""
 	}
 	return e.HPCJobMapping.Directory
+}
+
+// IsPodLabelsEnabled returns true if pod label enrichment is enabled for DCGM Exporter
+func (e *DCGMExporterSpec) IsPodLabelsEnabled() bool {
+	if e.PodMetrics == nil || e.PodMetrics.EnablePodLabels == nil {
+		return false
+	}
+	return *e.PodMetrics.EnablePodLabels
 }
 
 // IsEnabled returns true if gpu-feature-discovery is enabled(default) through gpu-operator

--- a/assets/state-dcgm-exporter/0210_clusterrole.yaml
+++ b/assets/state-dcgm-exporter/0210_clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nvidia-dcgm-exporter
+  labels:
+    app: nvidia-dcgm-exporter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/assets/state-dcgm-exporter/0220_clusterrolebinding.yaml
+++ b/assets/state-dcgm-exporter/0220_clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nvidia-dcgm-exporter
+  labels:
+    app: nvidia-dcgm-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nvidia-dcgm-exporter
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dcgm-exporter
+  namespace: "FILLED BY THE OPERATOR"

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -551,6 +551,9 @@ spec:
     {{- if .Values.dcgmExporter.hpcJobMapping }}
     hpcJobMapping: {{ toYaml .Values.dcgmExporter.hpcJobMapping | nindent 6 }}
     {{- end }}
+    {{- if .Values.dcgmExporter.podMetrics }}
+    podMetrics: {{ toYaml .Values.dcgmExporter.podMetrics | nindent 6 }}
+    {{- end }}
   gfd:
     enabled: {{ .Values.gfd.enabled }}
     {{- if .Values.gfd.repository }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -285,6 +285,11 @@ dcgmExporter:
   # hpcJobMapping:
   #   enabled: true
   #   directory: /var/lib/dcgm-exporter/job-mapping
+  # Pod metrics enrichment settings
+  podMetrics:
+    # Enable pod labels in metrics. When enabled, metrics will include labels from pods using GPUs.
+    # This requires cluster-wide read permissions to pods.
+    enablePodLabels: false
   service:
     internalTrafficPolicy: Cluster
   serviceMonitor:


### PR DESCRIPTION
Addresses #2009.

## Description

Add support for pod label enrichment in DCGM Exporter metrics. When enabled, GPU metrics will include labels from the pods using those GPUs.

This feature adds:
- New `dcgmExporter.podMetrics.enablePodLabels` configuration option
- ClusterRole and ClusterRoleBinding for cluster-wide pod read access (conditionally created)
- Automatic ServiceAccount token mounting when enabled
- `DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS` environment variable injection

The feature is **opt-in** (disabled by default) since it grants cluster-wide pod read permissions.

### Usage

```
dcgmExporter:
  podMetrics:
    enablePodLabels: true
```


In draft, needs to be tested.