### PR TITLE
Skip device plugin alert when devicePlugin is disabled in ClusterPolicy

### DIFF
--- a/assets/state-node-status-exporter/0800_prometheus_rule_openshift.yaml
+++ b/assets/state-node-status-exporter/0800_prometheus_rule_openshift.yaml
@@ -10,7 +10,10 @@ spec:
   - name: Alert on node deployment failure
     rules:
     - alert: GPUOperatorNodeDeploymentFailed
-      # There is no GPU exposed on the node,
+      # There is no GPU exposed on the node.
+      # When the device plugin is intentionally disabled in the ClusterPolicy
+      # (devicePlugin.enabled: false), the metric is set to -1, so this
+      # alert will not fire in that case.
       expr: |
         gpu_operator_node_device_plugin_devices_total == 0
       for: 30m

--- a/cmd/nvidia-validator/metrics.go
+++ b/cmd/nvidia-validator/metrics.go
@@ -306,7 +306,15 @@ func (nm *NodeMetrics) Run() error {
 	go nm.watchStatusFile(&nm.cudaReady, cudaStatusFile)
 
 	go nm.watchDriverValidation()
-	go nm.watchDevicePluginValidation()
+	if os.Getenv("DEVICE_PLUGIN_ENABLED") != "false" {
+		go nm.watchDevicePluginValidation()
+	} else {
+		// Set to -1 so the alert (expr: == 0) does not fire.
+		// The gauge is auto-registered by promauto and defaults to 0,
+		// which would be a false positive.
+		nm.deviceCount.Set(-1)
+		log.Info("metrics: DevicePlugin is disabled in ClusterPolicy, skipping device plugin validation")
+	}
 	go nm.watchNVIDIAPCI()
 
 	log.Printf("Running the metrics server, listening on :%d/metrics", nm.port)

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -131,6 +131,8 @@ const (
 	NvidiaDisableRequireEnvName = "NVIDIA_DISABLE_REQUIRE"
 	// GDSEnabledEnvName is the env name to enable GDS support with device-plugin
 	GDSEnabledEnvName = "GDS_ENABLED"
+	// DevicePluginEnabledEnvName indicates whether the device plugin is enabled in the ClusterPolicy
+	DevicePluginEnabledEnvName = "DEVICE_PLUGIN_ENABLED"
 	// MOFEDEnabledEnvName is the env name to enable MOFED devices injection with device-plugin
 	MOFEDEnabledEnvName = "MOFED_ENABLED"
 	// GDRCopyEnabledEnvName is the envvar that enables injection of the GDRCopy device node with the device-plugin
@@ -2537,6 +2539,12 @@ func TransformNodeStatusExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPol
 	if len(config.NodeStatusExporter.Args) > 0 {
 		obj.Spec.Template.Spec.Containers[0].Args = config.NodeStatusExporter.Args
 	}
+
+	devicePluginEnabled := "true"
+	if !config.DevicePlugin.IsEnabled() {
+		devicePluginEnabled = "false"
+	}
+	setContainerEnv(&(obj.Spec.Template.Spec.Containers[0]), DevicePluginEnabledEnvName, devicePluginEnabled)
 
 	// set/append environment variables for exporter container
 	if len(config.NodeStatusExporter.Env) > 0 {

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -3052,6 +3052,35 @@ func TestTransformNodeStatusExporter(t *testing.T) {
 					Name:            "dummy",
 					Image:           "nvcr.io/nvidia/cloud-native/node-status-exporter:v1.0.0",
 					ImagePullPolicy: corev1.PullIfNotPresent,
+					Env: []corev1.EnvVar{
+						{Name: DevicePluginEnabledEnvName, Value: "true"},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: rootUID,
+					},
+				}),
+		},
+		{
+			description: "node status exporter with device plugin disabled",
+			ds: NewDaemonset().
+				WithContainer(corev1.Container{Name: "dummy"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				NodeStatusExporter: gpuv1.NodeStatusExporterSpec{
+					Repository:      "nvcr.io/nvidia/cloud-native",
+					Image:           "node-status-exporter",
+					Version:         "v1.0.0",
+					ImagePullPolicy: "IfNotPresent",
+				},
+				DevicePlugin: gpuv1.DevicePluginSpec{Enabled: newBoolPtr(false)},
+			},
+			expectedDs: NewDaemonset().
+				WithContainer(corev1.Container{
+					Name:            "dummy",
+					Image:           "nvcr.io/nvidia/cloud-native/node-status-exporter:v1.0.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Env: []corev1.EnvVar{
+						{Name: DevicePluginEnabledEnvName, Value: "false"},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: rootUID,
 					},

--- a/tests/e2e/helpers/clusterpolicy.go
+++ b/tests/e2e/helpers/clusterpolicy.go
@@ -106,6 +106,18 @@ func (h *ClusterPolicyClient) DisableGFD(ctx context.Context, name string) error
 	})
 }
 
+func (h *ClusterPolicyClient) EnableDevicePlugin(ctx context.Context, name string) error {
+	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
+		clusterPolicy.Spec.DevicePlugin.Enabled = ptr.To(true)
+	})
+}
+
+func (h *ClusterPolicyClient) DisableDevicePlugin(ctx context.Context, name string) error {
+	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
+		clusterPolicy.Spec.DevicePlugin.Enabled = ptr.To(false)
+	})
+}
+
 func (h *ClusterPolicyClient) SetMIGStrategy(ctx context.Context, name, strategy string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
 		clusterPolicy.Spec.MIG.Strategy = nvidiav1.MIGStrategy(strategy)

--- a/tests/e2e/suites/clusterpolicy_test.go
+++ b/tests/e2e/suites/clusterpolicy_test.go
@@ -328,6 +328,43 @@ var _ = Describe("ClusterPolicy Management", Label("clusterPolicy"), func() {
 		})
 	})
 
