### PR TITLE
Update distroless base image to v4.0.1 to fix CVE-2025-15467

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/v${
 
 # The C/C++ distroless image is used as a base since the CUDA vectorAdd
 # sample application depends on C/C++ libraries.
-FROM nvcr.io/nvidia/distroless/cc:v4.0.1-dev
+FROM nvcr.io/nvidia/distroless/cc:v4.0.1
 
 ENV NVIDIA_VISIBLE_DEVICES=void
 


### PR DESCRIPTION
## Description
Moving from a -dev pre-release tag to a stable tag also fixes Dependabot
not proposing stable version updates. Dependabot's Docker ecosystem uses
semver to compare tags, and when the current tag has a pre-release
suffix (e.g. -dev), it stays on the same release channel and only
proposes updates to other pre-release tags. By switching to a stable tag
(v4.0.1), Dependabot will now track future stable releases (v4.0.2,
v4.1.0, etc.).

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->
