### PR TITLE
backport rbac permissions for dcgm-exporter pod

### DIFF
--- a/assets/state-dcgm-exporter/0210_clusterrole.yaml
+++ b/assets/state-dcgm-exporter/0210_clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nvidia-dcgm-exporter-read-pods
+  labels:
+    app: nvidia-dcgm-exporter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/assets/state-dcgm-exporter/0310_clusterrolebinding.yaml
+++ b/assets/state-dcgm-exporter/0310_clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nvidia-dcgm-exporter-read-pods
+  labels:
+    app: nvidia-dcgm-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nvidia-dcgm-exporter-read-pods
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dcgm-exporter
+  namespace: "FILLED BY THE OPERATOR"

--- a/assets/state-dcgm-exporter/0800_daemonset.yaml
+++ b/assets/state-dcgm-exporter/0800_daemonset.yaml
@@ -24,6 +24,7 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       serviceAccountName: nvidia-dcgm-exporter
+      automountServiceAccountToken: false
       initContainers:
       - name: toolkit-validation
         image: "FILLED BY THE OPERATOR"

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -445,6 +445,33 @@ func RoleBinding(n ClusterPolicyController) (gpuv1.State, error) {
 	return gpuv1.Ready, nil
 }
 
+var rbacGates = map[string]func(*gpuv1.ClusterPolicySpec) bool{
+	"nvidia-dcgm-exporter-read-pods": func(config *gpuv1.ClusterPolicySpec) bool {
+		return isDCGMExporterKubernetesPodMetadataEnabled(&config.DCGMExporter)
+	},
+}
+
+func isRBACEnabled(name string, config *gpuv1.ClusterPolicySpec) bool {
+	gate, ok := rbacGates[name]
+	if !ok {
+		return true
+	}
+	return gate(config)
+}
+
+func isDCGMExporterKubernetesPodMetadataEnabled(config *gpuv1.DCGMExporterSpec) bool {
+	for _, env := range config.Env {
+		switch env.Name {
+		case "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS", "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID":
+			enabled, err := strconv.ParseBool(env.Value)
+			if err == nil && enabled {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ClusterRole creates ClusterRole resource
 func ClusterRole(n ClusterPolicyController) (gpuv1.State, error) {
 	ctx := n.ctx
@@ -456,6 +483,15 @@ func ClusterRole(n ClusterPolicyController) (gpuv1.State, error) {
 
 	// Check if state is disabled and cleanup resource if exists
 	if !n.isStateEnabled(n.stateNames[n.idx]) {
+		err := n.client.Delete(ctx, obj)
+		if err != nil && !apierrors.IsNotFound(err) {
+			logger.Info("Couldn't delete", "Error", err)
+			return gpuv1.NotReady, err
+		}
+		return gpuv1.Disabled, nil
+	}
+
+	if !isRBACEnabled(obj.Name, &n.singleton.Spec) {
 		err := n.client.Delete(ctx, obj)
 		if err != nil && !apierrors.IsNotFound(err) {
 			logger.Info("Couldn't delete", "Error", err)
@@ -497,6 +533,15 @@ func ClusterRoleBinding(n ClusterPolicyController) (gpuv1.State, error) {
 
 	// Check if state is disabled and cleanup resource if exists
 	if !n.isStateEnabled(n.stateNames[n.idx]) {
+		err := n.client.Delete(ctx, obj)
+		if err != nil && !apierrors.IsNotFound(err) {
+			logger.Info("Couldn't delete", "Error", err)
+			return gpuv1.NotReady, err
+		}
+		return gpuv1.Disabled, nil
+	}
+
+	if !isRBACEnabled(obj.Name, &n.singleton.Spec) {
 		err := n.client.Delete(ctx, obj)
 		if err != nil && !apierrors.IsNotFound(err) {
 			logger.Info("Couldn't delete", "Error", err)
@@ -1818,6 +1863,10 @@ func TransformDCGMExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 		}
 		jobMappingVol := corev1.Volume{Name: "hpc-job-mapping", VolumeSource: jobMappingVolumeSource}
 		obj.Spec.Template.Spec.Volumes = append(obj.Spec.Template.Spec.Volumes, jobMappingVol)
+	}
+
+	if isDCGMExporterKubernetesPodMetadataEnabled(&config.DCGMExporter) {
+		obj.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(true)
 	}
 
 	// mount configmap for custom metrics if provided by user

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -526,7 +526,7 @@ func testDaemonsetCommon(t *testing.T, cp *gpuv1.ClusterPolicy, component string
 		require.Equal(t, spec.args, mainCtr.Args, "unexpected Args")
 	}
 	for _, env := range spec.env {
-		require.Contains(t, mainCtr.Env, env, "env var not present")
+		require.Equal(t, env.Value, getContainerEnv(&mainCtr, env.Name), "unexpected value for env var %s", env.Name)
 	}
 	// TODO: implement checks for other common fields (i.e. Resources, securityContext, Tolerations, etc.)
 
@@ -1151,6 +1151,14 @@ func getDCGMExporterTestInput(testCase string) *gpuv1.ClusterPolicy {
 	case "standalone-dcgm":
 		dcgmEnabled := true
 		cp.Spec.DCGM.Enabled = &dcgmEnabled
+	case "pod-labels-enabled":
+		cp.Spec.DCGMExporter.Env = []gpuv1.EnvVar{
+			{Name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS", Value: "true"},
+		}
+	case "pod-uid-enabled":
+		cp.Spec.DCGMExporter.Env = []gpuv1.EnvVar{
+			{Name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID", Value: "true"},
+		}
 	default:
 		return nil
 	}
@@ -1166,6 +1174,7 @@ func getDCGMExporterTestOutput(testCase string) map[string]interface{} {
 		"numDaemonsets":     1,
 		"dcgmExporterImage": "nvcr.io/nvidia/k8s/dcgm-exporter:3.3.0-3.2.0-ubuntu22.04",
 		"imagePullSecret":   "ngc-secret",
+		"clusterRoleExists": false,
 	}
 
 	switch testCase {
@@ -1175,6 +1184,16 @@ func getDCGMExporterTestOutput(testCase string) map[string]interface{} {
 		output["env"] = map[string]string{
 			"DCGM_REMOTE_HOSTENGINE_INFO": "nvidia-dcgm:5555",
 		}
+	case "pod-labels-enabled":
+		output["env"] = map[string]string{
+			"DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS": "true",
+		}
+		output["clusterRoleExists"] = true
+	case "pod-uid-enabled":
+		output["env"] = map[string]string{
+			"DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID": "true",
+		}
+		output["clusterRoleExists"] = true
 	default:
 		return nil
 	}
@@ -1199,6 +1218,16 @@ func TestDCGMExporter(t *testing.T) {
 			"StandalongDCGM",
 			getDCGMExporterTestInput("standalone-dcgm"),
 			getDCGMExporterTestOutput("standalone-dcgm"),
+		},
+		{
+			"PodLabelsEnabled",
+			getDCGMExporterTestInput("pod-labels-enabled"),
+			getDCGMExporterTestOutput("pod-labels-enabled"),
+		},
+		{
+			"PodUIDEnabled",
+			getDCGMExporterTestInput("pod-uid-enabled"),
+			getDCGMExporterTestOutput("pod-uid-enabled"),
 		},
 	}
 
@@ -1229,6 +1258,23 @@ func TestDCGMExporter(t *testing.T) {
 				if !envFound {
 					t.Fatalf("Expected env is not set for daemonset nvidia-dcgm-exporter %s->%s", key, value)
 				}
+			}
+
+			clusterRoleKey := client.ObjectKey{Name: "nvidia-dcgm-exporter-read-pods"}
+			clusterRole := &rbacv1.ClusterRole{}
+			clusterRoleGetErr := clusterPolicyController.client.Get(context.Background(), clusterRoleKey, clusterRole)
+			clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+			clusterRoleBindingGetErr := clusterPolicyController.client.Get(context.Background(), clusterRoleKey, clusterRoleBinding)
+			if tc.output["clusterRoleExists"].(bool) {
+				require.NoError(t, clusterRoleGetErr, "ClusterRole should exist when pod metadata enrichment is enabled")
+				require.NoError(t, clusterRoleBindingGetErr, "ClusterRoleBinding should exist when pod metadata enrichment is enabled")
+				require.NotNil(t, ds.Spec.Template.Spec.AutomountServiceAccountToken, "AutomountServiceAccountToken should be set when pod metadata enrichment is enabled")
+				require.True(t, *ds.Spec.Template.Spec.AutomountServiceAccountToken, "AutomountServiceAccountToken should be true when pod metadata enrichment is enabled")
+			} else {
+				require.True(t, apierrors.IsNotFound(clusterRoleGetErr), "ClusterRole should not exist when pod metadata enrichment is disabled (got err=%v)", clusterRoleGetErr)
+				require.True(t, apierrors.IsNotFound(clusterRoleBindingGetErr), "ClusterRoleBinding should not exist when pod metadata enrichment is disabled (got err=%v)", clusterRoleBindingGetErr)
+				require.NotNil(t, ds.Spec.Template.Spec.AutomountServiceAccountToken, "AutomountServiceAccountToken should be explicitly set false when pod metadata enrichment is disabled")
+				require.False(t, *ds.Spec.Template.Spec.AutomountServiceAccountToken, "AutomountServiceAccountToken should be false when pod metadata enrichment is disabled")
 			}
 
 			require.Equal(t, tc.output["dcgmExporterImage"], dcgmExporterImage, "Unexpected configuration for dcgm-exporter image")


### PR DESCRIPTION
This is required so that newer version of dcgm-exporter can have correct rbac permissions if needed

## Description
This PR does a partial backport of https://github.com/NVIDIA/gpu-operator/pull/2406

We added support to have rbac installed only when the appropriate flags are set. This PR brings in that change to 26.3 release branch so that newer dcgm-exporter pod can run without permission issues.
<!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing
Brought up a cluster using gpu-operator controller image built for this PR. It came up fine and shows no errors.

Without fix:
```
time=2026-05-21T21:16:14.185Z level=INFO msg="Initializing Pod Informer" nodeName=x11-0553
time=2026-05-21T21:16:14.186Z level=INFO msg="HTTP server started - ready to serve metrics"
time=2026-05-21T21:16:14.186Z level=INFO msg="Starting webserver"
time=2026-05-21T21:16:14.186Z level=INFO msg="Watching for changes in file" file=/etc/dcgm-exporter/dcp-metrics-included.csv debounce=200ms
time=2026-05-21T21:16:14.186Z level=INFO msg="Listening on" address=[::]:9400
time=2026-05-21T21:16:14.186Z level=INFO msg="TLS is disabled." http2=false address=[::]:9400
E0521 21:16:14.198212       1 reflector.go:227] "Failed to watch" err="failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:gpu-operator:nvidia-dcgm-exporter\" cannot list resource \"pods\" in API group \"\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.0/tools/cache/reflector.go:343" type="*v1.Pod"
E0521 21:16:15.644340       1 reflector.go:227] "Failed to watch" err="failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:gpu-operator:nvidia-dcgm-exporter\" cannot list resource \"pods\" in API group \"\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.0/tools/cache/reflector.go:343" type="*v1.Pod"
```

With fix:
```
time=2026-05-21T21:18:18.356Z level=INFO msg="Initializing system entities of type 'CPU Core'"
time=2026-05-21T21:18:18.356Z level=INFO msg="Not collecting CPU Core metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded"
time=2026-05-21T21:18:18.437Z level=INFO msg="Registry built successfully" collector_count=2
time=2026-05-21T21:18:18.437Z level=INFO msg="Kubernetes metrics collection enabled!"
time=2026-05-21T21:18:18.437Z level=WARN msg="Failed to get in-cluster config, pod labels will not be available" error="open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"
time=2026-05-21T21:18:18.438Z level=INFO msg="HTTP server started - ready to serve metrics"
time=2026-05-21T21:18:18.438Z level=INFO msg="Starting webserver"
time=2026-05-21T21:18:18.438Z level=INFO msg="Watching for changes in file" file=/etc/dcgm-exporter/dcp-metrics-included.csv debounce=200ms
time=2026-05-21T21:18:18.438Z level=INFO msg="Listening on" address=[::]:9400
time=2026-05-21T21:18:18.438Z level=INFO msg="TLS is disabled." http2=false address=[::]:9400
```
<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

