### PR TITLE
Make kataManager.config conditional in ClusterPolicy template

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -300,7 +300,9 @@ spec:
       {{- end }}
   kataManager:
     enabled: {{ .Values.kataManager.enabled }}
+    {{- if .Values.kataManager.config }}
     config: {{ toYaml .Values.kataManager.config | nindent 6 }}
+    {{- end }}
     {{- if .Values.kataManager.repository }}
     repository: {{ .Values.kataManager.repository }}
     {{- end }}


### PR DESCRIPTION
## Description

Default `kataManager.config` is empty and results in a `null` value which ClusterPolicy rejects.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

