### PR TITLE
fix: correct serviceMonitor relabelings example to use camelCase keys

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -300,10 +300,10 @@ dcgmExporter:
     honorLabels: false
     additionalLabels: {}
     relabelings: []
-    # - source_labels:
+    # - sourceLabels:
     #     - __meta_kubernetes_pod_node_name
     #   regex: (.*)
-    #   target_label: instance
+    #   targetLabel: instance
     #   replacement: $1
     #   action: replace
   # DCGM Exporter configuration


### PR DESCRIPTION
## Fix: correct `serviceMonitor.relabelings` example to use camelCase keys

### Problem

The commented example for `dcgmExporter.serviceMonitor.relabelings` in `values.yaml` uses snake_case keys (`source_labels`, `target_label`), which do not match the `monitoring.coreos.com/v1` ServiceMonitor CRD spec that requires camelCase (`sourceLabels`, `targetLabel`).

The gpu-operator passes the relabeling block through as-is to the generated ServiceMonitor via `toYaml` in `clusterpolicy.yaml`. As a result, users who follow the documented example get a ServiceMonitor with incomplete relabeling rules, `sourceLabels` and `targetLabel` are silently dropped, leaving a no-op rule:

```yaml
# What users get instead of what they expect:
relabelings:
- action: replace
  regex: (.*)
  replacement: $1
  # sourceLabels and targetLabel missing
```

The helm upgrade does emit warnings for the unrecognized fields:
```
Warning: unknown field "spec.dcgmExporter.serviceMonitor.relabelings[0].source_labels"
Warning: unknown field "spec.dcgmExporter.serviceMonitor.relabelings[0].target_label"
```
However since the upgrade still completes successfully, these are easy to overlook.

### Change

Update the commented example in `deployments/gpu-operator/values.yaml` to use the correct camelCase keys that the ServiceMonitor CRD expects:

```yaml
# Before:
# - source_labels:
#     - __meta_kubernetes_pod_node_name
#   regex: (.*)
#   target_label: instance
#   replacement: $1
#   action: replace

# After:
# - sourceLabels:
#     - __meta_kubernetes_pod_node_name
#   regex: (.*)
#   targetLabel: instance
#   replacement: $1
#   action: replace
```

### Testing

Verified on gpu-operator v25.10.1 + EKS + kube-prometheus-stack that using `sourceLabels`/`targetLabel` produces a correctly populated ServiceMonitor, while `source_labels`/`target_label` silently drops those fields from the generated resource.