### PR TITLE
fix: driver and toolkit ready state file cleanup

### DIFF
--- a/assets/state-container-toolkit/0500_daemonset.yaml
+++ b/assets/state-container-toolkit/0500_daemonset.yaml
@@ -81,6 +81,10 @@ spec:
           privileged: true
           seLinuxOptions:
             level: "s0"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/toolkit-ready"]
         volumeMounts:
           - name: nvidia-container-toolkit-entrypoint
             readOnly: true

--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -150,7 +150,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.driver-ctr-ready"]
+              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/driver-ready"]
       - image: "FILLED BY THE OPERATOR"
         imagePullPolicy: IfNotPresent
         name: nvidia-peermem-ctr


### PR DESCRIPTION
## Description
Fix stale readiness file handling for driver and toolkit operands during restart/upgrade flows.

During upgrade, the old driver-ready and toolkit-ready files can remain on the host because unlike .driver-ctr-ready, they were not being cleaned up during pod shutdown.
mig-manager only waits for those files to exist, not for new validation of the new driver/toolkit state. 
So after driver reinstall: mig-manager can start using old ready signals before the new driver/toolkit libraries are actually available.
files are only deleted when the corresponding validator runs again:

toolkit-ready :
```
func (t *Toolkit) validate() error {
	// delete status file is already present
	err := deleteStatusFile(outputDirFlag + "/" + toolkitStatusFile)
	if err != nil {
		return err
	}
```

driver-ready:
```
func (d *Driver) validate() error {
	// delete driver status file if already present
	err := deleteStatusFile(outputDirFlag + "/" + driverStatusFile)
	if err != nil {
		return err
	}
```

_The patch fixes that by cleaning up driver-ready and toolkit-ready file._

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Manual validation on hardware with MIG-capable GPUs  

## Testing
Reproduction in a test environment was not possible because the issue appears to be timing-dependent and hard to reproduce reliably.
Validation for this change was done by code-path analysis. 
I will perform manual validation on hardware with MIG-capable GPUs  

