### PR TITLE
Mark defaultRuntime as optional, remove validation constraints

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -139,9 +139,8 @@ const (
 // OperatorSpec describes configuration options for the operator
 type OperatorSpec struct {
 	// Deprecated: DefaultRuntime is no longer used by the gpu-operator. This is instead, detected at runtime.
-	// +kubebuilder:validation:Enum=docker;crio;containerd
-	// +kubebuilder:default=docker
-	DefaultRuntime Runtime `json:"defaultRuntime"`
+	// +optional
+	DefaultRuntime Runtime `json:"defaultRuntime,omitempty"`
 	// +kubebuilder:default=nvidia
 	RuntimeClass  string            `json:"runtimeClass,omitempty"`
 	InitContainer InitContainerSpec `json:"initContainer,omitempty"`

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -1887,13 +1887,8 @@ spec:
                       queryable and should be preserved when modifying objects.
                     type: object
                   defaultRuntime:
-                    default: docker
                     description: 'Deprecated: DefaultRuntime is no longer used by
                       the gpu-operator. This is instead, detected at runtime.'
-                    enum:
-                    - docker
-                    - crio
-                    - containerd
                     type: string
                   initContainer:
                     description: 'Deprecated: InitContainerSpec describes configuration
@@ -1934,8 +1929,6 @@ spec:
                       image should be used on OpenShift to build and install driver
                       modules
                     type: boolean
-                required:
-                - defaultRuntime
                 type: object
               psa:
                 description: PSA defines spec for PodSecurityAdmission configuration

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -1887,13 +1887,8 @@ spec:
                       queryable and should be preserved when modifying objects.
                     type: object
                   defaultRuntime:
-                    default: docker
                     description: 'Deprecated: DefaultRuntime is no longer used by
                       the gpu-operator. This is instead, detected at runtime.'
-                    enum:
-                    - docker
-                    - crio
-                    - containerd
                     type: string
                   initContainer:
                     description: 'Deprecated: InitContainerSpec describes configuration
@@ -1934,8 +1929,6 @@ spec:
                       image should be used on OpenShift to build and install driver
                       modules
                     type: boolean
-                required:
-                - defaultRuntime
                 type: object
               psa:
                 description: PSA defines spec for PodSecurityAdmission configuration

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -1887,13 +1887,8 @@ spec:
                       queryable and should be preserved when modifying objects.
                     type: object
                   defaultRuntime:
-                    default: docker
                     description: 'Deprecated: DefaultRuntime is no longer used by
                       the gpu-operator. This is instead, detected at runtime.'
-                    enum:
-                    - docker
-                    - crio
-                    - containerd
                     type: string
                   initContainer:
                     description: 'Deprecated: InitContainerSpec describes configuration
@@ -1934,8 +1929,6 @@ spec:
                       image should be used on OpenShift to build and install driver
                       modules
                     type: boolean
-                required:
-                - defaultRuntime
                 type: object
               psa:
                 description: PSA defines spec for PodSecurityAdmission configuration


### PR DESCRIPTION
 Commit cf964b8c marked `defaultRuntime` as deprecated, removed it from alm-examples in the OpenShift operator. However, the validations on this field remained in the CRD. As a result,  trying to create a default `ClusterPolicy` based on alm-examples failed with the following error:
    
```
spec.operator.defaultRuntime: Unsupported value: "": supported values:
"docker", "crio", "containerd"
```
    
This fixes the issue by making the field optional and removing the validations.

## Description

<!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

No code changes to affect unit-tests. The fix was tested manually with a custom bundle image.

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