+	// test_device_plugin_disabled_env - Verify DEVICE_PLUGIN_ENABLED env var propagation
+	When("Disabling device plugin", Label("device-plugin", "toggle"), func() {
+		It("should set DEVICE_PLUGIN_ENABLED=false on node-status-exporter when device plugin is disabled", func(ctx context.Context) {
+			clusterPolicy := getClusterPolicyOrSkip(ctx, clusterPolicyClient, policyName)
+			originalState := clusterPolicy.Spec.DevicePlugin.Enabled
+			DeferCleanup(func(ctx context.Context) {
+				if originalState == nil || *originalState {
+					_ = clusterPolicyClient.EnableDevicePlugin(ctx, policyName)
+					waitForDaemonSetReady(ctx, daemonSetClient, testNamespace, "nvidia-device-plugin-daemonset")
+				}
+			})
+
+			err := clusterPolicyClient.DisableDevicePlugin(ctx, policyName)
+			Expect(err).NotTo(HaveOccurred(), "Failed to disable device plugin in ClusterPolicy")
+
+			verifyEnvInDaemonSet(ctx, daemonSetClient, testNamespace,
+				"nvidia-node-status-exporter", "DEVICE_PLUGIN_ENABLED", "false")
+		})
+
+		It("should set DEVICE_PLUGIN_ENABLED=true on node-status-exporter when device plugin is re-enabled", func(ctx context.Context) {
+			clusterPolicy := getClusterPolicyOrSkip(ctx, clusterPolicyClient, policyName)
+			originalState := clusterPolicy.Spec.DevicePlugin.Enabled
+			DeferCleanup(func(ctx context.Context) {
+				if originalState != nil && !*originalState {
+					_ = clusterPolicyClient.DisableDevicePlugin(ctx, policyName)
+				}
+			})
+
+			err := clusterPolicyClient.EnableDevicePlugin(ctx, policyName)
+			Expect(err).NotTo(HaveOccurred(), "Failed to enable device plugin in ClusterPolicy")
+
+			verifyEnvInDaemonSet(ctx, daemonSetClient, testNamespace,
+				"nvidia-node-status-exporter", "DEVICE_PLUGIN_ENABLED", "true")
+			waitForDaemonSetReady(ctx, daemonSetClient, testNamespace, "nvidia-device-plugin-daemonset")
+		})
+	})
+
 	// test_custom_labels_override - Test custom labels on daemonsets
 	When("Updating daemonset custom labels", Label("labels", "config"), func() {
 		It("should apply custom labels to all operand pods", func(ctx context.Context) {


### PR DESCRIPTION
## Summary

When `devicePlugin.enabled` is set to `false` in the ClusterPolicy, the `nvidia-node-status-exporter` still monitors `gpu_operator_node_device_plugin_devices_total`, which reports `0` (since no device plugin pods are running). This triggers a false positive `GPUOperatorNodeDeploymentFailed` alert after 30 minutes.

This is a valid configuration — for example, when GPU allocation is managed externally via MIG partitioning through a third-party operator.

## Changes

- **`controllers/object_controls.go`**: The operator now injects a `DEVICE_PLUGIN_ENABLED` env var into the node-status-exporter daemonset based on `config.DevicePlugin.IsEnabled()`.
- **`cmd/nvidia-validator/metrics.go`**: When `DEVICE_PLUGIN_ENABLED=false`, the exporter skips device plugin validation and sets the gauge to `-1` (documented sentinel value), preventing the `== 0` alert from firing.
- **`assets/state-node-status-exporter/0800_prometheus_rule_openshift.yaml`**: Updated comment to document the behavior.
- **`controllers/transforms_test.go`**: Unit tests for env var injection (enabled + disabled).
- **`tests/e2e/helpers/clusterpolicy.go`**: `EnableDevicePlugin`/`DisableDevicePlugin` helpers.
- **`tests/e2e/suites/clusterpolicy_test.go`**: E2E tests verifying env var propagation to node-status-exporter daemonset.

## Test plan

- [x] Unit tests pass (`TestTransformNodeStatusExporter`)
- [x] Code compiles (`go build ./cmd/nvidia-validator/` and `go build ./controllers/`)
- [x] E2E tests compile (`go build ./tests/e2e/...`)
- [ ] Manual validation on hardware with MIG-capable GPUs and `devicePlugin.enabled: false`

Fixes: https://github.com/NVIDIA/gpu-operator/issues/2237