### PR TITLE
bump golang to 1.26.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG CUDA_SAMPLES_VERSION=12.9
 
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 ARG GOPROXY="https://proxy.golang.org,direct"
 ENV GOPROXY=$GOPROXY

--- a/versions.mk
+++ b/versions.mk
@@ -19,7 +19,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= v26.3.0
 
-GOLANG_VERSION ?= 1.26.1
+GOLANG_VERSION ?= 1.26.2
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 


### PR DESCRIPTION
## Description

Use go1.26.2 https://github.com/golang/go/releases/tag/go1.26.2

<!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

