### PR TITLE
[validation] error out when NRI Plugin is enabled and toolkit is disabled

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -1151,5 +1151,10 @@ func validateClusterPolicySpec(spec *gpuv1.ClusterPolicySpec) error {
 	if !spec.CDI.IsEnabled() && spec.CDI.IsNRIPluginEnabled() {
 		return fmt.Errorf("the NRI Plugin cannot be enabled when CDI is disabled")
 	}
+
+	if spec.CDI.IsNRIPluginEnabled() && !spec.Toolkit.IsEnabled() {
+		return fmt.Errorf("the NRI Plugin cannot be enabled when the Container Toolkit is disabled")
+	}
+
 	return nil
 }

--- a/controllers/state_manager_test.go
+++ b/controllers/state_manager_test.go
@@ -318,6 +318,19 @@ func TestValidateClusterPolicySpec(t *testing.T) {
 			},
 			err: errors.New("the NRI Plugin cannot be enabled when CDI is disabled"),
 		},
+		{
+			description: "invalid CDI and Toolkit config combination",
+			spec: &gpuv1.ClusterPolicySpec{
+				CDI: gpuv1.CDIConfigSpec{
+					Enabled:          ptr.To(true),
+					NRIPluginEnabled: ptr.To(true),
+				},
+				Toolkit: gpuv1.ToolkitSpec{
+					Enabled: ptr.To(false),
+				},
+			},
+			err: errors.New("the NRI Plugin cannot be enabled when the Container Toolkit is disabled"),
+		},
 	}
 
 	for _, tc := range tests {

--- a/deployments/gpu-operator/templates/validations.yaml
+++ b/deployments/gpu-operator/templates/validations.yaml
@@ -1,3 +1,7 @@
 {{- if and (eq .Values.cdi.enabled false) (eq .Values.cdi.nriPluginEnabled true) }}
 {{ fail "the NRI Plugin cannot be enabled when CDI is disabled" }}
-{{- end}}
+{{- end }}
+
+{{- if and (eq .Values.cdi.nriPluginEnabled true) (eq .Values.toolkit.enabled false)  }}
+{{ fail "the NRI Plugin cannot be enabled when the Container Toolkit is disabled" }}
+{{- end }}


### PR DESCRIPTION
Adding an extra validation check in response to the issue reported in #2382 