### PR TITLE
Revert "Update nvcr.io/nvidia/cloud-native/k8s-driver-manager Docker tag to v0.11.0

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -226,9 +226,9 @@ spec:
     - name: gpu-operator-validator-image
       image: ghcr.io/nvidia/gpu-operator:main-latest
     - name: k8s-driver-manager-image
-      image: nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.11.0@sha256:8aec215a8b159b0162b55e688065efd58ebfa848ebc999c1797221686ff1243d
+      image: nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.10.0@sha256:6677437faff2c45506484dd9f0f04ad3b4880aa65b26d11f76d169e65497fade
     - name: vfio-manager-image
-      image: nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.11.0@sha256:8aec215a8b159b0162b55e688065efd58ebfa848ebc999c1797221686ff1243d
+      image: nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.10.0@sha256:6677437faff2c45506484dd9f0f04ad3b4880aa65b26d11f76d169e65497fade
     - name: cc-manager-image
       image: nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.4.0@sha256:4e3bfe3fe9e0bb2d2dca89af3eb8c1437a98739c86a255d1730a80211312be75
     - name: sandbox-device-plugin-image
@@ -938,11 +938,11 @@ spec:
                   - name: "DRIVER_IMAGE-535"
                     value: "nvcr.io/nvidia/driver@sha256:659d9315957ffa2a3f2a003716f066f6a1b3c06ae5557192148ed410dc1b9a6e"
                   - name: "DRIVER_MANAGER_IMAGE"
-                    value: "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.11.0@sha256:8aec215a8b159b0162b55e688065efd58ebfa848ebc999c1797221686ff1243d"
+                    value: "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.10.0@sha256:6677437faff2c45506484dd9f0f04ad3b4880aa65b26d11f76d169e65497fade"
                   - name: "MIG_MANAGER_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.2@sha256:313586bfa5c07601a83f310dd700db0007d489df2ad42bb52c611802cbb7a278"
                   - name: "VFIO_MANAGER_IMAGE"
-                    value: "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.11.0@sha256:8aec215a8b159b0162b55e688065efd58ebfa848ebc999c1797221686ff1243d"
+                    value: "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.10.0@sha256:6677437faff2c45506484dd9f0f04ad3b4880aa65b26d11f76d169e65497fade"
                   - name: "CC_MANAGER_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.4.0@sha256:4e3bfe3fe9e0bb2d2dca89af3eb8c1437a98739c86a255d1730a80211312be75"
                   - name: "SANDBOX_DEVICE_PLUGIN_IMAGE"

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -182,7 +182,7 @@ driver:
     image: k8s-driver-manager
     # When choosing a different version of k8s-driver-manager, DO NOT downgrade to a version lower than v0.6.4
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
-    version: v0.11.0
+    version: v0.10.0
     imagePullPolicy: IfNotPresent
     env: []
   env: []
@@ -455,7 +455,7 @@ vgpuManager:
     image: k8s-driver-manager
     # When choosing a different version of k8s-driver-manager, DO NOT downgrade to a version lower than v0.6.4
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
-    version: v0.11.0
+    version: v0.10.0
     imagePullPolicy: IfNotPresent
     env: []
    # kernel module configuration for vGPU manager
@@ -480,7 +480,7 @@ vfioManager:
   enabled: true
   repository: nvcr.io/nvidia/cloud-native
   image: k8s-driver-manager
-  version: v0.11.0
+  version: v0.10.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   env: []
@@ -490,7 +490,7 @@ vfioManager:
     image: k8s-driver-manager
     # When choosing a different version of k8s-driver-manager, DO NOT downgrade to a version lower than v0.6.4
     # to ensure k8s-driver-manager stays compatible with gpu-operator starting from v24.3.0
-    version: v0.11.0
+    version: v0.10.0
     imagePullPolicy: IfNotPresent
     env: []
   hostNetwork: false


### PR DESCRIPTION
This reverts commit a21951a622a06ea5a7ee8d627853e02d5a618e34.

NOTE: We are reverting this change as an update to the k8s-driver-manager init container will lead to a driver daemonset rollout after users upgrade to gpu-operator v26.3.2 