### PR TITLE
Prevent ClusterPolicy ready state during driver upgrades

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -4012,6 +4012,7 @@ func isDaemonSetReady(name string, n ClusterPolicyController) gpuv1.State {
 	err := n.client.Get(ctx, types.NamespacedName{Namespace: n.operatorNamespace, Name: name}, ds)
 	if err != nil {
 		n.logger.Error(err, "could not get daemonset", "name", name)
+		return gpuv1.NotReady
 	}
 
 	if ds.Status.DesiredNumberScheduled == 0 {
@@ -4024,12 +4025,16 @@ func isDaemonSetReady(name string, n ClusterPolicyController) gpuv1.State {
 		return gpuv1.NotReady
 	}
 
-	// if ds is running with "OnDelete" strategy, check if the revision matches for all pods
+	// RollingUpdate DaemonSets are ready only after the latest generation is observed and all desired pods
+	// are updated and available. OnDelete DaemonSets fall through to per-pod revision checks below.
 	if ds.Spec.UpdateStrategy.Type != appsv1.OnDeleteDaemonSetStrategyType {
-		return gpuv1.Ready
+		if isDaemonSetRollingUpdateComplete(ds) {
+			return gpuv1.Ready
+		}
+		return gpuv1.NotReady
 	}
 
-	opts := []client.ListOption{client.MatchingLabels(ds.Spec.Template.Labels)}
+	opts := []client.ListOption{client.MatchingLabels(ds.Spec.Selector.MatchLabels)}
 
 	n.logger.V(2).Info("Pod", "LabelSelector", fmt.Sprintf("app=%s", name))
 	list := &corev1.PodList{}
@@ -4081,6 +4086,14 @@ func isDaemonSetReady(name string, n ClusterPolicyController) gpuv1.State {
 
 	// All containers are ready
 	return gpuv1.Ready
+}
+
+// isDaemonSetRollingUpdateComplete reports whether a RollingUpdate DaemonSet has observed its latest generation
+// and all desired pods are updated and available.
+func isDaemonSetRollingUpdateComplete(ds *appsv1.DaemonSet) bool {
+	return ds.Status.ObservedGeneration >= ds.Generation &&
+		ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled
 }
 
 func getPodsOwnedbyDaemonset(ds *appsv1.DaemonSet, pods []corev1.Pod, n ClusterPolicyController) []corev1.Pod {
@@ -4776,6 +4789,7 @@ func DaemonSet(n ClusterPolicyController) (gpuv1.State, error) {
 		if err != nil {
 			return gpuv1.NotReady, err
 		}
+		return gpuv1.NotReady, nil
 	} else {
 		logger.Info("DaemonSet identical, skipping update", "name", obj.Name)
 	}

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -136,6 +136,183 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+func TestIsDaemonSetRollingUpdateComplete(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   appsv1.DaemonSet
+		want bool
+	}{
+		{
+			name: "ready when observed and all desired pods are updated and available",
+			ds: appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     2,
+					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 3,
+					NumberAvailable:        3,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not ready when controller has not observed latest generation",
+			ds: appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 3,
+					NumberAvailable:        3,
+				},
+			},
+		},
+		{
+			name: "not ready when rollout has available old pods but not all pods are updated",
+			ds: appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     2,
+					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 2,
+					NumberAvailable:        3,
+				},
+			},
+		},
+		{
+			name: "not ready when all pods are updated but not all are available",
+			ds: appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     2,
+					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 3,
+					NumberAvailable:        2,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isDaemonSetRollingUpdateComplete(&tt.ds))
+		})
+	}
+}
+
+func TestIsDaemonSetReadyReturnsNotReadyWhenDaemonSetMissing(t *testing.T) {
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	controller := ClusterPolicyController{
+		ctx:               context.Background(),
+		client:            k8sClient,
+		operatorNamespace: "test-namespace",
+		logger:            ctrl.Log.WithName("test"),
+	}
+
+	require.Equal(t, gpuv1.NotReady, isDaemonSetReady("missing-daemonset", controller))
+}
+
+func TestIsDaemonSetReadyUsesSelectorLabelsForOnDeletePods(t *testing.T) {
+	const (
+		namespace = "test-namespace"
+		dsName    = "nvidia-driver-daemonset"
+		oldHash   = "565dcf5cc9"
+		newHash   = "69b97fbcbf"
+	)
+
+	dsUID := types.UID("driver-daemonset-uid")
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName,
+			Namespace: namespace,
+			UID:       dsUID,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": dsName}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":           dsName,
+						"helm.sh/chart": "gpu-operator-v26.3.2",
+					},
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 3,
+			NumberUnavailable:      0,
+		},
+	}
+
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "old-driver-pod",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":                             dsName,
+				"helm.sh/chart":                   "gpu-operator-v25.10.1",
+				PodControllerRevisionHashLabelKey: oldHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "DaemonSet",
+				Name:       dsName,
+				UID:        dsUID,
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+		},
+	}
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-driver-pod",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":                             dsName,
+				"helm.sh/chart":                   "gpu-operator-v26.3.2",
+				PodControllerRevisionHashLabelKey: newHash,
+			},
+			OwnerReferences: oldPod.OwnerReferences,
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+		},
+	}
+	oldRevision := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName + "-" + oldHash,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": dsName},
+		},
+		Revision: 1,
+	}
+	newRevision := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName + "-" + newHash,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": dsName},
+		},
+		Revision: 2,
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(ds, oldPod, newPod, oldRevision, newRevision).
+		Build()
+	controller := ClusterPolicyController{
+		ctx:               context.Background(),
+		client:            k8sClient,
+		operatorNamespace: namespace,
+		logger:            ctrl.Log.WithName("test"),
+	}
+
+	require.Equal(t, gpuv1.NotReady, isDaemonSetReady(dsName, controller))
+}
+
 func getModuleRoot(dir string) (string, error) {
 	if dir == "" || dir == "/" {
 		return "", fmt.Errorf("module root not found")


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Fixes: https://github.com/NVIDIA/gpu-operator/issues/1567

## Issue
During driver auto-upgrade, `ClusterPolicy.status.state` could briefly flip to `ready` even though not all driver pods had been upgraded yet.

The issue was in DaemonSet readiness detection for `OnDelete` DaemonSets. `isDaemonSetReady()` intended to verify that all DaemonSet-owned pods matched the latest DaemonSet controller revision, but it first listed pods using the DaemonSet pod template labels:

```go
client.MatchingLabels(ds.Spec.Template.Labels)
```

During a Helm/operator upgrade, pod template labels can change. For example, after upgrading from `25.10.1` to `26.3.2`, the new driver DaemonSet template has:
```
helm.sh/chart=gpu-operator-v26.3.2
```
while old driver pods still have:
```
helm.sh/chart=gpu-operator-v25.10.1
```
Because the pod list used the new template labels, old driver pods were filtered out before the revision check. As a result, `isDaemonSetReady()` only evaluated the already-upgraded pods and incorrectly returned `Ready`.

In the captured reproduction, the driver DaemonSet showed:
```
DESIRED=3 READY=3 UP-TO-DATE=1 AVAILABLE=3
```
but `ClusterPolicy` was still marked `ready`. Two driver pods were still on the old controller revision, but they were excluded from the readiness check because their chart label no longer matched the new DaemonSet template labels.

## Fix
Update `isDaemonSetReady()` to list pods using the DaemonSet selector labels instead of the mutable pod template labels:
```go
client.MatchingLabels(ds.Spec.Selector.MatchLabels)
```
The DaemonSet selector is the correct source for identifying pods selected by that DaemonSet. This makes the readiness check independent of mutable template labels such as chart/version labels.

The fix does not rely on a global driver label. It uses the selector of the DaemonSet currently being checked.

For ClusterPolicy-managed drivers, this may be:
```
app=nvidia-driver-daemonset
```
For NVIDIADriver-managed drivers, this may be a generated app label such as:
```
app=nvidia-gpu-driver-ubuntu22.04-<hash>
```
In both cases, the selector identifies the pods belonging to that specific DaemonSet, which is exactly what `isDaemonSetReady()` needs.

After this change, old and new revision pods selected by the DaemonSet are both included in the readiness check, and the existing `controller-revision-hash` comparison correctly keeps `ClusterPolicy` `notReady` until all DaemonSet pods are updated.

## Additional Hardening
This change also hardens DaemonSet readiness by:

* Returning `NotReady` if the DaemonSet cannot be fetched.
* Checking RollingUpdate DaemonSets with:
        * ObservedGeneration >= Generation
        * UpdatedNumberScheduled == DesiredNumberScheduled
        * NumberAvailable == DesiredNumberScheduled
* Returning `NotReady` immediately after updating a DaemonSet spec, so readiness is evaluated on a later reconcile.


## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

Tested this change by deploying to a cluster and upgrading from v25.10.1 to v26.3.2 with the operator image overwritten with image from this PR. Now, we don't see fluctuation during driver upgrades which was seen previously without the fix.