### PR TITLE
[Feature]: Allow specific annotation to be set on dgcm-exporter pod's daemonset

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -970,6 +970,11 @@ type DCGMExporterSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:text"
 	Args []string `json:"args,omitempty"`
 
+	// Optional: Annotations is an unstructured key value map stored with a resource that may be
+	// set by external tools to store and retrieve arbitrary metadata. They are not
+	// queryable and should be preserved when modifying objects.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// Optional: List of environment variables
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Environment Variables"

--- a/api/nvidia/v1/zz_generated.deepcopy.go
+++ b/api/nvidia/v1/zz_generated.deepcopy.go
@@ -430,6 +430,13 @@ func (in *DCGMExporterSpec) DeepCopyInto(out *DCGMExporterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]EnvVar, len(*in))

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -553,6 +553,14 @@ spec:
               dcgmExporter:
                 description: DCGMExporter spec
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Optional: Annotations is an unstructured key value map stored with a resource that may be
+                      set by external tools to store and retrieve arbitrary metadata. They are not
+                      queryable and should be preserved when modifying objects.
+                    type: object
                   args:
                     description: 'Optional: List of arguments'
                     items:

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -553,6 +553,14 @@ spec:
               dcgmExporter:
                 description: DCGMExporter spec
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Optional: Annotations is an unstructured key value map stored with a resource that may be
+                      set by external tools to store and retrieve arbitrary metadata. They are not
+                      queryable and should be preserved when modifying objects.
+                    type: object
                   args:
                     description: 'Optional: List of arguments'
                     items:

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1755,6 +1755,12 @@ func TransformDCGMExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 	if len(config.DCGMExporter.ImagePullSecrets) > 0 {
 		addPullSecrets(&obj.Spec.Template.Spec, config.DCGMExporter.ImagePullSecrets)
 	}
+
+	// merge extra annotations at the pod template level
+	if len(config.DCGMExporter.Annotations) > 0 {
+		addExtraAnnotations(obj, config.DCGMExporter.Annotations)
+	}
+
 	// set resource limits
 	if config.DCGMExporter.Resources != nil {
 		// apply resource limits to all containers
@@ -1849,6 +1855,15 @@ func TransformDCGMExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 	}
 
 	return nil
+}
+
+func addExtraAnnotations(obj *appsv1.DaemonSet, annotations map[string]string) {
+	if obj.Spec.Template.Annotations == nil {
+		obj.Spec.Template.Annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
+		obj.Spec.Template.Annotations[k] = v
+	}
 }
 
 // TransformDCGM transforms dcgm daemonset with required config as per ClusterPolicy

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -1512,6 +1512,101 @@ func TestTransformDCGMExporter(t *testing.T) {
 				WithRuntimeClassName("nvidia").
 				WithHostPathVolume("hpc-job-mapping", "/run/nvidia/dcgm-job-mapping", ptr.To(corev1.HostPathDirectoryOrCreate)),
 		},
+		{
+			description: "transform dcgm exporter with extra annotations adds it at pod template level",
+			ds: NewDaemonset().
+				WithContainer(corev1.Container{Name: "dcgm-exporter"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Repository: "nvcr.io/nvidia/k8s",
+					Image:      "dcgm-exporter",
+					Version:    "v1.0.0",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   "8080",
+						"prometheus.io/path":   "/metrics",
+					},
+				},
+			},
+			expectedDs: NewDaemonset().
+				WithPodAnnotations(map[string]string{
+					"prometheus.io/scrape": "true",
+					"prometheus.io/port":   "8080",
+					"prometheus.io/path":   "/metrics",
+				}).
+				WithContainer(corev1.Container{
+					Name:            "dcgm-exporter",
+					Image:           "nvcr.io/nvidia/k8s/dcgm-exporter:v1.0.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Env: []corev1.EnvVar{
+						{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "nvidia-dcgm:5555"},
+					},
+				}).
+				WithRuntimeClassName("nvidia"),
+		},
+		{
+			description: "transform dcgm exporter appends extra annotations to existing ones at pod template level",
+			ds: NewDaemonset().
+				WithPodAnnotations(map[string]string{
+					"foo": "bar",
+				}).
+				WithContainer(corev1.Container{Name: "dcgm-exporter"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Repository: "nvcr.io/nvidia/k8s",
+					Image:      "dcgm-exporter",
+					Version:    "v1.0.0",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+					},
+				},
+			},
+			expectedDs: NewDaemonset().
+				WithPodAnnotations(map[string]string{
+					"foo":                  "bar",
+					"prometheus.io/scrape": "true",
+				}).
+				WithContainer(corev1.Container{
+					Name:            "dcgm-exporter",
+					Image:           "nvcr.io/nvidia/k8s/dcgm-exporter:v1.0.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Env: []corev1.EnvVar{
+						{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "nvidia-dcgm:5555"},
+					},
+				}).
+				WithRuntimeClassName("nvidia"),
+		},
+		{
+			description: "transform dcgm exporter overrides annotation with same key at pod template level",
+			ds: NewDaemonset().
+				WithPodAnnotations(map[string]string{
+					"foo": "bar",
+				}).
+				WithContainer(corev1.Container{Name: "dcgm-exporter"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Repository: "nvcr.io/nvidia/k8s",
+					Image:      "dcgm-exporter",
+					Version:    "v1.0.0",
+					Annotations: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+			expectedDs: NewDaemonset().
+				WithPodAnnotations(map[string]string{
+					"foo": "baz",
+				}).
+				WithContainer(corev1.Container{
+					Name:            "dcgm-exporter",
+					Image:           "nvcr.io/nvidia/k8s/dcgm-exporter:v1.0.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Env: []corev1.EnvVar{
+						{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "nvidia-dcgm:5555"},
+					},
+				}).
+				WithRuntimeClassName("nvidia"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -553,6 +553,14 @@ spec:
               dcgmExporter:
                 description: DCGMExporter spec
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Optional: Annotations is an unstructured key value map stored with a resource that may be
+                      set by external tools to store and retrieve arbitrary metadata. They are not
+                      queryable and should be preserved when modifying objects.
+                    type: object
                   args:
                     description: 'Optional: List of arguments'
                     items:

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -540,6 +540,9 @@ spec:
     {{- end }}
   dcgmExporter:
     enabled: {{ .Values.dcgmExporter.enabled }}
+    {{- if .Values.dcgmExporter.annotations }}
+    annotations: {{ toYaml .Values.dcgmExporter.annotations | nindent 6 }}
+    {{- end }}
     {{- if .Values.dcgmExporter.repository }}
     repository: {{ .Values.dcgmExporter.repository }}
     {{- end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -279,6 +279,7 @@ dcgm:
 
 dcgmExporter:
   enabled: true
+  annotations: {}
   repository: nvcr.io/nvidia/k8s
   image: dcgm-exporter
   version: 4.5.1-4.8.0-distroless


### PR DESCRIPTION
## Description

Add support to set extra annotations to `dcgm-exporter` only.
Solves #2271 

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Added multiple units tests for now:
- add annotations on `dcgm-exporter` when `daemonsets.annotations` is empty
- combine annotations of `dcgm-exporter` and `daemonsets.annotations` when both are set