### PR TITLE
reconcile all nvidiadrivers when any nvidiadriver is changed

### DIFF
--- a/controllers/nvidiadriver_controller.go
+++ b/controllers/nvidiadriver_controller.go
@@ -249,6 +249,33 @@ func (r *NVIDIADriverReconciler) updateCrStatus(
 	return nil
 }
 
+// enqueueAllNVIDIADrivers lists all NVIDIADriver instances in the cluster and enqueues a reconcile
+// request for each instance. This is used to trigger reconciliation for all NVIDIADriver instances
+// when a relevant event occurs (e.g. ClusterPolicy/NVIDIADriver update, node label change, etc).
+func (r *NVIDIADriverReconciler) enqueueAllNVIDIADrivers(ctx context.Context) []reconcile.Request {
+	logger := log.FromContext(ctx)
+	list := &nvidiav1alpha1.NVIDIADriverList{}
+
+	err := r.List(ctx, list)
+	if err != nil {
+		logger.Error(err, "Unable to list NVIDIADriver resources")
+		return []reconcile.Request{}
+	}
+
+	reconcileRequests := make([]reconcile.Request, 0, len(list.Items))
+	for _, nvidiaDriver := range list.Items {
+		reconcileRequests = append(reconcileRequests,
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      nvidiaDriver.GetName(),
+					Namespace: nvidiaDriver.GetNamespace(),
+				},
+			})
+	}
+
+	return reconcileRequests
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *NVIDIADriverReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	// Create state manager
@@ -278,11 +305,17 @@ func (r *NVIDIADriverReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		return err
 	}
 
-	// Watch for changes to the primary resource NVIDIaDriver
+	// Watch for changes to NVIDIADriver CRs. Whenever an event is generated for a NVIDIADriver CR,
+	// enqueue a reconcile request for all NVIDIADriver instances.
+	nvidiaDriverMapFn := func(ctx context.Context, _ *nvidiav1alpha1.NVIDIADriver) []reconcile.Request {
+		return r.enqueueAllNVIDIADrivers(ctx)
+	}
+
+	// Watch for changes to the primary resource NVIDIADriver
 	err = c.Watch(source.Kind(
 		mgr.GetCache(),
 		&nvidiav1alpha1.NVIDIADriver{},
-		&handler.TypedEnqueueRequestForObject[*nvidiav1alpha1.NVIDIADriver]{},
+		handler.TypedEnqueueRequestsFromMapFunc(nvidiaDriverMapFn),
 		predicate.TypedGenerationChangedPredicate[*nvidiav1alpha1.NVIDIADriver]{},
 	),
 	)
@@ -292,63 +325,21 @@ func (r *NVIDIADriverReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 
 	// Watch for changes to ClusterPolicy. Whenever an event is generated for ClusterPolicy, enqueue
 	// a reconcile request for all NVIDIADriver instances.
-	mapFn := func(ctx context.Context, cp *gpuv1.ClusterPolicy) []reconcile.Request {
-		logger := log.FromContext(ctx)
-		opts := []client.ListOption{}
-		list := &nvidiav1alpha1.NVIDIADriverList{}
-
-		err := mgr.GetClient().List(ctx, list, opts...)
-		if err != nil {
-			logger.Error(err, "Unable to list NVIDIADriver resources")
-			return []reconcile.Request{}
-		}
-
-		reconcileRequests := []reconcile.Request{}
-		for _, nvidiaDriver := range list.Items {
-			reconcileRequests = append(reconcileRequests,
-				reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      nvidiaDriver.GetName(),
-						Namespace: nvidiaDriver.GetNamespace(),
-					},
-				})
-		}
-
-		return reconcileRequests
+	mapFn := func(ctx context.Context, _ *gpuv1.ClusterPolicy) []reconcile.Request {
+		return r.enqueueAllNVIDIADrivers(ctx)
 	}
 
-	// Watch for changes to the Nodes. Whenever an event is generated for ClusterPolicy, enqueue
+	// Watch for changes to the Nodes. Whenever an event is generated for a Node, enqueue
 	// a reconcile request for all NVIDIADriver instances.
