### PR TITLE
avoid unicode character that messes up pod rendering

### DIFF
--- a/assets/state-kata-device-plugin/0500_daemonset.yaml
+++ b/assets/state-kata-device-plugin/0500_daemonset.yaml
@@ -30,7 +30,7 @@ spec:
           command: ['sh', '-c']
           args:
             - until [ -f /run/nvidia/validations/workload-type ]; do echo waiting for workload type status file; sleep 5; done;
-              if [ "$(</run/nvidia/validations/workload-type)" != "vm-passthrough" ]; then echo kata not needed, skipping validation; exit 0; fi;
+              if [ "$(cat /run/nvidia/validations/workload-type)" != "vm-passthrough" ]; then echo kata not needed, skipping validation; exit 0; fi;
               until [ -f /run/nvidia/validations/vfio-pci-ready ]; do echo waiting for vfio-pci driver ...; sleep 5; done;
           env:
             - name: NVIDIA_VISIBLE_DEVICES

--- a/assets/state-sandbox-device-plugin/0500_daemonset.yaml
+++ b/assets/state-sandbox-device-plugin/0500_daemonset.yaml
@@ -30,7 +30,7 @@ spec:
           command: ['sh', '-c']
           args:
             - until [ -f /run/nvidia/validations/workload-type ]; do echo waiting for workload type status file; sleep 5; done;
-              if [ "$(</run/nvidia/validations/workload-type)" != "vm-passthrough" ]; then echo vfio-pci not needed, skipping validation; exit 0; fi;
+              if [ "$(cat /run/nvidia/validations/workload-type)" != "vm-passthrough" ]; then echo vfio-pci not needed, skipping validation; exit 0; fi;
               until [ -f /run/nvidia/validations/vfio-pci-ready ]; do echo waiting for vfio-pci driver ...; sleep 5; done;
           env:
             - name: NVIDIA_VISIBLE_DEVICES
@@ -46,7 +46,7 @@ spec:
           command: ['sh', '-c']
           args:
             - until [ -f /run/nvidia/validations/workload-type ]; do echo waiting for workload type status file; sleep 5; done;
-              if [ "$(</run/nvidia/validations/workload-type)" != "vm-vgpu" ]; then echo vgpu-devices not needed, skipping validation; exit 0; fi;
+              if [ "$(cat /run/nvidia/validations/workload-type)" != "vm-vgpu" ]; then echo vgpu-devices not needed, skipping validation; exit 0; fi;
               until [ -f /run/nvidia/validations/vgpu-devices-ready ]; do echo waiting for vGPU devices...; sleep 5; done;
           env:
             - name: NVIDIA_VISIBLE_DEVICES


### PR DESCRIPTION
## Description

When using the '<' character, the script is rendered like this:
`if [ \"$(\u003c/run/nvidia/validations/workload-type)\" != \"vm-passthrough\" ]; then echo kata not needed, skipping validation; exit 0; fi;`

This PR changes the `<` to `cat` so that the init check is functional.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Manual out of band testing.
