### PR TITLE
Add B300 (0x3182) device ID to GPU Operator validator

### DIFF
--- a/assets/state-vgpu-device-manager/0500_configmap.yaml
+++ b/assets/state-vgpu-device-manager/0500_configmap.yaml
@@ -2888,3 +2888,7 @@ data:
               devices: all
               vgpu-devices:
                 6000D-84Q: 1
+- device-filter: "0x318210DE"
+  devices: all
+  vgpu-devices:
+    B300-SXM6-AC: 2


### PR DESCRIPTION
Fixes: nvidia-operator-validator fails to find device ID 3182
- Adds 0x318210DE to vgpu-manager configmap
- Resolves init container loop and symlink creation failures
- Enables B300 GPU deployment in Kubernetes clusters



