### PR TITLE
Improve script robustness with set -euo pipefail

### DIFF
--- a/scripts/gpu-operator-nvaie.sh
+++ b/scripts/gpu-operator-nvaie.sh
@@ -27,7 +27,7 @@
 #
 #   2. vGPU driver license have to be downloaded from the NVIDIA licensing portal in the current directory and saved as "client_configuration_token.tok"
 
-set -u
+set -euo pipefail
 
 NGC_API_KEY=${NGC_API_KEY:?"Missing NGC_API_KEY"}
 NGC_USER_EMAIL=${NGC_USER_EMAIL:?"Missing NGC_USER_EMAIL"}


### PR DESCRIPTION
## Description

Enable set -euo pipefail in the GPU Operator NVAIE installation script to improve robustness.
This ensures the script:

- Exits immediately on any command failure (-e)
- Detects use of unset variables (-u)
- Fails if any command in a pipeline fails (-o pipefail)

This change reduces the risk of partial or inconsistent deployments during installation.

## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing
Tested manually by running the script on a cluster with an existing GPU Operator namespace, verifying that:

- The script exits immediately if a required environment variable is missing
- The script stops if any kubectl or helm command fails
- Existing resources are handled correctly without partial creation


