### PR TITLE
[state-driver] add new toleration to handle driver upgrades

### DIFF
--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -30,6 +30,9 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+        - key: nvidia.com/gpu-driver-update
+          operator: Exists
+          effect: NoSchedule
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -313,6 +313,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -333,6 +333,9 @@ spec:
         key: nvidia.com/gpu
         operator: Exists
       - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
+      - effect: NoSchedule
         key: foo
         operator: Equal
         value: bar

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -487,6 +487,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -367,6 +367,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -367,6 +367,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-hostnetwork.yaml
+++ b/internal/state/testdata/golden/driver-hostnetwork.yaml
@@ -306,6 +306,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -304,6 +304,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -423,6 +423,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -307,6 +307,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -387,6 +387,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -381,6 +381,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-secret-env.yaml
+++ b/internal/state/testdata/golden/driver-secret-env.yaml
@@ -399,6 +399,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -386,6 +386,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -292,6 +292,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
@@ -310,6 +310,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -310,6 +310,9 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu-driver-update
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/nvidia

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -87,6 +87,9 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+        - key: nvidia.com/gpu-driver-update
+          operator: Exists
+          effect: NoSchedule
         {{- if .Driver.Spec.Tolerations }}
         {{- .Driver.Spec.Tolerations | yaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This change is added in anticipation of a new enhancement
in k8s-driver-manager where the driver-manager will add
a taint to a node where a gpu driver upgrade is taking
place. This taint helps the driver-manager to evict
third party gpu client pods to ensure driver module
unloads are successful during an upgrade cycle.

Related PR: https://github.com/NVIDIA/k8s-driver-manager/pull/177