### PR TITLE
add back defaultRuntime to almExample

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -29,6 +29,7 @@ metadata:
           },
           "spec": {
             "operator": {
+              "defaultRuntime": "crio",
               "use_ocp_driver_toolkit": true
             },
             "cdi": {


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Without this, openshift specific tests were failing in CI here: https://github.com/rh-ecosystem-edge/nvidia-ci/pull/472
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

