### PR TITLE
fix: prevent dcgm-exporter pod from being bound to other SCC objects

### DIFF
--- a/assets/state-dcgm-exporter/0200_role.yaml
+++ b/assets/state-dcgm-exporter/0200_role.yaml
@@ -12,6 +12,8 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+  resourceNames:
+  - privileged
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
On OpenShift, we deploy a custom Security Context Constraint (SCC) object for dcgm-exporter. The intent is for this SCC object to define what permissions the dcgm-exporter pod is allowed to run with.

There is a bug where the dcgm-exporter pod gets bound to another SCC object, not the one named 'nvidia-dcgm-exporter' which the GPU Operator creates. For example, on an OpenShift environment I see:

```
$ oc get $(oc get pod -oname -l app=nvidia-dcgm-exporter) -o yaml | grep openshift.io/scc
    openshift.io/scc: lvms-vgmanager
```

The root cause lies in the dcgm-exporter Role -- the dcgm-exporter service account can use any SCC because of the missing 'resourceNames' restriction. As a result, OpenShift's SCC admission controller can select another SCC that is more restrictive than the 'nvidia-dcgm-exporter' SCC but still satisfies the pod's security requirements.

This commit updates the dcgm-exporter Role object so that it can only use the 'privileged' SCC (and not all SCCs). This change was made to align the dcgm-exporter Role object with other operands, like dcgm / gpu-feature-discovery / device-plugin, etc. who also have permissions to use the 'privileged' SCC.

In a follow-up, we should explore the possibility of removing this permission from our Role objects entirely. The SCCs that the gpu-operator creates specify the service accounts that can use them, so there should be no need to specify permissions to use specific SCCs in the operand's Role objects.
