### PR TITLE
[renovate] fix renovate config for a few operands

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,20 +65,14 @@
         "nvcr.io/nvidia/cloud-native/k8s-driver-manager",
         "nvcr.io/nvidia/cloud-native/k8s-kata-manager",
         "nvcr.io/nvidia/cloud-native/vgpu-device-manager",
-        "nvcr.io/nvidia/cloud-native/vgpu-cc-manager",
+        "nvcr.io/nvidia/cloud-native/k8s-cc-manager",
+        "nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin",
         "nvcr.io/nvidia/kubevirt-gpu-device-plugin",
-        "nvcr.io/nvidia/k8s-device-plugin"
+        "nvcr.io/nvidia/k8s-device-plugin",
+        "nvcr.io/nvidia/k8s/container-toolkit",
+        "nvcr.io/nvidia/cloud-native/k8s-mig-manager"
       ],
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "separateMajorMinor": false
-    },
-    {
-      "matchPaths": ["deployments/gpu-operator/values.yaml"],
-      "matchPackageNames": [
-       "nvcr.io/nvidia/k8s/container-toolkit",
-       "nvcr.io/nvidia/cloud-native/k8s-mig-manager"
-      ],
-      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ubuntu(?<ubuntu>\\d+\\.\\d+)$",
       "separateMajorMinor": false
     },
     {


### PR DESCRIPTION
This commit does the following:
- Fix typo in the k8s-cc-manager image name
- Update rules for container-toolkit and k8s-mig-manager as their image tags no longer have a distro suffix
- Add nvidia-sandbox-device-plugin to list of images

This was tested on my fork. I manually ran the renovate github action workflow on my fork (https://github.com/cdesiniotis/gpu-operator/actions/runs/23223632109) and it generated the following PRs for k8s-cc-manager and k8s-mig-manager:
https://github.com/cdesiniotis/gpu-operator/pull/12
https://github.com/cdesiniotis/gpu-operator/pull/11 (note, this did not update the CSV file since we point to ghcr.io there currently)