### PR TITLE
[dependabot.yml] remove validator directory from the watchlist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,12 +32,6 @@ updates:
     schedule:
       interval: "daily"
 
-  # Update GPU Operator Validator base images.
-  - package-ecosystem: "docker"
-    directory: "/validator"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We are no longer publishing a separate validator image, so the validator Dockerfile was removed. Dependabot does not need to monitor this directory. 