### PR TITLE
helm: restore kataManager defaults

### DIFF
--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -492,7 +492,23 @@ vfioManager:
 
 kataManager:
   enabled: false
-  config: {}
+  config:
+    artifactsDir: "/opt/nvidia-gpu-operator/artifacts/runtimeclasses"
+    runtimeClasses:
+      - name: kata-nvidia-gpu
+        nodeSelector: {}
+        artifacts:
+          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.54.03
+          pullSecret: ""
+      - name: kata-nvidia-gpu-snp
+        nodeSelector:
+          "nvidia.com/cc.capable": "true"
+        artifacts:
+          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.86.10-snp
+          pullSecret: ""
+  repository: nvcr.io/nvidia/cloud-native
+  image: k8s-kata-manager
+  version: v0.2.3
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   env: []


### PR DESCRIPTION
## Description

This fixes a regression in the Helm chart defaults for `kataManager`.

In `v25.10.0`, the chart shipped a complete default `kataManager` block including:
- `config`
- `repository`
- `image`
- `version`

In `v26.3.1`, those defaults were removed, leaving `kataManager` incomplete when enabled through values. This caused the rendered `ClusterPolicy.spec.kataManager` to miss required image metadata and broke reconciliation.

## What changed

Restored the missing default `kataManager` values in `deployments/gpu-operator/values.yaml`.

## Validation

I verified the following:

1. Stock `v26.3.1` reproduced the issue and the `ClusterPolicy` reported:
   - `Failed to reconcile state-kata-manager: empty image path provided through both ClusterPolicy CR and ENV KATA_MANAGER_IMAGE`

2. With this patch applied and the chart rendered locally, the `kataManager` block was complete again.

3. Upgrading from the patched local chart resulted in:
   - `ClusterPolicy.status.state: ready`
   - `ClusterPolicy is ready as all resources have been successfully reconciled`

## Notes

For local source-based validation only, I temporarily adjusted `Chart.yaml` so the raw source chart would not use `main-latest`, but that change is not part of this PR.