### PR TITLE
docs: add GPU operator architecture documentation in Korean

### DIFF
--- a/_docs/00-gpu-driver-userspace-architecture.md
+++ b/_docs/00-gpu-driver-userspace-architecture.md
@@ -1,0 +1,82 @@
+# GPU 드라이버 유저스페이스 아키텍처
+
+> libcuda.so는 왜 일반 라이브러리가 아닌가
+
+## 배경
+
+GPU 컨테이너 환경에서 가장 흔한 오해 중 하나는 `libcuda.so`를 일반 라이브러리처럼
+컨테이너 이미지에 직접 설치할 수 있다고 생각하는 것이다.
+
+## 일반 라이브러리 vs libcuda.so
+
+| 구분 | 일반 라이브러리 (libssl, libz 등) | libcuda.so |
+|------|----------------------------------|------------|
+| 이미지에 포함 가능 여부 | O | **X** |
+| 커널 의존성 | 없음 | nvidia.ko와 1:1 매칭 필수 |
+| 노드마다 다를 수 있음 | X | **O** (드라이버 버전이 다르면 다름) |
+| 런타임 주입 필요 | X | **O** |
+
+## 커널 모듈과 유저스페이스의 관계
+
+```
+libcuda.so  ←── ioctl() ──→  nvidia.ko (커널 모듈)
+   (유저스페이스)                  (커널)
+```
+
+`libcuda.so`는 커널의 NVIDIA 드라이버(`nvidia.ko`)와 **ioctl 시스템 콜**로 직접 통신한다.
+둘 사이에는 내부 ABI(Application Binary Interface)가 존재하며,
+**반드시 같은 드라이버 빌드에서 생성된 쌍**이어야 정상 동작한다.
+
+### 호스트에서 드라이버 설치 시 흐름
+
+```
+드라이버 설치 (예: NVIDIA-Linux-x86_64-560.35.03.run)
+    │
+    ├─→ nvidia.ko         (커널 모듈로 로드)
+    └─→ libcuda.so.560.35.03  (유저스페이스 라이브러리)
+         이 둘은 동일 빌드의 쌍
+```
+
+## 컨테이너에서의 주입 메커니즘
+
+```
+호스트에서 드라이버 설치
+    → nvidia.ko + libcuda.so 쌍으로 생성
+                     │
+      nvidia-container-toolkit이
+      이 libcuda.so를 컨테이너에 bind mount로 주입
+                     │
+      컨테이너 안 CUDA 앱이 사용
+```
+
+### nvidia-container-toolkit의 역할
+
+1. 컨테이너 런타임(containerd, cri-o 등)에 hook으로 등록
+2. GPU 컨테이너 생성 시 호스트의 NVIDIA 라이브러리/디바이스 노드를 자동 마운트
+3. 주입 대상:
+   - `libcuda.so` — CUDA Driver API
+   - `libnvidia-ml.so` — NVML (GPU 모니터링)
+   - `libnvidia-ptxjitcompiler.so` — PTX JIT 컴파일러
+   - `/dev/nvidia*` — GPU 디바이스 노드
+
+## 컨테이너 이미지에 직접 넣으면 안 되는 이유
+
+1. **호스트 드라이버 업그레이드 시 버전 불일치** → 크래시 또는 기능 오동작
+2. **다른 노드에 스케줄링 시** 해당 노드의 드라이버 버전이 다르면 → 크래시
+3. **이미지 이식성 상실** — 특정 드라이버 버전에 종속된 이미지가 됨
+
+## GPU Operator에서의 처리
+
+NVIDIA GPU Operator는 이 문제를 체계적으로 해결한다:
+
+1. **state-driver**: 호스트에 NVIDIA 커널 모듈을 DaemonSet으로 설치
+2. **state-container-toolkit**: nvidia-container-toolkit을 배포하여 런타임 주입 설정
+3. **state-device-plugin**: `nvidia.com/gpu` 리소스를 Kubernetes에 등록
+
+이 순서가 중요하다 — 드라이버가 먼저 설치되어야 toolkit이 주입할 라이브러리가 존재하고,
+toolkit이 설정되어야 device plugin이 GPU를 할당받은 Pod에서 실제로 GPU를 사용할 수 있다.
+
+## 정리
+
+GPU 컨테이너 생태계가 복잡한 근본적 이유는 **단순히 라이브러리를 설치하는 문제가 아니라,
+호스트 커널 드라이버와 매칭되는 유저스페이스를 런타임에 주입해야 하는 문제**이기 때문이다.

