### PR TITLE
[Perf] Update labelGPUNodes() to reset updateLabels inside loop

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -488,11 +488,10 @@ func (n *ClusterPolicyController) labelGPUNodes() (bool, int, error) {
 	}
 
 	clusterHasNFDLabels := false
-	updateLabels := false
 	gpuNodesTotal := 0
 	for _, node := range list.Items {
 		node := node
-
+		updateLabels := false
 		nodeOriginal := node.DeepCopy()
 		// get node labels
 		labels := node.GetLabels()


### PR DESCRIPTION
As a golden rule of performance, we should never do work that is not necessary. In the current implementation where updateLabels is declared outside the for loop, if updateLabels becomes true for the first node in a large GPU cluster, it triggers a PATCH request to the API for every subsequent node even when not necessary. This maybe a cheap call but we should never do work that is not necessary. Moving updateLabels inside of the for loop, reduces APi calls and load, along with improving reconcilliation time.

## Description

<!-- Brief description of the change, including context or motivation -->

## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [X] Lint checks passing (`make lint`)
- [X] Generated assets in-sync (`make validate-generated-assets`)
- [X] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

