### PR TITLE
[OLM] update sample clusterpolicy JSON

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -126,6 +126,7 @@ func (r Runtime) String() string {
 
 // OperatorSpec describes configuration options for the operator
 type OperatorSpec struct {
+	// Deprecated: DefaultRuntime is no longer used by the gpu-operator. This is instead, detected at runtime.
 	// +kubebuilder:validation:Enum=docker;crio;containerd
 	// +kubebuilder:default=docker
 	DefaultRuntime Runtime `json:"defaultRuntime"`

--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -29,11 +29,11 @@ metadata:
           },
           "spec": {
             "operator": {
-              "defaultRuntime": "crio",
               "use_ocp_driver_toolkit": true
             },
             "cdi": {
-              "enabled": true
+              "enabled": true,
+              "nriPluginEnabled": false
             },
             "sandboxWorkloads": {
               "enabled": false,

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -1812,7 +1812,8 @@ spec:
                     type: object
                   defaultRuntime:
                     default: docker
-                    description: Runtime defines container runtime type
+                    description: 'Deprecated: DefaultRuntime is no longer used by
+                      the gpu-operator. This is instead, detected at runtime.'
                     enum:
                     - docker
                     - crio

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -1812,7 +1812,8 @@ spec:
                     type: object
                   defaultRuntime:
                     default: docker
-                    description: Runtime defines container runtime type
+                    description: 'Deprecated: DefaultRuntime is no longer used by
+                      the gpu-operator. This is instead, detected at runtime.'
                     enum:
                     - docker
                     - crio

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -1812,7 +1812,8 @@ spec:
                     type: object
                   defaultRuntime:
                     default: docker
-                    description: Runtime defines container runtime type
+                    description: 'Deprecated: DefaultRuntime is no longer used by
+                      the gpu-operator. This is instead, detected at runtime.'
                     enum:
                     - docker
                     - crio


### PR DESCRIPTION
This PR updates the ALM example to 

i) Remove deprecated (and no-op) field `defaultRuntime`
ii) Introduce the new field `.spec.cdi.nriPluginEnabled`