--- a/_docs/01-operator-architecture-overview.md
+++ b/_docs/01-operator-architecture-overview.md
@@ -1,0 +1,168 @@
+# GPU Operator 아키텍처 개요
+
+> NVIDIA GPU Operator의 전체 구조와 동작 원리
+
+## 프로젝트 개요
+
+NVIDIA GPU Operator는 Kubernetes 클러스터에서 GPU 노드를 운영하는 데 필요한
+모든 NVIDIA 소프트웨어 컴포넌트의 라이프사이클을 자동화하는 Kubernetes Operator이다.
+
+### 핵심 가치
+
+- GPU 노드에 **표준 OS 이미지**만 사용 (커스텀 이미지 불필요)
+- 드라이버, 툴킷, 디바이스 플러그인 등을 **컨테이너로 배포/관리**
+- 클라우드 환경에서 GPU 노드의 동적 프로비저닝에 적합
+
+## CRD (Custom Resource Definitions)
+
+### 1. ClusterPolicy (v1) — 주요 CRD
+
+클러스터 전체의 GPU 소프트웨어 스택 상태를 선언한다.
+
+```yaml
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-policy
+spec:
+  driver:         # NVIDIA 커널 드라이버
+  toolkit:        # Container Toolkit
+  devicePlugin:   # Kubernetes Device Plugin
+  dcgm:           # DCGM (Data Center GPU Manager)
+  dcgmExporter:   # DCGM 메트릭 익스포터
+  migManager:     # Multi-Instance GPU 관리
+  gfd:            # GPU Feature Discovery
+  # ... 기타 컴포넌트
+```
+
+### 2. NVIDIADriver (v1alpha1) — 세분화된 드라이버 관리
+
+노드 풀별로 다른 드라이버 설정을 적용할 수 있는 CRD이다.
+
+```yaml
+apiVersion: nvidia.com/v1alpha1
+kind: NVIDIADriver
+metadata:
+  name: gpu-driver
+spec:
+  driverType: gpu            # gpu | vgpu | vgpu-host-manager
+  kernelModuleType: open     # auto | open | proprietary
+  usePrecompiled: false
+```
+
+## 컨트롤러 (Reconcilers)
+
+### 1. ClusterPolicyReconciler
+
+- `ClusterPolicy` 리소스와 `Node` 라벨을 감시
+- **상태 머신(State Machine)** 기반으로 모든 operand를 순서대로 배포
+- 준비 안 된 상태가 있으면 5초마다 재시도
+
+### 2. NVIDIADriverReconciler
+
+- `NVIDIADriver` CR을 reconcile
+- 노드 풀별 드라이버 DaemonSet 관리
+
+### 3. UpgradeReconciler
+
+- GPU 드라이버 DaemonSet의 롤링 업그레이드 관리
+- `nvidia.com/gpu` 리소스를 사용하는 Pod만 필터링하여 처리
+
+## 상태 머신 (State Machine)
+
+ClusterPolicy 컨트롤러는 고정된 순서로 상태(operand)를 처리한다:
+
+```
+1.  pre-requisites          ─ RuntimeClass 등 전제 조건
+2.  state-operator-metrics  ─ Operator 메트릭 수집
+3.  state-driver            ─ NVIDIA 커널 드라이버 (DaemonSet)
+4.  state-container-toolkit ─ nvidia-container-toolkit
+5.  state-operator-validation ─ Operator 검증
+6.  state-device-plugin     ─ Kubernetes GPU Device Plugin
+7.  state-mps-control-daemon ─ MPS (Multi-Process Service)
+8.  state-dcgm              ─ DCGM 독립 컴포넌트
+9.  state-dcgm-exporter     ─ DCGM 메트릭 익스포터
+10. gpu-feature-discovery   ─ GPU Feature Discovery
+11. state-mig-manager       ─ MIG 파티셔닝 관리
+12. state-node-status-exporter ─ 노드 상태 익스포터
+```
+
+### Sandbox 워크로드 상태 (VM/vGPU)
+
+```
+13. state-vgpu-manager
+14. state-vgpu-device-manager
+15. state-sandbox-validation
+16. state-vfio-manager
+17. state-sandbox-device-plugin
+18. state-kata-manager
+19. state-cc-manager
+```
+
+### 상태 순서가 중요한 이유
+
+```
+driver → toolkit → device-plugin
+
+1. 드라이버가 먼저 설치되어야 → libcuda.so가 존재
+2. toolkit이 설정되어야      → 컨테이너에 주입 가능
+3. device-plugin이 등록되어야 → Pod에 GPU 할당 가능
+```
+
+## Assets 구조
+
+각 상태는 `assets/` 디렉토리의 YAML 매니페스트에 매핑된다:
+
+```
+assets/
+├── state-driver/
+│   ├── 0100_service_account.yaml
+│   ├── 0200_role.yaml
+│   ├── 0300_cluster_role.yaml
+│   ├── 0400_rolebinding.yaml
+│   └── 0500_daemonset.yaml
+├── state-container-toolkit/
+├── state-device-plugin/
+├── state-dcgm/
+├── state-dcgm-exporter/
+├── gpu-feature-discovery/
+├── state-mig-manager/
+└── ...
+```
+
+번호 접두사(`0100_`, `0200_`)는 리소스 생성 순서를 보장한다.
+
+## 워크로드 타입별 노드 라벨
+
+GPU Operator는 노드의 워크로드 타입에 따라 다른 컴포넌트를 배포한다:
+
+| 워크로드 타입 | 배포 컴포넌트 |
+|-------------|-------------|
+| **container** (기본) | driver, toolkit, device-plugin, dcgm, dcgm-exporter, gfd, node-status-exporter |
+| **vm-passthrough** | sandbox-device-plugin, vfio-manager, kata-manager, cc-manager |
+| **vm-vgpu** | sandbox-device-plugin, vgpu-manager, vgpu-device-manager, cc-manager |
+
+## GPU 노드 감지
+
+Node Feature Discovery(NFD)가 GPU 노드에 다음 라벨을 부여하면 Operator가 감지한다:
+
+```
+feature.node.kubernetes.io/pci-10de.present=true
+```
+
+`10de`는 NVIDIA의 PCI 벤더 ID이다.
+
+## 디렉토리 구조 요약
+
+```
+gpu-operator/
+├── api/          # CRD 타입 정의 (Go)
+├── assets/       # 각 operand의 Kubernetes 매니페스트
+├── cmd/          # 바이너리 진입점 (gpu-operator, nvidia-validator 등)
+├── controllers/  # Reconciler/Controller 로직
+├── internal/     # 내부 라이브러리 (state, conditions, render 등)
+├── deployments/  # Helm 차트
+├── config/       # Kustomize/kubebuilder 설정
+├── validator/    # GPU 노드 검증 로직
+└── vendor/       # Go 의존성
+```

