### PR TITLE
[ci] bump containerd, kubernetes and calico versions

### DIFF
--- a/tests/holodeck.yaml
+++ b/tests/holodeck.yaml
@@ -11,26 +11,16 @@ spec:
   instance:
     type: g4dn.xlarge
     region: us-west-1
-    ingressIpRanges:
-    - 18.190.12.32/32
-    - 3.143.46.93/32
-    - 52.15.119.136/32
-    - 35.155.108.162/32
-    - 35.162.190.51/32
-    - 54.201.61.24/32
-    - 52.24.205.48/32
-    - 44.235.4.62/32
-    - 44.230.241.223/32
     image:
       architecture: amd64
       imageId: ami-07c175e73e37b02df
   containerRuntime:
     install: true
     name: containerd
-    version: 1.7.27
+    version: 2.2.3
   kubernetes:
     install: true
     installer: kubeadm
-    version: v1.34.5
-    crictlVersion: v1.34.0
-    calicoVersion: v3.31.4
+    version: v1.35.4
+    crictlVersion: v1.35.0
+    calicoVersion: v3.31.5


### PR DESCRIPTION
NOTE: `IngressIpRanges` is no longer required as holodeck (starting with (v0.2.14)[https://github.com/NVIDIA/holodeck/releases/tag/v0.2.14]) can detect the IP by itself. More information [here](https://github.com/NVIDIA/holodeck/blob/main/docs/commands/create.md#automated-ip-detection). 