### PR TITLE
Remove default kata-manager config from helm values

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -477,23 +477,7 @@ vfioManager:
 
 kataManager:
   enabled: false
-  config:
-    artifactsDir: "/opt/nvidia-gpu-operator/artifacts/runtimeclasses"
-    runtimeClasses:
-      - name: kata-nvidia-gpu
-        nodeSelector: {}
-        artifacts:
-          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.54.03
-          pullSecret: ""
-      - name: kata-nvidia-gpu-snp
-        nodeSelector:
-          "nvidia.com/cc.capable": "true"
-        artifacts:
-          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.86.10-snp
-          pullSecret: ""
-  repository: nvcr.io/nvidia/cloud-native
-  image: k8s-kata-manager
-  version: v0.2.3
+  config: {}
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   env: []


### PR DESCRIPTION
The k8s-kata-manager operand is deprecated: https://github.com/NVIDIA/k8s-kata-manager/commit/ea4044e951f16a615de9c15b65dfb6c760c7af1d To enable kata containers for GPUs, it is required to install the upstream kata-deploy helm chart which will lay down all of the kata runtime classes (including NVIDIA-specific runtime classes).