--- a/_docs/02-container-runtime-injection.md
+++ b/_docs/02-container-runtime-injection.md
@@ -1,0 +1,116 @@
+# 컨테이너 런타임 GPU 라이브러리 주입
+
+> nvidia-container-toolkit이 GPU 라이브러리를 컨테이너에 주입하는 메커니즘
+
+## 문제 정의
+
+GPU 워크로드를 컨테이너에서 실행하려면 다음이 필요하다:
+
+1. **NVIDIA 디바이스 노드** (`/dev/nvidia0`, `/dev/nvidiactl`, `/dev/nvidia-uvm`)
+2. **유저스페이스 라이브러리** (`libcuda.so`, `libnvidia-ml.so` 등)
+3. **적절한 cgroup 권한**
+
+이들은 호스트의 드라이버 버전에 종속되므로 컨테이너 이미지에 미리 포함할 수 없다.
+
+## nvidia-container-toolkit 동작 흐름
+
+```
+┌─────────────────────────────────────────────────┐
+│ Kubernetes                                       │
+│  ┌──────────┐    ┌───────────────┐              │
+│  │ kubelet  │───→│ Container     │              │
+│  │          │    │ Runtime       │              │
+│  └──────────┘    │ (containerd)  │              │
+│                  └───────┬───────┘              │
+│                          │                      │
+│              ┌───────────▼──────────┐           │
+│              │ nvidia-container-    │           │
+│              │ runtime (OCI hook)   │           │
+│              └───────────┬──────────┘           │
+│                          │                      │
+│              ┌───────────▼──────────┐           │
+│              │ nvidia-container-cli │           │
+│              │  • bind mount libs   │           │
+│              │  • mount /dev/nvidia*│           │
+│              │  • set cgroup perms  │           │
+│              └──────────────────────┘           │
+└─────────────────────────────────────────────────┘
+```
+
+### 주입 단계
+
+1. **Pod 생성 요청**: `nvidia.com/gpu` 리소스를 요청하는 Pod이 스케줄링됨
+2. **Device Plugin**: GPU 디바이스를 할당하고 환경 변수 설정
+3. **컨테이너 런타임 Hook**: nvidia-container-runtime이 OCI 런타임 hook으로 개입
+4. **라이브러리 마운트**: 호스트의 NVIDIA 라이브러리를 컨테이너에 bind mount
+5. **디바이스 노드 마운트**: `/dev/nvidia*` 디바이스를 컨테이너에 노출
+6. **컨테이너 시작**: CUDA 앱이 주입된 라이브러리와 디바이스를 사용
+
+## 주입되는 라이브러리 목록
+
+| 라이브러리 | 역할 |
+|-----------|------|
+| `libcuda.so` | CUDA Driver API (커널 모듈과 직접 통신) |
+| `libnvidia-ml.so` | NVML — GPU 모니터링/관리 API |
+| `libnvidia-ptxjitcompiler.so` | PTX → SASS JIT 컴파일러 |
+| `libnvidia-opencl.so` | OpenCL ICD |
+| `libnvidia-nvvm.so` | NVVM IR 컴파일러 |
+| `libnvidia-cfg.so` | GPU 설정 관리 |
+| `libnvidia-allocator.so` | 메모리 할당 |
+
+## 주입되는 디바이스 노드
+
+| 디바이스 | 역할 |
+|---------|------|
+| `/dev/nvidia0` (..N) | 각 GPU 디바이스 |
+| `/dev/nvidiactl` | NVIDIA 제어 디바이스 |
+| `/dev/nvidia-uvm` | Unified Virtual Memory |
+| `/dev/nvidia-uvm-tools` | UVM 디버깅 도구 |
+| `/dev/nvidia-modeset` | 디스플레이 모드 설정 |
+
+## GPU Operator에서의 배포
+
+GPU Operator의 **state-container-toolkit** 상태가 이 컴포넌트를 배포한다:
+
+```
+assets/state-container-toolkit/
+├── 0100_service_account.yaml
+├── 0200_role.yaml
+├── 0300_cluster_role.yaml
+├── 0400_rolebinding.yaml
+├── 0500_cluster_role_binding.yaml
+└── 0600_daemonset.yaml     ← toolkit DaemonSet
+```
+
+DaemonSet이 각 GPU 노드에서 실행되며:
+1. 호스트의 컨테이너 런타임 설정을 수정
+2. nvidia-container-runtime을 기본 OCI 런타임으로 등록
+3. 노드 재부팅 없이 설정 적용
+
+## CUDA Runtime API vs Driver API
+
+```
+┌──────────────────────────────┐
+│        사용자 CUDA 코드        │
+│  (cudaMalloc, cudaMemcpy)    │
+└──────────────┬───────────────┘
+               │
+┌──────────────▼───────────────┐
+│     libcudart.so             │  ← CUDA Runtime API
+│     (CUDA Runtime Library)   │     이미지에 포함 가능!
+└──────────────┬───────────────┘
+               │
+┌──────────────▼───────────────┐
+│     libcuda.so               │  ← CUDA Driver API
+│     (CUDA Driver Library)    │     호스트에서 주입 필수!
+└──────────────┬───────────────┘
+               │ ioctl()
+┌──────────────▼───────────────┐
+│     nvidia.ko                │  ← 커널 모듈
+│     (Kernel Module)          │
+└──────────────────────────────┘
+```
+
+**중요한 구분:**
+- `libcudart.so` (CUDA Runtime API) → 컨테이너 이미지에 **포함 가능** (nvidia/cuda 베이스 이미지에 이미 포함)
+- `libcuda.so` (CUDA Driver API) → 호스트에서 **주입 필수** (드라이버 버전 종속)


### PR DESCRIPTION
Add internal documentation covering:
- GPU driver userspace architecture (libcuda.so injection rationale)
- Operator architecture overview (CRDs, state machine, controllers)
- Container runtime GPU library injection mechanism

https://claude.ai/code/session_01XvwJycT9D4bMfaM8GThhdc

## Description

<!-- Brief description of the change, including context or motivation -->

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

