### PR TITLE
Drop must-gather entrypoint from gpu-operator image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,8 +117,6 @@ COPY assets /opt/gpu-operator/
 COPY manifests /opt/gpu-operator/manifests
 COPY validator/manifests /opt/validator/manifests
 
-COPY hack/must-gather.sh /usr/bin/gather
-
 # Add CRD resource into the image for helm upgrades
 COPY deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml /opt/gpu-operator/nvidia.com_clusterpolicies.yaml
 COPY deployments/gpu-operator/crds/nvidia.com_nvidiadrivers.yaml /opt/gpu-operator/nvidia.com_nvidiadrivers.yaml


### PR DESCRIPTION
## Description

The `/usr/bin/gather` entrypoint depended on bash, kubectl, and oc, none of which ship in the distroless base. Customers run `hack/must-gather.sh` from outside the cluster against an existing kubeconfig, which remains in the repo for that flow.

Follow-up to #2434.

Resolves #2436

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Single-line `COPY` removal in `docker/Dockerfile`; no Go or manifest changes. CI image-builds verify the build still succeeds.