### PR TITLE
Add scrapeTimeout to DCGM Exporter ServiceMonitor

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -152,6 +152,14 @@ type ServiceMonitorConfig struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	Interval promv1.Duration `json:"interval,omitempty"`
 
+	// ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+	// If not specified, Prometheus' global scrape timeout is used.
+	// Supported units: y, w, d, h, m, s, ms
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Scrape timeout"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	ScrapeTimeout promv1.Duration `json:"scrapeTimeout,omitempty"`
+
 	// HonorLabels chooses the metric’s labels on collisions with target labels.
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Choose the metric's label on collisions with target labels"

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -783,6 +783,13 @@ spec:
                               type: string
                           type: object
                         type: array
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                          If not specified, Prometheus' global scrape timeout is used.
+                          Supported units: y, w, d, h, m, s, ms
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                     type: object
                   version:
                     description: NVIDIA DCGM Exporter image tag
@@ -2083,6 +2090,13 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                              If not specified, Prometheus' global scrape timeout is used.
+                              Supported units: y, w, d, h, m, s, ms
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
                         type: object
                     type: object
                   runtimeClass:

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -783,6 +783,13 @@ spec:
                               type: string
                           type: object
                         type: array
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                          If not specified, Prometheus' global scrape timeout is used.
+                          Supported units: y, w, d, h, m, s, ms
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                     type: object
                   version:
                     description: NVIDIA DCGM Exporter image tag
@@ -2083,6 +2090,13 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                              If not specified, Prometheus' global scrape timeout is used.
+                              Supported units: y, w, d, h, m, s, ms
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
                         type: object
                     type: object
                   runtimeClass:

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -4934,6 +4934,10 @@ func applyServiceMonitorCustomEdits(desiredState *gpuv1.ServiceMonitorConfig, cu
 		currentState.Spec.Endpoints[0].Interval = desiredState.Interval
 	}
 
+	if desiredState.ScrapeTimeout != "" {
+		currentState.Spec.Endpoints[0].ScrapeTimeout = desiredState.ScrapeTimeout
+	}
+
 	if desiredState.HonorLabels != nil {
 		currentState.Spec.Endpoints[0].HonorLabels = *desiredState.HonorLabels
 	}

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -1432,6 +1432,7 @@ func TestServiceMonitor(t *testing.T) {
 					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{
 						Enabled:          ptr.To(true),
 						Interval:         promv1.Duration("15s"),
+						ScrapeTimeout:    promv1.Duration("10s"),
 						HonorLabels:      ptr.To(true),
 						AdditionalLabels: map[string]string{"a": "b"},
 						Relabelings:      []*promv1.RelabelConfig{{Action: "keep"}},
@@ -1448,8 +1449,9 @@ func TestServiceMonitor(t *testing.T) {
 				Spec: promv1.ServiceMonitorSpec{
 					NamespaceSelector: promv1.NamespaceSelector{MatchNames: []string{"test-namespace"}},
 					Endpoints: []promv1.Endpoint{{
-						Interval:    promv1.Duration("15s"),
-						HonorLabels: true,
+						Interval:      promv1.Duration("15s"),
+						ScrapeTimeout: promv1.Duration("10s"),
+						HonorLabels:   true,
 						RelabelConfigs: []promv1.RelabelConfig{{
 							Action: "keep",
 						}},

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -783,6 +783,13 @@ spec:
                               type: string
                           type: object
                         type: array
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                          If not specified, Prometheus' global scrape timeout is used.
+                          Supported units: y, w, d, h, m, s, ms
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                     type: object
                   version:
                     description: NVIDIA DCGM Exporter image tag
@@ -2083,6 +2090,13 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                              If not specified, Prometheus' global scrape timeout is used.
+                              Supported units: y, w, d, h, m, s, ms
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
                         type: object
                     type: object
                   runtimeClass:

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -314,6 +314,7 @@ dcgmExporter:
   serviceMonitor:
     enabled: false
     interval: 15s
+    scrapeTimeout: 10s
     honorLabels: false
     additionalLabels: {}
     relabelings: []


### PR DESCRIPTION
## Description

Expose `scrapeTimeout` on the DCGM Exporter ServiceMonitor in the `ClusterPolicy` CR and the gpu-operator Helm values, so users can configure a scrape interval shorter than Prometheus' 10s default timeout.

Resolves #2129.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Unit test added in `TestServiceMonitor`.