### PR TITLE
Set NVIDIADriver status to NotReady on selector conflict

### DIFF
--- a/controllers/nvidiadriver_controller.go
+++ b/controllers/nvidiadriver_controller.go
@@ -145,6 +145,7 @@ func (r *NVIDIADriverReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// is deployed per GPU node.
 	if err := r.nodeSelectorValidator.Validate(ctx, instance); err != nil {
 		logger.Error(err, "nodeSelector validation failed")
+		instance.Status.State = nvidiav1alpha1.NotReady
 		if condErr := r.conditionUpdater.SetConditionsError(ctx, instance, conditions.ConflictingNodeSelector, err.Error()); condErr != nil {
 			logger.Error(condErr, "failed to set condition")
 		}

--- a/controllers/nvidiadriver_controller_test.go
+++ b/controllers/nvidiadriver_controller_test.go
@@ -42,11 +42,15 @@ import (
 // FakeConditionUpdater implements conditions.Updater
 // It always returns CustomError if set
 type FakeConditionUpdater struct {
-	CustomError error
+	CustomError    error
+	LastErrorState nvidiav1alpha1.State
 }
 
 // SetConditionsError always returns CustomError if set
 func (f *FakeConditionUpdater) SetConditionsError(ctx context.Context, obj any, condType, msg string) error {
+	if driver, ok := obj.(*nvidiav1alpha1.NVIDIADriver); ok {
+		f.LastErrorState = driver.Status.State
+	}
 	return f.CustomError
 }
 
@@ -192,4 +196,52 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileConflictSetsNotReadyState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiav1alpha1.AddToScheme(scheme))
+	require.NoError(t, gpuv1.AddToScheme(scheme))
+
+	driver := &nvidiav1alpha1.NVIDIADriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-driver",
+			Namespace: "default",
+		},
+		Status: nvidiav1alpha1.NVIDIADriverStatus{
+			State: nvidiav1alpha1.Ready,
+		},
+	}
+
+	cp := &gpuv1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: gpuv1.ClusterPolicySpec{
+			Driver: gpuv1.DriverSpec{
+				UseNvidiaDriverCRD: ptr.To(true),
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cp, driver).Build()
+	updater := &FakeConditionUpdater{}
+
+	reconciler := &NVIDIADriverReconciler{
+		Client:           client,
+		Scheme:           scheme,
+		conditionUpdater: updater,
+		nodeSelectorValidator: &FakeNodeSelectorValidator{
+			CustomError: errors.New("conflicting selector"),
+		},
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      driver.Name,
+			Namespace: driver.Namespace,
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, nvidiav1alpha1.NotReady, updater.LastErrorState)
 }


### PR DESCRIPTION
## Description

### Problem
When two or more NVIDIADriver CRs have conflicting nodeSelectors (selecting overlapping sets of GPU nodes), the controller correctly detects this conflict during reconciliation and sets a condition on the affected CRs. However, the controller does not update status's state, leaving it unchanged.

This creates a misleading state where a previously `ready` NVIDIADriver remains visibly `ready` in `kubectl get nvidiadriver` output, even though:

* A conflict condition prevents it from reconciling further
* The driver cannot be modified until the conflict is resolved
* The CR is effectively blocked/non-functional

Example:
```
$ kubectl get nvidiadriver
NAME         STATUS   AGE
default      ready    1h  # ← Still shows ready despite conflict!
nvd-gold     ready    1h  # ← Also shows ready despite conflict!
```

### Root Cause
The conflict validation code (around line 144-151) only sets the conflict condition but does not update [status.state]. Other error branches in the same Reconcile() function correctly set [instance.Status.State = NotReady] before updating conditions. This inconsistency causes the status field to not reflect the actual state.

### Solution
Set [instance.Status.State = nvidiav1alpha1.NotReady] in the conflict validation branch before calling SetConditionsError(), mirroring the behavior of other error paths.

After Fix:
```
$ kubectl get nvidiadriver
NAME         STATUS   AGE
default      notReady 1h  # ← Now correctly shows notReady
nvd-gold     notReady 1h  # ← Now correctly shows notReady
```
Users can now clearly see from `kubectl get nvidiadriver` that the CRs are blocked, and they can inspect [.status.conditions] to see the conflicting nodeselector reason.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

