### PR TITLE
[ci-e2e] update TARGET_DRIVER_VERSION

### DIFF
--- a/tests/scripts/.definitions.sh
+++ b/tests/scripts/.definitions.sh
@@ -17,7 +17,7 @@ TERRAFORM="terraform -chdir=${TERRAFORM_DIR}"
 : ${LOG_DIR:="/tmp/logs"}
 : ${PROJECT:="$(basename "${PROJECT_DIR}")"}
 : ${TEST_NAMESPACE:="test-operator"}
-: ${TARGET_DRIVER_VERSION:="535.288.01"}
+: ${TARGET_DRIVER_VERSION:="580.159.04"}
 
 : ${OPERATOR_IMAGE:="nvcr.io/nvidia/gpu-operator"}
 


### PR DESCRIPTION
The R535 driver branch transitions to EOL as of June 2026. Given this, we bump the TARGET_DRIVER_VERSION to use a driver version from the oldest driver branch that is still actively supported.