### PR TITLE
[renovate] add labels to the generated pull requests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,6 +54,10 @@
       "versioningTemplate": "loose"
     }
   ],
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
   "packageRules": [
     {
       "matchPaths": ["deployments/gpu-operator/values.yaml"],


### PR DESCRIPTION
This change configures renovate bot to automatically add labels to the PRs it generates. These labels
make it easy to query PRs that are auto-generated
for dependency bumps and/or by renovate bot.