### PR TITLE
Add leader election configuration to operator deployment

### DIFF
--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -39,7 +39,9 @@ spec:
         imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
         command: ["gpu-operator"]
         args:
+        {{- if .Values.operator.leaderElection }}
         - --leader-elect
+        {{- end }}
       {{- if .Values.operator.logging.develMode }}
         - --zap-devel
       {{- else }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -74,6 +74,8 @@ operator:
   priorityClassName: system-node-critical
   runtimeClass: nvidia
   use_ocp_driver_toolkit: false
+  # Enable leader election
+  leaderElection: true
   # cleanup CRD on chart un-install
   cleanupCRD: false
   # upgrade CRD on chart upgrade, requires --disable-openapi-validation flag


### PR DESCRIPTION
## Description

Add config to operator's leader election, for single replica, disable the leader election can prevent the unwanted crash of gpu-operator due to transient error.

https://github.com/NVIDIA/gpu-operator/issues/772

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

