### PR TITLE
Remove the CC_CAPABLE_DEVICE_IDS variable

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -513,9 +513,6 @@ ccManager:
   version: v0.3.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
-  env:
-    - name: CC_CAPABLE_DEVICE_IDS
-      value: "0x2339,0x2331,0x2330,0x2324,0x2322,0x233d"
   resources: {}
 
 # Array of extra K8s manifests to deploy


### PR DESCRIPTION
The use of this variable has been obsoleted in k8s-cc-manager, hence removing the variable from values.yaml