### PR TITLE
Updated Red Hat mounts for air-gapped clusters

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -3704,10 +3704,15 @@ func transformDriverContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicy
 
 	// set up subscription entitlements for RHEL(using K8s with a non-CRIO runtime) and SLES
 	if (osID == "rhel" && n.openshift == "" && n.runtime != gpuv1.CRIO) || osID == "sles" || osID == "sl-micro" {
-		n.logger.Info("Mounting subscriptions into the driver container", "OS", osID)
-		pathToVolumeSource, err := n.getSubscriptionPathsToVolumeSources()
-		if err != nil {
-			return fmt.Errorf("ERROR: failed to get path items for subscription entitlements: %v", err)
+		pathToVolumeSource := MountPathToVolumeSource{}
+		if config.Driver.RepoConfig != nil && config.Driver.RepoConfig.ConfigMapName != "" && osID == "rhel" {
+			n.logger.Info("Skipping host subscription mounts because repoConfig is enabled", "OS", osID)
+		} else {
+			n.logger.Info("Mounting subscriptions into the driver container", "OS", osID)
+			pathToVolumeSource, err = n.getSubscriptionPathsToVolumeSources()
+			if err != nil {
+				return fmt.Errorf("ERROR: failed to get path items for subscription entitlements: %w", err)
+			}
 		}
 
 		// sort host path volumes to ensure ordering is preserved when adding to pod spec

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	kata_v1alpha1 "github.com/NVIDIA/k8s-kata-manager/api/v1alpha1/config"
@@ -4345,6 +4346,115 @@ func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 			require.EqualValues(t, tc.expectedDs, tc.ds)
 		})
 	}
+}
+
+func TestTransformDriverSubscriptionMounts(t *testing.T) {
+	repoConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo-config",
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			"redhat.repo": "[test-repo]",
+		},
+	}
+	mockClient := fake.NewFakeClient(repoConfigMap)
+
+	testCases := []struct {
+		description                 string
+		osRelease                   string
+		osTag                       string
+		repoConfigEnabled           bool
+		expectSubscriptionMounts    bool
+		expectedSubscriptionHostMap map[string]corev1.HostPathType
+	}{
+		{
+			description:              "rhel with repo config skips host subscription mounts",
+			osRelease:                "rhel",
+			osTag:                    "rhel8.10",
+			repoConfigEnabled:        true,
+			expectSubscriptionMounts: false,
+		},
+		{
+			description:              "rhel without repo config mounts host subscription paths",
+			osRelease:                "rhel",
+			osTag:                    "rhel8.10",
+			expectSubscriptionMounts: true,
+			expectedSubscriptionHostMap: map[string]corev1.HostPathType{
+				"/etc/pki/entitlement":         corev1.HostPathDirectory,
+				"/etc/yum.repos.d/redhat.repo": corev1.HostPathFile,
+				"/etc/rhsm":                    corev1.HostPathDirectory,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ds := NewDaemonset().WithContainer(corev1.Container{Name: "nvidia-driver-ctr"}).
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"})
+			cpSpec := &gpuv1.ClusterPolicySpec{
+				Driver: gpuv1.DriverSpec{
+					Repository:      "nvcr.io/nvidia",
+					Image:           "driver",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "580.126.16",
+					Manager: gpuv1.DriverManagerSpec{
+						Repository:      "nvcr.io/nvidia/cloud-native",
+						Image:           "k8s-driver-manager",
+						ImagePullPolicy: "IfNotPresent",
+						Version:         "v0.8.0",
+					},
+				},
+			}
+			if tc.repoConfigEnabled {
+				cpSpec.Driver.RepoConfig = &gpuv1.DriverRepoConfigSpec{ConfigMapName: "test-repo-config"}
+			}
+
+			err := TransformDriver(ds.DaemonSet, cpSpec, ClusterPolicyController{
+				client:            mockClient,
+				runtime:           gpuv1.Containerd,
+				operatorNamespace: "test-ns",
+				logger:            ctrl.Log.WithName("test"),
+				gpuNodeOSRelease:  tc.osRelease,
+				gpuNodeOSTag:      tc.osTag,
+			})
+			require.NoError(t, err)
+
+			driverContainer := findContainerByName(ds.Spec.Template.Spec.Containers, "nvidia-driver-ctr")
+			require.NotNil(t, driverContainer)
+			assertSubscriptionHostPathVolumesForTransform(t, ds.Spec.Template.Spec.Volumes, tc.expectedSubscriptionHostMap)
+			assert.Equal(t, tc.expectSubscriptionMounts, hasSubscriptionVolumeMountForTransform(driverContainer.VolumeMounts))
+		})
+	}
+}
+
+func hasSubscriptionVolumeMountForTransform(volumeMounts []corev1.VolumeMount) bool {
+	for _, volumeMount := range volumeMounts {
+		if strings.HasPrefix(volumeMount.Name, "subscription-config-") {
+			return true
+		}
+	}
+	return false
+}
+
+func assertSubscriptionHostPathVolumesForTransform(t *testing.T, volumes []corev1.Volume, expected map[string]corev1.HostPathType) {
+	t.Helper()
+
+	if expected == nil {
+		expected = map[string]corev1.HostPathType{}
+	}
+
+	actual := map[string]corev1.HostPathType{}
+	for _, volume := range volumes {
+		if !strings.HasPrefix(volume.Name, "subscription-config-") {
+			continue
+		}
+		require.NotNil(t, volume.HostPath)
+		require.NotNil(t, volume.HostPath.Type)
+		actual[volume.HostPath.Path] = *volume.HostPath.Type
+	}
+
+	assert.Equal(t, expected, actual)
 }
 
 // baseDriverDaemonSetSpec returns a minimal DaemonSetSpec representative of

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,8 +35,10 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
+	"github.com/NVIDIA/gpu-operator/internal/consts"
 	"github.com/NVIDIA/gpu-operator/internal/render"
 )
 
