### PR TITLE
[ci][validate-images] replace global regclient with a locally init'ed one

### DIFF
--- a/cmd/gpuop-cfg/validate/clusterpolicy/images.go
+++ b/cmd/gpuop-cfg/validate/clusterpolicy/images.go
@@ -26,8 +26,6 @@ import (
 	v1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 )
 
-var client = regclient.New()
-
 func validateImages(ctx context.Context, spec *v1.ClusterPolicySpec) error {
 	// Driver
 	path, err := v1.ImagePath(&spec.Driver)
@@ -158,6 +156,7 @@ func validateImages(ctx context.Context, spec *v1.ClusterPolicySpec) error {
 }
 
 func validateImage(ctx context.Context, path string) error {
+	var client = regclient.New()
 	ref, err := ref.New(path)
 	if err != nil {
 		return fmt.Errorf("failed to construct an image reference: %v", err)

--- a/cmd/gpuop-cfg/validate/csv/images.go
+++ b/cmd/gpuop-cfg/validate/csv/images.go
@@ -26,8 +26,6 @@ import (
 	"github.com/regclient/regclient/types/ref"
 )
 
-var client = regclient.New()
-
 func validateImages(ctx context.Context, csv *v1alpha1.ClusterServiceVersion) error {
 	// validate all 'relatedImages'
 	images := csv.Spec.RelatedImages
@@ -63,6 +61,7 @@ func validateImages(ctx context.Context, csv *v1alpha1.ClusterServiceVersion) er
 }
 
 func validateImage(ctx context.Context, path string) error {
+	var client = regclient.New()
 	ref, err := ref.New(path)
 	if err != nil {
 		return fmt.Errorf("failed to construct an image reference: %v", err)


### PR DESCRIPTION
This PR fixes the recent `401 unauthorized` errors observed in our CI pipelines. To fix this error, we instantiate the regclient every time `validateImages` is called as opposed to use a single regclient reused globally throughout the programme's lifetime.

h/t to @karthikvetrivel  for figuring this out very quickly!