### PR TITLE
[fix] : add labels and annotations to daemonset metadata when provisioned by nvidiadriver

### DIFF
--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -135,10 +135,14 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
+    custom-annotation-1: custom-value-1
+    custom-annotation-2: custom-value-2
     openshift.io/scc: nvidia-gpu-driver-ubuntu22.04
   labels:
     app: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b
     app.kubernetes.io/component: nvidia-driver
+    custom-label-1: custom-value-1
+    custom-label-2: custom-value-2
     nvidia.com/node.os-version: ubuntu22.04
     nvidia.com/precompiled: "false"
   name: nvidia-gpu-driver-ubuntu22.04-7c6d7bd86b

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -20,10 +20,16 @@ metadata:
     openshift.driver-toolkit.rhcos-image-missing: "true"
     {{- end }}
     {{- end }}
+    {{- if .Driver.Spec.Labels }}
+    {{- .Driver.Spec.Labels | yaml | nindent 4 }}
+    {{- end }}
   name: {{ .Driver.AppName }}
   namespace: {{ .Runtime.Namespace }}
   annotations:
     openshift.io/scc: {{ .Driver.Name }}
+    {{- if .Driver.Spec.Annotations }}
+    {{- .Driver.Spec.Annotations | yaml | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
For clusterpolicy, labels and annotations are applied to both daemonset metadata and pod template. We need to match the clusterpolicy behavior for nvidiadriver managed daemonset as well.

## Description
For daemonsets created by clusterpolicy, we add the labels to daemonset here:
https://github.com/NVIDIA/gpu-operator/blob/v25.10.1/controllers/object_controls.go#L4522-L4524
https://github.com/NVIDIA/gpu-operator/blob/v25.10.1/controllers/object_controls.go#L792-L800

However, for nvidiadriver, we were just adding it to pod template (under daemonset.spec.template). We need to add it to daemonset's labels and annotations as well.
<!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing
Deployed a cluster with this change and validated that driver daemonset is getting labels and annotations set as well.
<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

