### PR TITLE
[ci] allow manual invocation of renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,6 +1,7 @@
 name: Renovate
 
 on:
+  workflow_dispatch:
   schedule:
      - cron: "0 9 * * *" # every day at 9:00 AM UTC
 


### PR DESCRIPTION
This allows one to manually run the renovate workflow which updates container images (when updates are available).

