### PR TITLE
remove dependency on /etc/os-release host mount

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -904,10 +904,6 @@ spec:
                     memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-                volumeMounts:
-                - mountPath: /host-etc/os-release
-                  name: host-os-release
-                  readOnly: true
                 env:
                   - name: OPERATOR_NAMESPACE
                     valueFrom:
@@ -945,10 +941,6 @@ spec:
                   - name: "GDRCOPY_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/gdrdrv@sha256:5c4e61f7ba83d7a64ff2523d447c209ce5bde1ddc79acaf1f32f19620b4912d6"
               terminationGracePeriodSeconds: 10
-              volumes:
-              - hostPath:
-                  path: /etc/os-release
-                name: host-os-release
               serviceAccountName: gpu-operator
     strategy: deployment
   installModes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,10 +56,6 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts:
-          - mountPath: /host-etc/os-release
-            name: host-os-release
-            readOnly: true
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:
@@ -72,7 +68,3 @@ spec:
           - name: metrics
             containerPort: 8080
       terminationGracePeriodSeconds: 10
-      volumes:
-        - hostPath:
-            path: /etc/os-release
-          name: host-os-release

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -149,18 +149,6 @@ func getModuleRoot(dir string) (string, error) {
 	return dir, nil
 }
 
-// mockOSRelease returns a mock parseOSRelease function for testing.
-// It allows tests to simulate different operating systems without filesystem access.
-func mockOSRelease(osID, version string) func() (map[string]string, error) {
-	return func() (map[string]string, error) {
-		return map[string]string{
-			"ID":         osID,
-			"VERSION_ID": version,
-			"NAME":       osID,
-		}, nil
-	}
-}
-
 // setup creates a mock kubernetes cluster and client. Nodes are labeled with the minimum
 // required NFD labels to be detected as GPU nodes by the GPU Operator. A sample
 // ClusterPolicy resource is applied to the cluster. The ClusterPolicyController
@@ -172,9 +160,6 @@ func setup() error {
 	boolFalse = new(bool)
 	boolTrue = new(bool)
 	*boolTrue = true
-
-	// Mock parseOSRelease to avoid filesystem dependency in tests
-	parseOSRelease = mockOSRelease("ubuntu", "20.04")
 
 	s := scheme.Scheme
 	if err := gpuv1.AddToScheme(s); err != nil {
@@ -1450,62 +1435,6 @@ func TestService(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestParseOSReleaseFromFile(t *testing.T) {
-	tests := []struct {
-		description string
-		content     string
-		expected    map[string]string
-	}{
-		{
-			description: "quoted values",
-			content:     `NAME="Ubuntu"` + "\n" + `VERSION_ID="20.04"`,
-			expected:    map[string]string{"NAME": "Ubuntu", "VERSION_ID": "20.04"},
-		},
-		{
-			description: "unquoted values",
-			content:     `NAME=Ubuntu` + "\n" + `ID=ubuntu`,
-			expected:    map[string]string{"NAME": "Ubuntu", "ID": "ubuntu"},
-		},
-		{
-			description: "mixed quoted and unquoted",
-			content:     `ID="rhel"` + "\n" + `VERSION_ID=8.5`,
-			expected:    map[string]string{"ID": "rhel", "VERSION_ID": "8.5"},
-		},
-		{
-			description: "empty lines and comments",
-			content:     `NAME="Ubuntu"` + "\n\n# comment\n" + `ID=ubuntu`,
-			expected:    map[string]string{"NAME": "Ubuntu", "ID": "ubuntu"},
-		},
-	}
-
-	tempDir := t.TempDir()
-
-	// Save original value and restore after tests for future subsequent tests (if needed)
-	originalPath := osReleaseFilePath
-	defer func() { osReleaseFilePath = originalPath }()
-
-	for i, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			testFile := filepath.Join(tempDir, fmt.Sprintf("os-release-%d", i))
-			err := os.WriteFile(testFile, []byte(test.content), 0600)
-			require.NoError(t, err)
-
-			// Override the path for this test
-			osReleaseFilePath = testFile
-			result, err := parseOSReleaseFromFile()
-			require.NoError(t, err)
-			require.Equal(t, test.expected, result)
-		})
-	}
-
-	t.Run("file not found", func(t *testing.T) {
-		osReleaseFilePath = "/nonexistent/path"
-		_, err := parseOSReleaseFromFile()
-		require.Error(t, err)
-		require.True(t, os.IsNotExist(err))
-	})
 }
 
 func TestCertConfigPathMap(t *testing.T) {

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -50,8 +50,10 @@ func initMockK8sClients() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				nfdKernelLabelKey: "6.8.0-60-generic",
-				commonGPULabelKey: "true",
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "20.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
 			},
 		},
 	}
