### PR TITLE
[dcgm][dcgm-exporter] add liveness and readiness probes

### DIFF
--- a/assets/state-dcgm-exporter/0800_daemonset.yaml
+++ b/assets/state-dcgm-exporter/0800_daemonset.yaml
@@ -52,6 +52,17 @@ spec:
         ports:
         - name: "metrics"
           containerPort: 9400
+        livenessProbe:
+          httpGet:
+            port: 9400
+            path: /health
+          initialDelaySeconds: 45
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            port: 9400
+            path: /health
+          initialDelaySeconds: 45
         volumeMounts:
         - name: "pod-gpu-resources"
           readOnly: true

--- a/assets/state-dcgm/0400_dcgm.yml
+++ b/assets/state-dcgm/0400_dcgm.yml
@@ -43,6 +43,14 @@ spec:
         ports:
         - name: "dcgm"
           containerPort: 5555
+        livenessProbe:
+          tcpSocket:
+            port: 5555
+          initialDelaySeconds: 15
+        readinessProbe:
+          tcpSocket:
+            port: 5555
+          initialDelaySeconds: 15
       volumes:
         - name: run-nvidia
           hostPath:


### PR DESCRIPTION
This commit adds liveness and readiness probes to the dcgm and dcgm-exporter operands. Adding probes to the DCGM pods ensure that these pods aren't marked as "Ready" until the DCGM is actually ready to serve traffic. The DCGM-Exporter probes have been taken from the default probes configured in the helm chart of the NVIDIA/dcgm-exporter project.

The liveness and readiness probe values have been taken from the standalone DCGM Exporter helm chart. Please see [here](https://github.com/NVIDIA/dcgm-exporter/blob/7b8b7006d147e5d2e9227c427b2549dc351238a8/deployment/values.yaml#L347)
