### PR TITLE
eliminate redundant node list calls when retrieving the GPU Node OS Info

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -662,67 +662,6 @@ func (n ClusterPolicyController) getKernelVersionsMap() (map[string]string, erro
 	return kernelVersionMap, nil
 }
 
-func kernelFullVersion(n ClusterPolicyController) (string, string, string) {
-	ctx := n.ctx
-	logger := n.logger.WithValues("Request.Namespace", "default", "Request.Name", "Node")
-	// We need the node labels to fetch the correct container
-	opts := []client.ListOption{
-		client.MatchingLabels{"nvidia.com/gpu.present": "true"},
-	}
-
-	list := &corev1.NodeList{}
-	err := n.client.List(ctx, list, opts...)
-	if err != nil {
-		logger.Info("Could not get NodeList", "ERROR", err)
-		return "", "", ""
-	}
-
-	if len(list.Items) == 0 {
-		// none of the nodes matched nvidia GPU label
-		// either the nodes do not have GPUs, or NFD is not running
-		logger.Info("Could not get any nodes to match nvidia.com/gpu.present label", "ERROR", "")
-		return "", "", ""
-	}
-
-	// Assuming all nodes are running the same kernel version,
-	// One could easily add driver-kernel-versions for each node.
-	node := list.Items[0]
-	labels := node.GetLabels()
-
-	var ok bool
-	kFVersion, ok := labels[nfdKernelLabelKey]
-	if ok {
-		logger.Info(kFVersion)
-	} else {
-		err := apierrors.NewNotFound(schema.GroupResource{Group: "Node", Resource: "Label"}, nfdKernelLabelKey)
-		logger.Info("Couldn't get kernelVersion, did you run the node feature discovery?", "Error", err)
-		return "", "", ""
-	}
-
-	osName, ok := labels[nfdOSReleaseIDLabelKey]
-	if !ok {
-		return kFVersion, "", ""
-	}
-	osVersion, ok := labels[nfdOSVersionIDLabelKey]
-	if !ok {
-		return kFVersion, "", ""
-	}
-	osMajorVersion := strings.Split(osVersion, ".")[0]
-	osMajorNumber, err := strconv.Atoi(osMajorVersion)
-	if err != nil {
-		return kFVersion, "", ""
-	}
-
-	// If the OS is RockyLinux or RHEL 10 & above, we will omit the minor version when constructing the os image tag
-	if osName == "rocky" || (osName == "rhel" && osMajorNumber >= 10) {
-		osVersion = osMajorVersion
-	}
-
-	osTag := fmt.Sprintf("%s%s", osName, osVersion)
-
-	return kFVersion, osTag, osVersion
-}
-
 func preprocessService(obj *corev1.Service, n ClusterPolicyController) error {
 	logger := n.logger.WithValues("Service", obj.Name)
 	transformations := map[string]func(*corev1.Service, *gpuv1.ClusterPolicySpec) error{
@@ -3206,12 +3145,6 @@ func transformOpenShiftDriverToolkitContainer(obj *appsv1.DaemonSet, config *gpu
 
 // resolveDriverTag resolves image tag based on the OS of the worker node
 func resolveDriverTag(n ClusterPolicyController, driverSpec interface{}) (string, error) {
-	// obtain os version
-	kvers, osTag, _ := kernelFullVersion(n)
-	if kvers == "" {
-		return "", fmt.Errorf("ERROR: Could not find kernel full version: ('%s', '%s')", kvers, osTag)
-	}
-
 	// obtain image path
 	var image string
 	var err error
@@ -3262,59 +3195,44 @@ func resolveDriverTag(n ClusterPolicyController, driverSpec interface{}) (string
 	// if image digest is specified, use it directly
 	if !strings.Contains(image, "sha256:") {
 		// append os-tag to the provided driver version
-		image = fmt.Sprintf("%s-%s", image, osTag)
+		image = fmt.Sprintf("%s-%s", image, n.gpuNodeOSTag)
 	}
 	return image, nil
 }
 
-// getGPUNodeOSID returns the base OS identifier (e.g. "rhel", "ubuntu", "rocky") for GPU
-// worker nodes by extracting the version suffix from the osTag obtained via NFD labels.
-func (n ClusterPolicyController) getGPUNodeOSID() (string, string, error) {
-	_, osTag, _ := kernelFullVersion(n)
-	if osTag == "" {
-		return "", "", fmt.Errorf("unable to determine GPU node OS from NFD labels, is NFD installed?")
-	}
+func getOSName(osTag string) string {
 	// Extract base OS ID by stripping version suffix from osTag
 	// Examples: "rhel10" -> "rhel", "ubuntu22.04" -> "ubuntu", "rocky9" -> "rocky"
 	osID := strings.TrimRight(osTag, "0123456789.")
-	return osID, osTag, nil
+	return osID
 }
 
 // getRepoConfigPath returns the standard OS specific path for repository configuration files.
 func (n ClusterPolicyController) getRepoConfigPath() (string, error) {
-	osID, osTag, err := n.getGPUNodeOSID()
-	if err != nil {
-		return "", err
-	}
+	osID := getOSName(n.gpuNodeOSTag)
 	if path, ok := RepoConfigPathMap[osID]; ok {
 		return path, nil
 	}
-	return "", fmt.Errorf("repository configuration not supported for distribution %s", osTag)
+	return "", fmt.Errorf("repository configuration not supported for distribution %s", n.gpuNodeOSTag)
 }
 
 // getCertConfigPath returns the standard OS specific path for ssl keys/certificates.
 func (n ClusterPolicyController) getCertConfigPath() (string, error) {
-	osID, osTag, err := n.getGPUNodeOSID()
-	if err != nil {
-		return "", err
-	}
+	osID := getOSName(n.gpuNodeOSTag)
 	if path, ok := CertConfigPathMap[osID]; ok {
 		return path, nil
 	}
-	return "", fmt.Errorf("certificate configuration not supported for distribution %s", osTag)
+	return "", fmt.Errorf("certificate configuration not supported for distribution %s", n.gpuNodeOSTag)
 }
 
 // getSubscriptionPathsToVolumeSources returns the MountPathToVolumeSource map containing all
 // OS-specific subscription/entitlement paths that need to be mounted in the container.
 func (n ClusterPolicyController) getSubscriptionPathsToVolumeSources() (MountPathToVolumeSource, error) {
-	osID, osTag, err := n.getGPUNodeOSID()
-	if err != nil {
-		return nil, err
-	}
+	osID := getOSName(n.gpuNodeOSTag)
 	if pathToVolumeSource, ok := SubscriptionPathMap[osID]; ok {
 		return pathToVolumeSource, nil
 	}
-	return nil, fmt.Errorf("subscription paths not found for distribution %s", osTag)
+	return nil, fmt.Errorf("subscription paths not found for distribution %s", n.gpuNodeOSTag)
 }
 
 // createConfigMapVolumeMounts creates a VolumeMount for each key
@@ -3578,10 +3496,7 @@ func transformDriverContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 		}
 	}
 
-	osID, _, err := n.getGPUNodeOSID()
-	if err != nil {
-		return fmt.Errorf("ERROR: failed to retrieve OS name of GPU Node: %w", err)
-	}
+	osID := getOSName(n.gpuNodeOSTag)
 	// set up subscription entitlements for RHEL(using K8s with a non-CRIO runtime) and SLES
 	if (osID == "rhel" && n.openshift == "" && n.runtime != gpuv1.CRIO) || osID == "sles" || osID == "sl-micro" {
 		n.logger.Info("Mounting subscriptions into the driver container", "OS", osID)

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -2919,7 +2919,7 @@ func TestTransformDriver(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			err := TransformDriver(tc.ds.DaemonSet, tc.cpSpec,
 				ClusterPolicyController{client: tc.client, runtime: gpuv1.Containerd,
-					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test"), gpuNodeOSTag: "ubuntu20.04"})
 			if tc.errorExpected {
 				require.Error(t, err)
 				return
@@ -3311,7 +3311,7 @@ func TestTransformDriverWithLicensingConfig(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			err := TransformDriver(tc.ds.DaemonSet, tc.cpSpec,
 				ClusterPolicyController{client: tc.client, runtime: gpuv1.Containerd,
-					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test"), gpuNodeOSTag: "ubuntu20.04"})
 			if tc.errorExpected {
 				require.Error(t, err)
 				return
@@ -3435,7 +3435,7 @@ func TestTransformDriverWithResources(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			err := TransformDriver(tc.ds.DaemonSet, tc.cpSpec,
 				ClusterPolicyController{client: tc.client, runtime: gpuv1.Containerd,
-					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test"), gpuNodeOSTag: "ubuntu20.04"})
 			if tc.errorExpected {
 				require.Error(t, err)
 				return
@@ -3524,7 +3524,7 @@ func TestTransformDriverRDMA(t *testing.T) {
 
 	err := TransformDriver(ds.DaemonSet, cpSpec,
 		ClusterPolicyController{client: mockClient, runtime: gpuv1.Containerd,
-			operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+			operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test"), gpuNodeOSTag: "ubuntu20.04"})
 	require.NoError(t, err)
 
 	// Remove dynamically generated digest before comparison
@@ -3597,7 +3597,7 @@ func TestTransformDriverVGPUTopologyConfig(t *testing.T) {
 
 	err := TransformDriver(ds.DaemonSet, cpSpec,
 		ClusterPolicyController{client: mockClient, runtime: gpuv1.Containerd,
-			operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+			operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test"), gpuNodeOSTag: "ubuntu20.04"})
 	require.NoError(t, err)
 	removeDigestFromDaemonSet(ds.DaemonSet)
 	require.EqualValues(t, expectedDs, ds)
@@ -3730,8 +3730,10 @@ func TestTransformVGPUManager(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				nfdKernelLabelKey: "6.8.0-60-generic",
-				commonGPULabelKey: "true",
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "24.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
 			},
 		},
 	}
@@ -3847,7 +3849,14 @@ func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 		},
 	}
 
-	mockClient := fake.NewFakeClient(node, testCertConfigMap)
+	testRepoConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo-config",
+			Namespace: "test-ns",
+		},
+	}
+
+	mockClient := fake.NewFakeClient(node, testCertConfigMap, testRepoConfigMap)
 
 	testCases := []struct {
 		description   string
@@ -3856,6 +3865,7 @@ func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 		client        client.Client
 		expectedDs    Daemonset
 		errorExpected bool
+		errorMessage  string
 	}{
 		{
 			description: "transform driver with cert config",
@@ -3899,15 +3909,110 @@ func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 			}),
 			errorExpected: false,
 		},
+		{
+			description: "transform driver with cert config enabled and non-existent configmap",
+			ds: NewDaemonset().WithContainer(corev1.Container{Name: "nvidia-driver-ctr"}).
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				Driver: gpuv1.DriverSpec{
+					Repository:      "nvcr.io/nvidia",
+					Image:           "driver",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "580.126.16",
+					Manager: gpuv1.DriverManagerSpec{
+						Repository:      "nvcr.io/nvidia/cloud-native",
+						Image:           "k8s-driver-manager",
+						ImagePullPolicy: "IfNotPresent",
+						Version:         "v0.8.0",
+					},
+					CertConfig: &gpuv1.DriverCertConfigSpec{
+						Name: "test-cert2",
+					},
+				},
+			},
+			client:        mockClient,
+			errorExpected: true,
+			errorMessage: "ERROR: failed to create ConfigMap VolumeMounts for custom certs: ERROR: could not get " +
+				"ConfigMap test-cert2 from client: configmaps \"test-cert2\" not found",
+		},
+		{
+			description: "transform driver with custom repo config",
+			ds: NewDaemonset().WithContainer(corev1.Container{Name: "nvidia-driver-ctr"}).
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				Driver: gpuv1.DriverSpec{
+					Repository:      "nvcr.io/nvidia",
+					Image:           "driver",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "580.126.16",
+					Manager: gpuv1.DriverManagerSpec{
+						Repository:      "nvcr.io/nvidia/cloud-native",
+						Image:           "k8s-driver-manager",
+						ImagePullPolicy: "IfNotPresent",
+						Version:         "v0.8.0",
+					},
+					RepoConfig: &gpuv1.DriverRepoConfigSpec{
+						ConfigMapName: "test-repo-config",
+					},
+				},
+			},
+			client: mockClient,
+			expectedDs: NewDaemonset().WithContainer(corev1.Container{
+				Name:            "nvidia-driver-ctr",
+				Image:           "nvcr.io/nvidia/driver:580.126.16-ubuntu24.04",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			}).WithInitContainer(corev1.Container{
+				Name:            "k8s-driver-manager",
+				Image:           "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.8.0",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			}).WithVolume(corev1.Volume{
+				Name: "test-repo-config",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-repo-config",
+						},
+					},
+				},
+			}),
+			errorExpected: false,
+		},
+		{
+			description: "transform driver with custom repo config and non-existent configmap",
+			ds: NewDaemonset().WithContainer(corev1.Container{Name: "nvidia-driver-ctr"}).
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				Driver: gpuv1.DriverSpec{
+					Repository:      "nvcr.io/nvidia",
+					Image:           "driver",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "580.126.16",
+					Manager: gpuv1.DriverManagerSpec{
+						Repository:      "nvcr.io/nvidia/cloud-native",
+						Image:           "k8s-driver-manager",
+						ImagePullPolicy: "IfNotPresent",
+						Version:         "v0.8.0",
+					},
+					RepoConfig: &gpuv1.DriverRepoConfigSpec{
+						ConfigMapName: "test-repo-config2",
+					},
+				},
+			},
+			client:        mockClient,
+			errorExpected: true,
+			errorMessage: "ERROR: failed to create ConfigMap VolumeMounts for custom repo config: ERROR: could not get " +
+				"ConfigMap test-repo-config2 from client: configmaps \"test-repo-config2\" not found",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			err := TransformDriver(tc.ds.DaemonSet, tc.cpSpec,
 				ClusterPolicyController{client: tc.client, runtime: gpuv1.Containerd,
-					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test")})
+					operatorNamespace: "test-ns", logger: ctrl.Log.WithName("test"), gpuNodeOSTag: "ubuntu24.04"})
 			if tc.errorExpected {
 				require.Error(t, err)
+				require.Equal(t, tc.errorMessage, err.Error())
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
The commits dcb3f478620ba95988eb1dc22e9f53192db09632 and efaac78606e40e32e6eedbfed365a6767ab01c45 have
removed the dependency on the host-mounted /etc/os-release file and replaced it with NFD labels as the source of information. This commit builds upon those changes by eliminating the redundant calls to Node List
operations. This makes the gpu-operator scale better when it applies transformations especially in large clusters.