@@ -43,6 +46,27 @@ const (
 	manifestDir       = "../../manifests"
 	manifestResultDir = "./testdata/golden"
 )
+
+type testClusterInfo struct {
+	runtime          string
+	openshiftVersion string
+}
+
+func (i testClusterInfo) GetContainerRuntime() (string, error) {
+	return i.runtime, nil
+}
+
+func (i testClusterInfo) GetOpenshiftVersion() (string, error) {
+	return i.openshiftVersion, nil
+}
+
+func (i testClusterInfo) GetOpenshiftDriverToolkitImages() map[string]string {
+	return nil
+}
+
+func (i testClusterInfo) GetOpenshiftProxySpec() (*configv1.ProxySpec, error) {
+	return nil, nil
+}
 
 func getYAMLString(objs []*unstructured.Unstructured) (string, error) {
 	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme,
@@ -58,6 +82,35 @@ func getYAMLString(objs []*unstructured.Unstructured) (string, error) {
 		sb.WriteString("---\n")
 	}
 	return sb.String(), nil
+}
+
+func hasSubscriptionVolumeMount(volumeMounts []corev1.VolumeMount) bool {
+	for _, volumeMount := range volumeMounts {
+		if strings.HasPrefix(volumeMount.Name, "subscription-config-") {
+			return true
+		}
+	}
+	return false
+}
+
+func assertSubscriptionHostPathVolumes(t *testing.T, volumes []corev1.Volume, expected map[string]corev1.HostPathType) {
+	t.Helper()
+
+	if expected == nil {
+		expected = map[string]corev1.HostPathType{}
+	}
+
+	actual := map[string]corev1.HostPathType{}
+	for _, volume := range volumes {
+		if !strings.HasPrefix(volume.Name, "subscription-config-") {
+			continue
+		}
+		require.NotNil(t, volume.HostPath)
+		require.NotNil(t, volume.HostPath.Type)
+		actual[volume.HostPath.Path] = *volume.HostPath.Type
+	}
+
+	assert.Equal(t, expected, actual)
 }
 
 func TestDriverRenderMinimal(t *testing.T) {
@@ -438,6 +491,69 @@ func TestDriverAdditionalConfigs(t *testing.T) {
 	require.Nil(t, err)
 
 	require.Equal(t, string(o), actual)
+}
+
+func TestDriverAdditionalConfigsSubscriptionMounts(t *testing.T) {
+	repoConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo-config",
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			"redhat.repo": "[test-repo]",
+		},
+	}
+
+	testCases := []struct {
+		description                 string
+		osRelease                   string
+		repoConfigEnabled           bool
+		expectSubscriptionMounts    bool
+		expectedSubscriptionHostMap map[string]corev1.HostPathType
+	}{
+		{
+			description:              "rhel with repo config skips host subscription mounts",
+			osRelease:                "rhel",
+			repoConfigEnabled:        true,
+			expectSubscriptionMounts: false,
+		},
+		{
+			description:              "rhel without repo config mounts host subscription paths",
+			osRelease:                "rhel",
+			expectSubscriptionMounts: true,
+			expectedSubscriptionHostMap: map[string]corev1.HostPathType{
+				"/etc/pki/entitlement":         corev1.HostPathDirectory,
+				"/etc/yum.repos.d/redhat.repo": corev1.HostPathFile,
+				"/etc/rhsm":                    corev1.HostPathDirectory,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			stateDriver := &stateDriver{
+				stateSkel: stateSkel{
+					client:    fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(repoConfigMap).Build(),
+					namespace: "test-ns",
+				},
+			}
+			driver := &nvidiav1alpha1.NVIDIADriver{}
+			if tc.repoConfigEnabled {
+				driver.Spec.RepoConfig = &nvidiav1alpha1.DriverRepoConfigSpec{Name: "test-repo-config"}
+			}
+
+			configs, err := stateDriver.getDriverAdditionalConfigs(
+				context.Background(),
+				driver,
+				testClusterInfo{runtime: consts.Containerd},
+				nodePool{osRelease: tc.osRelease, osVersion: tc.osRelease},
+			)
+			require.NoError(t, err)
+
+			assertSubscriptionHostPathVolumes(t, configs.Volumes, tc.expectedSubscriptionHostMap)
+			assert.Equal(t, tc.expectSubscriptionMounts, hasSubscriptionVolumeMount(configs.VolumeMounts))
+		})
+	}
 }
 
 func TestDriverOpenshiftDriverToolkit(t *testing.T) {

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -182,10 +182,19 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 
 		// set up subscription entitlements for RHEL(using K8s with a non-CRIO runtime) and SLES
 		if (pool.osRelease == "rhel" && openshiftVersion == "" && runtime != consts.CRIO) || pool.osRelease == "sles" || pool.osRelease == "sl-micro" {
-			logger.Info("Mounting subscriptions into the driver container", "OS", pool.osVersion)
-			pathToVolumeSource, err := getSubscriptionPathsToVolumeSources(pool.osRelease)
-			if err != nil {
-				return nil, fmt.Errorf("ERROR: failed to get path items for subscription entitlements: %v", err)
+			pathToVolumeSource := MountPathToVolumeSource{}
+			// Custom repo ConfigMap supplies yum repos in offline/air-gapped installs. Skip
+			// mounting host RHSM paths (/etc/pki/entitlement, redhat.repo, /etc/rhsm): they may
+			// be missing or not directories on minimal nodes, and are not needed when packages
+			// come only from the mounted repo ConfigMap.
+			if cr.Spec.IsRepoConfigEnabled() && pool.osRelease == "rhel" {
+				logger.Info("Skipping host subscription mounts because repoConfig is enabled", "OS", pool.osVersion)
+			} else {
+				logger.Info("Mounting subscriptions into the driver container", "OS", pool.osVersion)
+				pathToVolumeSource, err = getSubscriptionPathsToVolumeSources(pool.osRelease)
+				if err != nil {
+					return nil, fmt.Errorf("ERROR: failed to get path items for subscription entitlements: %w", err)
+				}
 			}
 
 			// sort host path volumes to ensure ordering is preserved when adding to pod spec


### PR DESCRIPTION
## Description

This change is in response to this [issue](https://github.com/NVIDIA/gpu-operator/issues/1501). In summary, when we install the gpu-operator on an air-gapped cluster the driver pod spec can error because the node does not have the HostPathFile.

`MountVolume.SetUp failed for volume "subscription-config-1" : hostPath type check failed: /etc/yum.repos.d/redhat.repo is not a file
  Warning  FailedMount  3m55s (x23 over 34m)  kubelet
MountVolume.SetUp failed for volume "subscription-config-0" : hostPath type check failed: /etc/pki/entitlement is not a directory`

When we set up the gpu-operator to run in air-gapped environments (see [here](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-air-gapped.html#local-package-repository)), we will setup a local package repository containing the the Red Hat packages needed to run, and create a configMap referencing a repo list containing the packages. In a regular environment, the driver container uses Ret Hat Subscription Management (RHSM) to determine what repos you need and how to install them from Red Hat's CDN. With a repoConfig ConfigMap (air-gapped / custom mirror): you do not rely on that subscription path for package location. The ConfigMap will provide the server/files where the Driver can pull the repos. Therefore, the operator can skip RHSM mounts because the repo definitions and mirror content are already provided.

The following changes were made:

`// Custom repo ConfigMap supplies yum repos in offline/air-gapped installs. Skip mounting host RHSM paths when using a custom repo ConfigMap
if cr.Spec.IsRepoConfigEnabled() && pool.osRelease == "rhel" {
	pathToVolumeSource = map[string]corev1.VolumeSource{}
}`
...ensuring that we no longer mount the RHSM paths.

## Testing

An Air-gapped cluster was setup following instructions here: https://kubernetes.io/blog/2023/10/12/bootstrap-an-air-gapped-cluster-with-kubeadm/.

Created a configMap of the form:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: repo-config-rhel8
  namespace: gpu-operator
  labels:
    app.kubernetes.io/name: gpu-operator
    nvidia.com/repo-config: rhel8
data:
  # RHEL/RHCOS: HTTP root of nginx mirror on this lab host (pods reach node IP on port 80).
  # Paths include dnf reposync repoid subdirs under baseos/appstream.
  custom-repo.repo: |
    [baseos]
    name=RHEL 8 BaseOS (local)
    # Use fixed 8.10/x86_64: some driver images do not expand $releasever/$baseurl in baseurl here.
    baseurl=http://10.176.177.185/rhel8/8.10/x86_64/os/baseos/rhel-8-for-x86_64-baseos-rpms/
    gpgcheck=0
    enabled=1
    [appstream]
    name=RHEL 8 AppStream (local)
    baseurl=http://10.176.177.185/rhel8/8.10/x86_64/os/appstream/rhel-8-for-x86_64-appstream-rpms/
    gpgcheck=0
    enabled=1
```
Verified we are deploying correctly without seeing the volumeMount:

```
[local-agadiyar@1u1g-gen-0057 ~]$ kubectl get pods -n gpu-operator
NAME                                                          READY   STATUS      RESTARTS   AGE
gpu-feature-discovery-qkmx7                                   1/1     Running     0          4d3h
gpu-operator-85c9946787-hnqsh                                 1/1     Running     0          4d20h
gpu-operator-node-feature-discovery-gc-6c8d95ff4-fsxth        1/1     Running     0          4d22h
gpu-operator-node-feature-discovery-master-5cb84cf47d-g96qv   1/1     Running     0          4d22h
gpu-operator-node-feature-discovery-worker-lc6c7              1/1     Running     0          4d22h
nvidia-container-toolkit-daemonset-hhsmx                      1/1     Running     0          4d3h
nvidia-cuda-validator-sxbwb                                   0/1     Completed   0          4d3h
nvidia-dcgm-exporter-cpgml                                    1/1     Running     0          4d3h
nvidia-device-plugin-daemonset-2b2t4                          1/1     Running     0          4d3h
nvidia-driver-daemonset-mlkms                                 1/1     Running     0          4d3h
nvidia-mig-manager-xss46                                      1/1     Running     0          4d3h
nvidia-operator-validator-v62qw                               1/1     Running     0          4d3h
[local-agadiyar@1u1g-gen-0057 gpu-operator]$ kubectl get pod -n gpu-operator nvidia-driver-daemonset-mlkms -o yaml | grep -E '(/etc/yum\.repos\.d/redhat\.repo|/etc/pki/entitlement|/etc/rhsm|mountPath: /run/secrets/redhat\.repo|mountPath: /run/secrets/etc-pki-entitlement|mountPath: /run/secrets/rhsm)'
[local-agadiyar@1u1g-gen-0057 gpu-operator]$ 
```

Added Unit tests:
In internal/state/driver_test.go, TestDriverAdditionalConfigsSubscriptionMounts calls getDriverAdditionalConfigs directly with different OS/repoConfig combinations:
rhel + repoConfig enabled: expects no subscription-config-* volume mounts or hostPath volumes.
rhel + repoConfig disabled: expects the normal RHSM host paths, including /etc/yum.repos.d/redhat.repo as HostPathFileOrCreate.

In controllers/transforms_test.go, TestTransformDriverSubscriptionMounts does the same behavioral check through the legacy TransformDriver path. It builds a minimal driver DaemonSet, runs the transform, then inspects the generated driver container volume mounts and pod volumes.
