### PR TITLE
fix: device plugin needs update rights to nodefeatures

### DIFF
--- a/assets/state-sandbox-device-plugin/0200_role.yaml
+++ b/assets/state-sandbox-device-plugin/0200_role.yaml
@@ -31,3 +31,4 @@ rules:
   - get
   - list
   - watch
+  - update


### PR DESCRIPTION

## Description

If the device plugin restarts, it will attempt to update the existing nodefeatures object
Also need to update the nodefeatures object for the 'gpu.count' label

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Manual testing
