### PR TITLE
Add update-sonarqube job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ testbin/*
 *~
 *.DS_Store
 .vscode
+.scannerwork/
 
 # Credentials and runtime environment
 kubeconfig

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -162,6 +162,25 @@ update-nspect:
     NSPECT_CLIENT_ID: "${NSPECT_PROD_CLIENT_ID}" 
     NSPECT_CLIENT_SECRET: "${NSPECT_PROD_CLIENT_SECRET}"
 
+update-sonarqube:
+  stage: ngc-publish
+  needs:
+    - job: update-nspect
+      optional: true
+    - job: update-nspect-staging
+      optional: true
+  image:
+    name: sonarsource/sonar-scanner-cli:11
+    entrypoint: [""]
+  variables:
+    SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"
+    GIT_DEPTH: "0"
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'main'
+  allow_failure: true
+  script:
+    - sonar-scanner -Dsonar.host.url="${SONAR_HOST_URL}" -Dsonar.projectKey=gpu-operator -Dsonar.projectName=gpu-operator -Dsonar.sources=.
+
 .publish-images:
   stage: ngc-publish
   extends:


### PR DESCRIPTION
## Description

This change creates a job to update sonarqube for the gpu-operator repository. It will only run on the main branch to ensure the sonarqube version is up to date. It will use the sonarsource/sonar-scanner-cli:11 image.

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Pipeline was tested manually on Gitlab test branch; verified that sonarqube report was being generated online.

