### PR TITLE
update URL based on recommendation in v2.12.1 changelog of golangci-lint

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -16,4 +16,4 @@ ARG GOLANGCI_LINT_VERSION=1.60.3
 
 FROM golang:${GOLANG_VERSION}
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}


### PR DESCRIPTION
## Description

See https://github.com/golangci/golangci-lint/releases/tag/v2.12.1

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

