### PR TITLE
fix: use multi-arch digest for kubevirt-dp instead of amd64 digest

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -232,7 +232,7 @@ spec:
     - name: cc-manager-image
       image: nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.3.0@sha256:22af62e436736c183e76e324d8d0d4927646803604c972f73007d298f02a5211
     - name: sandbox-device-plugin-image
-      image: nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0@sha256:98ff0ae43263b8ab4255197462f0b5d571eed9f263ec5f611f4b98e6fb2920d3
+      image: nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0@sha256:90f05ac42aeb7f259d69157a31cca03c97bed803fa28853e6429b85e238b90d6
     - name: kata-sandbox-device-plugin-image
       image: nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin:v0.0.2@sha256:bbb234d120992ca23046fae64521b1ee68443b6f4bdc827aa926912d30fc5f2f
     - name: vgpu-device-manager-image
@@ -944,7 +944,7 @@ spec:
                   - name: "CC_MANAGER_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.3.0@sha256:22af62e436736c183e76e324d8d0d4927646803604c972f73007d298f02a5211"
                   - name: "SANDBOX_DEVICE_PLUGIN_IMAGE"
-                    value: "nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0@sha256:98ff0ae43263b8ab4255197462f0b5d571eed9f263ec5f611f4b98e6fb2920d3"
+                    value: "nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0@sha256:90f05ac42aeb7f259d69157a31cca03c97bed803fa28853e6429b85e238b90d6"
                   - name: "KATA_SANDBOX_DEVICE_PLUGIN_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin:v0.0.2@sha256:bbb234d120992ca23046fae64521b1ee68443b6f4bdc827aa926912d30fc5f2f"
                   - name: "VGPU_DEVICE_MANAGER_IMAGE"


### PR DESCRIPTION
Starting with v1.5.0 of the NVIDIA KubeVirt GPU Device Plugin, images that get published to nvcr.io are multi-arch. The image digest in the OLM bundle is incorrectly referring to the amd64 digest, causing the following error when this image is launched on an ARM server:

```
exec container process `/usr/bin/shelless_ulimit`: Exec format error
```

This commit updates the digest to refer to the multi-arch digest.
```
$ docker buildx imagetools inspect nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0
Name:      nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:90f05ac42aeb7f259d69157a31cca03c97bed803fa28853e6429b85e238b90d6

Manifests:
  Name:      nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0@sha256:98ff0ae43263b8ab4255197462f0b5d571eed9f263ec5f611f4b98e6fb2920d3
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

  Name:      nvcr.io/nvidia/kubevirt-gpu-device-plugin:v1.5.0@sha256:a9e205b6ba1bc07e005960c0bd93dace7dbb8f2e5550ef3b5cd648f2e8ebe998
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
```

Just as a note, our renovate bot updated this image to the v1.5.0 in this commit: https://github.com/NVIDIA/gpu-operator/commit/b05151b5e99d938249e578c623710e4799e5896f. 

