### PR TITLE
dcgm-exporter: enable ServiceMonitor by default and skip gracefully when Prometheus CRD is absent

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -4996,9 +4996,10 @@ func ServiceMonitor(n ClusterPolicyController) (gpuv1.State, error) {
 			return gpuv1.Disabled, nil
 		}
 
+		// If Prometheus CRD is missing, skip gracefully
 		if !serviceMonitorCRDExists {
-			logger.Error(fmt.Errorf("couldn't find ServiceMonitor CRD"), "Install Prometheus and necessary CRDs for gathering GPU metrics!")
-			return gpuv1.NotReady, nil
+			logger.V(1).Info("ServiceMonitor CRD not found, skipping DCGM Exporter ServiceMonitor creation")
+			return gpuv1.Ready, nil
 		}
 
 		// Apply custom edits for DCGM Exporter

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -1325,7 +1325,7 @@ func TestServiceMonitor(t *testing.T) {
 			expectedServiceMonitor: nil,
 		},
 		{
-			description: "dcgm-exporter SM enabled, CRD missing -> NotReady",
+			description: "dcgm-exporter SM explicitly enabled, CRD missing -> Ready (skip gracefully)",
 			stateName:   "state-dcgm-exporter",
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
@@ -1334,7 +1334,45 @@ func TestServiceMonitor(t *testing.T) {
 					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{Enabled: ptr.To(true)},
 				},
 			},
-			expectedState:          gpuv1.NotReady,
+			expectedState:          gpuv1.Ready,
+			expectedServiceMonitor: nil,
+		},
+		{
+			description: "dcgm-exporter SM nil config, CRD missing -> Ready (cleanup path; CRD absent)",
+			stateName:   "state-dcgm-exporter",
+			k8sObjects:  nil,
+			clusterPolicySpec: gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Enabled: ptr.To(true),
+				},
+			},
+			expectedState:          gpuv1.Ready,
+			expectedServiceMonitor: nil,
+		},
+		{
+			description: "dcgm-exporter SM provided but Enabled nil, CRD missing -> Ready (skip cleanup)",
+			stateName:   "state-dcgm-exporter",
+			k8sObjects:  nil,
+			clusterPolicySpec: gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Enabled:        ptr.To(true),
+					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{},
+				},
+			},
+			expectedState:          gpuv1.Ready,
+			expectedServiceMonitor: nil,
+		},
+		{
+			description: "dcgm-exporter SM provided but Enabled nil, CRD present -> Disabled (default false)",
+			stateName:   "state-dcgm-exporter",
+			k8sObjects:  []client.Object{serviceMonitorCRD},
+			clusterPolicySpec: gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Enabled:        ptr.To(true),
+					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{},
+				},
+			},
+			expectedState:          gpuv1.Disabled,
 			expectedServiceMonitor: nil,
 		},
 		{

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -312,7 +312,7 @@ dcgmExporter:
   service:
     internalTrafficPolicy: Cluster
   serviceMonitor:
-    enabled: false
+    enabled: true
     interval: 15s
     scrapeTimeout: 10s
     honorLabels: false


### PR DESCRIPTION
### Problem

The DCGM Exporter `ServiceMonitor` has been opt-in (`enabled: false`) since the feature was introduced in 2022. Every user who wants GPU metrics scraped by Prometheus must remember to set `serviceMonitor.enabled: true` — **a silent misconfiguration that causes hours of debugging** (#305 #363) .

On top of that, when `enabled: true` is set and the Prometheus `ServiceMonitor` CRD is absent, the operator returns `NotReady` and blocks the entire reconcile loop (re-queuing every 5 seconds). This was documented in release 23.3 with added logging, but the underlying blocking behavior was never fixed. As a result, missing Prometheus CRDs prevent GFD pods from starting.

### Solution

Two minimal changes:

1. **Set `serviceMonitor.enabled: true` by default** in `values.yaml`.
2. **Fix the blocking behavior**: when the Prometheus `ServiceMonitor` CRD is absent, the operator now returns `Ready` and skips gracefully instead of blocking the reconcile loop. This aligns `state-dcgm-exporter` with the existing behavior of `state-operator-metrics`, which already handled this case correctly.

An explicit `enabled: false` continues to disable and remove the resource.

| Scenario | Before | After |
|---|---|---|
| `enabled: true` + CRD absent | `NotReady` (blocks reconcile loop, GFD stalls) | `Ready` (silent skip) |
| `enabled: true` + CRD present | created | created (unchanged) |
| `enabled: false` explicit | `Disabled` | `Disabled` (unchanged) |

### Changes

- **`deployments/gpu-operator/values.yaml`** — `serviceMonitor.enabled: false` → `enabled: true`.
- **`controllers/object_controls.go`** — `ServiceMonitor()`: CRD-absent path returns `Ready` instead of `NotReady`, consistent with `state-operator-metrics`.


### Testing

```bash
go test ./controllers/... -run TestServiceMonitor -v
```