@@ -2866,7 +2868,7 @@ func TestTransformDriver(t *testing.T) {
 			client: mockClientMap["secret-env-client"],
 			expectedDs: NewDaemonset().WithContainer(corev1.Container{
 				Name:            "nvidia-driver-ctr",
-				Image:           "nvcr.io/nvidia/driver:570.172.08-",
+				Image:           "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				EnvFrom: []corev1.EnvFromSource{{
 					SecretRef: &corev1.SecretEnvSource{
@@ -2887,7 +2889,7 @@ func TestTransformDriver(t *testing.T) {
 				},
 			}).WithContainer(corev1.Container{
 				Name:  "nvidia-fs",
-				Image: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.20.5-",
+				Image: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.20.5-ubuntu20.04",
 				EnvFrom: []corev1.EnvFromSource{{
 					SecretRef: &corev1.SecretEnvSource{
 						LocalObjectReference: corev1.LocalObjectReference{
@@ -2897,7 +2899,7 @@ func TestTransformDriver(t *testing.T) {
 				}},
 			}).WithContainer(corev1.Container{
 				Name:  "nvidia-gdrcopy",
-				Image: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.5-",
+				Image: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.5-ubuntu20.04",
 				EnvFrom: []corev1.EnvFromSource{{
 					SecretRef: &corev1.SecretEnvSource{
 						LocalObjectReference: corev1.LocalObjectReference{
@@ -3176,8 +3178,10 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				nfdKernelLabelKey: "6.8.0-60-generic",
-				commonGPULabelKey: "true",
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "20.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
 			},
 		},
 	}
@@ -3215,7 +3219,7 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 			client: mockClient,
 			expectedDs: NewDaemonset().WithContainer(corev1.Container{
 				Name:            "nvidia-driver-ctr",
-				Image:           "nvcr.io/nvidia/driver:570.172.08-",
+				Image:           "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -3269,7 +3273,7 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 			client: mockClient,
 			expectedDs: NewDaemonset().WithContainer(corev1.Container{
 				Name:            "nvidia-driver-ctr",
-				Image:           "nvcr.io/nvidia/driver:570.172.08-",
+				Image:           "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -3326,8 +3330,10 @@ func TestTransformDriverWithResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				nfdKernelLabelKey: "6.8.0-60-generic",
-				commonGPULabelKey: "true",
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "20.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
 			},
 		},
 	}
@@ -3387,7 +3393,7 @@ func TestTransformDriverWithResources(t *testing.T) {
 			client: mockClient,
 			expectedDs: NewDaemonset().WithContainer(corev1.Container{
 				Name:            "nvidia-driver-ctr",
-				Image:           "nvcr.io/nvidia/driver:570.172.08-",
+				Image:           "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources: corev1.ResourceRequirements{
 					Requests: resources.Requests,
@@ -3405,14 +3411,14 @@ func TestTransformDriverWithResources(t *testing.T) {
 				},
 			}).WithContainer(corev1.Container{
 				Name:  "nvidia-fs",
-				Image: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.20.5-",
+				Image: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.20.5-ubuntu20.04",
 				Resources: corev1.ResourceRequirements{
 					Requests: resources.Requests,
 					Limits:   resources.Limits,
 				},
 			}).WithContainer(corev1.Container{
 				Name:  "nvidia-gdrcopy",
-				Image: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.5-",
+				Image: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.5-ubuntu20.04",
 				Resources: corev1.ResourceRequirements{
 					Requests: resources.Requests,
 					Limits:   resources.Limits,
@@ -3448,8 +3454,10 @@ func TestTransformDriverRDMA(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				nfdKernelLabelKey: "6.8.0-60-generic",
-				commonGPULabelKey: "true",
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "20.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
 			},
 		},
 	}
@@ -3478,7 +3486,7 @@ func TestTransformDriverRDMA(t *testing.T) {
 
 	expectedDs := NewDaemonset().WithContainer(corev1.Container{
 		Name:            "nvidia-driver-ctr",
-		Image:           "nvcr.io/nvidia/driver:570.172.08-",
+		Image:           "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Env: []corev1.EnvVar{
 			{
@@ -3505,7 +3513,7 @@ func TestTransformDriverRDMA(t *testing.T) {
 		},
 	}).WithContainer(corev1.Container{
 		Name:  "nvidia-peermem",
-		Image: "nvcr.io/nvidia/driver:570.172.08-",
+		Image: "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 		Env: []corev1.EnvVar{
 			{
 				Name:  "USE_HOST_MOFED",
@@ -3529,8 +3537,10 @@ func TestTransformDriverVGPUTopologyConfig(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				nfdKernelLabelKey: "6.8.0-60-generic",
-				commonGPULabelKey: "true",
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "20.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
 			},
 		},
 	}
@@ -3555,7 +3565,7 @@ func TestTransformDriverVGPUTopologyConfig(t *testing.T) {
 
 	expectedDs := NewDaemonset().WithContainer(corev1.Container{
 		Name:            "nvidia-driver-ctr",
-		Image:           "nvcr.io/nvidia/driver:570.172.08-",
+		Image:           "nvcr.io/nvidia/driver:570.172.08-ubuntu20.04",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -3813,6 +3823,98 @@ func TestTransformVGPUManager(t *testing.T) {
 					},
 				},
 			}, tc.daemonset.Spec.Template.Spec.Volumes[0])
+		})
+	}
+}
+
+func TestTransformDriverWithAdditionalConfig(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "24.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
+			},
+		},
+	}
+
+	testCertConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cert",
+			Namespace: "test-ns",
+		},
+	}
+
+	mockClient := fake.NewFakeClient(node, testCertConfigMap)
+
+	testCases := []struct {
+		description   string
+		ds            Daemonset
+		cpSpec        *gpuv1.ClusterPolicySpec
+		client        client.Client
+		expectedDs    Daemonset
+		errorExpected bool
+	}{
+		{
+			description: "transform driver with cert config",
+			ds: NewDaemonset().WithContainer(corev1.Container{Name: "nvidia-driver-ctr"}).
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				Driver: gpuv1.DriverSpec{
+					Repository:      "nvcr.io/nvidia",
+					Image:           "driver",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "580.126.16",
+					Manager: gpuv1.DriverManagerSpec{
+						Repository:      "nvcr.io/nvidia/cloud-native",
+						Image:           "k8s-driver-manager",
+						ImagePullPolicy: "IfNotPresent",
+						Version:         "v0.8.0",
+					},
+					CertConfig: &gpuv1.DriverCertConfigSpec{
+						Name: "test-cert",
+					},
+				},
+			},
+			client: mockClient,
+			expectedDs: NewDaemonset().WithContainer(corev1.Container{
+				Name:            "nvidia-driver-ctr",
+				Image:           "nvcr.io/nvidia/driver:580.126.16-ubuntu24.04",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			}).WithInitContainer(corev1.Container{
+				Name:            "k8s-driver-manager",
+				Image:           "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.8.0",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			}).WithVolume(corev1.Volume{
+				Name: "test-cert",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-cert",
+						},
+					},
+				},
+			}),
+			errorExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := TransformDriver(tc.ds.DaemonSet, tc.cpSpec,
+				ClusterPolicyController{client: tc.client, runtime: gpuv1.Containerd,
+					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+			if tc.errorExpected {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Remove dynamically generated digest before comparison
+			removeDigestFromDaemonSet(tc.ds.DaemonSet)
+			require.EqualValues(t, tc.expectedDs, tc.ds)
 		})
 	}
 }

--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -59,10 +59,6 @@ spec:
               fieldPath: metadata.namespace
         - name: "DRIVER_MANAGER_IMAGE"
           value: "{{ include "driver-manager.fullimage" . }}"
-        volumeMounts:
-          - name: host-os-release
-            mountPath: "/host-etc/os-release"
-            readOnly: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -82,10 +78,6 @@ spec:
         ports:
           - name: metrics
             containerPort: 8080
-      volumes:
-        - name: host-os-release
-          hostPath:
-            path: "/etc/os-release"
     {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This PR builds on top of #2101 - using the NFD labels to get the `/etc/os-release` information instead of directly querying the node's `/etc/os-release` file via a host mount.

With the existing approach, the gpu-operator assumes that the node on which the gpu-operator pod is scheduled has the same OS as the GPU node. There are cases where users may choose to deploy the gpu-operator pod on a CPU node having an OS different from that of the GPU node. These changes enable the gpu-operator to function in these scenarios.