### PR TITLE
Fix English capitalization and clarify plural example in README

### DIFF
--- a/vendor/k8s.io/kubectl/pkg/util/i18n/translations/README.md
+++ b/vendor/k8s.io/kubectl/pkg/util/i18n/translations/README.md
@@ -69,10 +69,10 @@ To use translations, you simply need to add:
 import pkg/i18n
 ...
 // Get a translated string
-translated := i18n.T("Your message in english here")
+translated := i18n.T("Your message in English here")
 
 // Get a translated plural string
-translated := i18n.T("You had %d items", items)
+translatedPlural := i18n.T("You had %d items", items)
 
 // Translated error
 return i18n.Error("Something bad happened")


### PR DESCRIPTION
## Description

This PR addresses minor documentation issues in the README.md:

- Corrects the capitalization of English in the translation example.
- Improves readability of the plural translation example by clearly separating singular and plural cases.

## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [X] Lint checks passing (`make lint`)
- [X] Generated assets in-sync (`make validate-generated-assets`)
- [X] Go mod artifacts in-sync (`make validate-modules`)
- [X] Test cases are added for new code paths

## Testing

No functional changes.  
Only documentation edits; tested by reviewing the README content.
