### PR TITLE
Remove deprecated cdi.default from ClusterPolicy template

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -149,9 +149,6 @@ spec:
     enabled: {{ .Values.psa.enabled }}
   cdi:
     enabled: {{ .Values.cdi.enabled }}
-    {{- if .Values.cdi.default }}
-    default: {{ .Values.cdi.default }}
-    {{- end }}
     {{- if and (.Values.cdi.enabled) (.Values.cdi.nriPluginEnabled) }}
     nriPluginEnabled: {{ .Values.cdi.nriPluginEnabled }}
     {{- end }}


### PR DESCRIPTION
## What this PR does

Removes the dead conditional block for `cdi.default` from the ClusterPolicy Helm template.

The `cdi.default` field was removed from `values.yaml` when CDI was made the default device injection mechanism in v26.3.0 (`cdi.enabled=true` now automatically configures CDI as the default). The conditional block in the template was left behind:

```yaml
{{- if .Values.cdi.default }}
default: {{ .Values.cdi.default }}
{{- end }}
```

Since `cdi.default` no longer exists in `values.yaml`, this block never renders and is dead code.
