### PR TITLE
docs: fix state container toolkit comment typo

### DIFF
--- a/assets/state-container-toolkit/0400_configmap.yaml
+++ b/assets/state-container-toolkit/0400_configmap.yaml
@@ -23,7 +23,7 @@ data:
     # The below delay is a workaround for an issue affecting some versions
     # of containerd starting with 1.6.9. Staring with containerd 1.6.9 we
     # started seeing the toolkit container enter a crashloop whereby it
-    # would recieve a SIGTERM shortly after restarting containerd.
+    # would receive a SIGTERM shortly after restarting containerd.
     #
     # Refer to the commit message where this workaround was implemented
     # for additional details:


### PR DESCRIPTION
## Summary

Fixes a spelling typo in a state container toolkit ConfigMap comment.

## Files changed

- `assets/state-container-toolkit/0400_configmap.yaml`: `recieve` -> `receive`

## Before / after

Before, the comment describing the SIGTERM behavior had a misspelling. After, the comment text is corrected with no behavior change.

## Verification

- Inspected the diff to confirm this is a comment-only change.
- Ran `rg "recieve" assets/state-container-toolkit/0400_configmap.yaml` and confirmed no matches.

## Competing PR check

Checked for existing PRs with:

- `gh pr list --repo NVIDIA/gpu-operator --search "recieve SIGTERM containerd" --state all --limit 10`
- `gh pr list --repo NVIDIA/gpu-operator --search "state-container-toolkit recieve" --state all --limit 10`

No matching PRs were returned.