### PR TITLE
fix version matching for dcgmexporter image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -80,7 +80,7 @@
       "matchPackageNames": [
         "nvcr.io/nvidia/k8s/dcgm-exporter"
       ],
-      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-distroless$",
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-\\d+\\.\\d+\\.\\d+-distroless$",
       "separateMajorMinor": false
     },
     {


### PR DESCRIPTION
## Description

Current regex only matches tags like `4.5.1-distroless` but fails for tags like `4.5.1-4.8.0-distroless`

There were a couple of releases for dcgmexporter which were missed. Fixing the regex used.

Sample output after the fix where it correctly detects newer version of dcgmExporter:
```
{
  "depName": "nvcr.io/nvidia/k8s/dcgm-exporter",
  "currentValue": "4.5.1-4.8.0-distroless",
  "datasource": "docker",
  "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-\\d+\\.\\d+\\.\\d+-distroless$",
  "updates": [
    {
      "bucket": "latest",
      "newVersion": "4.5.3-4.8.2-distroless",
      "newValue": "4.5.3-4.8.2-distroless",
      "updateType": "patch",
      "branchName": "renovate/nvcr.ionvidiak8sdcgm-exporter"
    }
  ]
}
```

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