-	nodeMapFn := func(ctx context.Context, cp *corev1.Node) []reconcile.Request {
-		logger := log.FromContext(ctx)
-		opts := []client.ListOption{}
-		list := &nvidiav1alpha1.NVIDIADriverList{}
-
-		err := mgr.GetClient().List(ctx, list, opts...)
-		if err != nil {
-			logger.Error(err, "Unable to list NVIDIADriver resources")
-			return []reconcile.Request{}
-		}
-
-		reconcileRequests := []reconcile.Request{}
-		for _, nvidiaDriver := range list.Items {
-			reconcileRequests = append(reconcileRequests,
-				reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      nvidiaDriver.GetName(),
-						Namespace: nvidiaDriver.GetNamespace(),
-					},
-				})
-		}
-
-		return reconcileRequests
+	nodeMapFn := func(ctx context.Context, _ *corev1.Node) []reconcile.Request {
+		return r.enqueueAllNVIDIADrivers(ctx)
 	}
 
 	err = c.Watch(
 		source.Kind(
 			mgr.GetCache(),
 			&gpuv1.ClusterPolicy{},
-			handler.TypedEnqueueRequestsFromMapFunc[*gpuv1.ClusterPolicy](mapFn),
+			handler.TypedEnqueueRequestsFromMapFunc(mapFn),
 			predicate.TypedGenerationChangedPredicate[*gpuv1.ClusterPolicy]{},
 		),
 	)
@@ -386,7 +377,7 @@ func (r *NVIDIADriverReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	err = c.Watch(
 		source.Kind(mgr.GetCache(),
 			&corev1.Node{},
-			handler.TypedEnqueueRequestsFromMapFunc[*corev1.Node](nodeMapFn),
+			handler.TypedEnqueueRequestsFromMapFunc(nodeMapFn),
 			nodePredicate,
 		),
 	)

--- a/controllers/nvidiadriver_controller_test.go
+++ b/controllers/nvidiadriver_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"sort"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -244,4 +245,25 @@ func TestReconcileConflictSetsNotReadyState(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, nvidiav1alpha1.NotReady, updater.LastErrorState)
+}
+
+func TestEnqueueAllNVIDIADrivers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiav1alpha1.AddToScheme(scheme))
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&nvidiav1alpha1.NVIDIADriver{ObjectMeta: metav1.ObjectMeta{Name: "driver-a", Namespace: "default"}},
+		&nvidiav1alpha1.NVIDIADriver{ObjectMeta: metav1.ObjectMeta{Name: "driver-b", Namespace: "default"}},
+	).Build()
+
+	reconciler := &NVIDIADriverReconciler{Client: client}
+	requests := reconciler.enqueueAllNVIDIADrivers(context.Background())
+
+	require.Len(t, requests, 2)
+	got := []string{
+		requests[0].String(),
+		requests[1].String(),
+	}
+	sort.Strings(got)
+	require.Equal(t, []string{"default/driver-a", "default/driver-b"}, got)
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/NVIDIA/gpu-operator/issues/2259

<!-- Brief description of the change, including context or motivation -->
### Issue

When multiple NVIDIADriver CRs exist, conflict validation is global (overlapping node selection across all driver CRs). A common case is the default CR (no nodeSelector) selecting all GPU nodes, which blocks custom CRs with targeted selectors.
Blocked CRs currently exit reconcile from the validation path with no requeue, so they remain stuck until an external event re-triggers them.
Deleting the conflicting default CR changes global validity, but previously only the deleted object was enqueued by the primary watch, so remaining CRs were not retried immediately.

### Options Considered

#### Option 1 (implemented): 
On NVIDIADriver events, enqueue reconcile for all NVIDIADriver CRs via TypedEnqueueRequestsFromMapFunc (fan-out).

#### Option 2 (not implemented): 
Return error from validation failure so each conflicting CR self-requeues via the rate-limiter.
Basically here. switch from nil to error: https://github.com/NVIDIA/gpu-operator/blob/d5750f2f3033f38341c991e2f2a494744344abea/controllers/nvidiadriver_controller.go#L151

### Why Option 1

- Retries happen when global conflict state actually changes (create/update/delete of relevant CRs), which is the right signal.
- Avoids continuous error-driven retry loops while conflict is expected/user-caused.
- Reduces log noise and unnecessary reconcile churn, especially with many conflicting CRs and MaxConcurrentReconciles=1.
- Provides immediate unstick behavior after deleting the blocking CR, without waiting for backoff retry windows.

### Why Option 2 is less useful

- Treats a configuration conflict as a transient controller failure, causing repeated retries that usually cannot succeed until user action.
- Generates sustained error logs and queue pressure; with single-worker reconcile this can delay useful work for other requests.
- Many conflicting CRs could keep that single worker busy with repeated retries.
- Converges eventually, but less efficiently and with poorer operational signal-to-noise.

### Expected Outcome

After removing a conflicting NVIDIADriver (for example, deleting default CR), remaining previously blocked CRs are automatically revalidated and can proceed without manual nudges.


## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

