### PR TITLE
fix failing unit test in object_controls_test.go

### DIFF
--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -4035,10 +4035,22 @@ func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 				Name:            "nvidia-driver-ctr",
 				Image:           "nvcr.io/nvidia/driver:580.126.16-ubuntu24.04",
 				ImagePullPolicy: corev1.PullIfNotPresent,
+				Env: []corev1.EnvVar{
+					{
+						Name:  "DRIVER_CONFIG_DIGEST",
+						Value: "2050622367",
+					},
+				},
 			}).WithInitContainer(corev1.Container{
 				Name:            "k8s-driver-manager",
 				Image:           "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.8.0",
 				ImagePullPolicy: corev1.PullIfNotPresent,
+				Env: []corev1.EnvVar{
+					{
+						Name:  "DRIVER_CONFIG_DIGEST",
+						Value: "2050622367",
+					},
+				},
 			}).WithVolume(corev1.Volume{
 				Name: "test-repo-config",
 				VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
This PR fixes the unit test [failures](https://github.com/NVIDIA/gpu-operator/actions/runs/22326785378/job/64599328601) observed in the main branch. 

The failure is coming from a test case introduced in this PR #2144. The PR #2147 was not rebased completely after the merge of #2144, so we couldn't catch this unit test failure during PR reviews