### PR TITLE
ci: skip multi-arch manifest publish when push is disabled

### DIFF
--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -141,6 +141,7 @@ jobs:
 
   build-multi-arch-images:
     needs: [variables, build-gpu-operator-arm64, build-gpu-operator-amd64]
+    if: needs.variables.outputs.push_on_build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -163,4 +164,3 @@ jobs:
             ${OPERATOR_IMAGE_AMD} \
             ${OPERATOR_IMAGE_ARM}
           docker manifest push ${OPERATOR_MULTIARCH_IMAGE}
-


### PR DESCRIPTION
## Summary
- skip the multi-arch manifest job when `push_on_build` is `false`

## Why
The per-arch image builds already honor `push_on_build` through the build output settings, but the final manifest job still runs unconditionally.

That leaves us with an inconsistent flow in non-push contexts: the workflow can skip pushing the arch images and then still try to create and push a multi-arch manifest that references images that were never published.

This showed up after the CI workflow split introduced `push_on_build` into the modular workflows, but the manifest job never started consuming that signal.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/image-builds.yaml")'`

I did not run the workflow end-to-end locally.
