### PR TITLE
Update Memory Hotplug hostvolume to /sys/devices/system

### DIFF
--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -128,8 +128,8 @@ spec:
           - name: run-mellanox-drivers
             mountPath: /run/mellanox/drivers
             mountPropagation: HostToContainer
-          - name: sysfs-memory-online
-            mountPath: /sys/devices/system/memory/auto_online_blocks
+          - name: host-sys-devices-system
+            mountPath: /sys/devices/system
           - name: firmware-search-path
             mountPath: /sys/module/firmware_class/parameters/path
           - name: nv-firmware
@@ -320,9 +320,10 @@ spec:
         - name: firmware-search-path
           hostPath:
             path: /sys/module/firmware_class/parameters/path
-        - name: sysfs-memory-online
+        - name: host-sys-devices-system
           hostPath:
-            path: /sys/devices/system/memory/auto_online_blocks
+            path: /sys/devices/system
+            type: Directory
         - name: nv-firmware
           hostPath:
             path: /run/nvidia/driver/lib/firmware

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -142,6 +142,56 @@ func TestDriverRenderMinimal(t *testing.T) {
 	require.Equal(t, string(o), actual)
 }
 
+func TestDriverHostSysDevicesSystemVolumeUsesStableParentDirectory(t *testing.T) {
+	state, err := NewStateDriver(nil, "", nil, manifestDir)
+	require.Nil(t, err)
+	stateDriver, ok := state.(*stateDriver)
+	require.True(t, ok)
+
+	objs, err := stateDriver.renderer.RenderObjects(
+		&render.TemplatingData{
+			Data: getMinimalDriverRenderData(),
+		})
+	require.Nil(t, err)
+	require.NotEmpty(t, objs)
+
+	ds, err := getDaemonsetFromObjects(objs)
+	require.Nil(t, err)
+
+	var hostSysDevicesSystemVolume *corev1.Volume
+	for i := range ds.Spec.Template.Spec.Volumes {
+		if ds.Spec.Template.Spec.Volumes[i].Name == "host-sys-devices-system" {
+			hostSysDevicesSystemVolume = &ds.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, hostSysDevicesSystemVolume)
+	require.NotNil(t, hostSysDevicesSystemVolume.HostPath)
+	require.NotNil(t, hostSysDevicesSystemVolume.HostPath.Type)
+	assert.Equal(t, "/sys/devices/system", hostSysDevicesSystemVolume.HostPath.Path)
+	assert.Equal(t, corev1.HostPathDirectory, *hostSysDevicesSystemVolume.HostPath.Type)
+
+	var driverContainer *corev1.Container
+	for i := range ds.Spec.Template.Spec.Containers {
+		if ds.Spec.Template.Spec.Containers[i].Name == "nvidia-driver-ctr" {
+			driverContainer = &ds.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, driverContainer)
+
+	var hostSysDevicesSystemMount *corev1.VolumeMount
+	for i := range driverContainer.VolumeMounts {
+		if driverContainer.VolumeMounts[i].Name == "host-sys-devices-system" {
+			hostSysDevicesSystemMount = &driverContainer.VolumeMounts[i]
+			break
+		}
+	}
+	require.NotNil(t, hostSysDevicesSystemMount)
+	assert.Equal(t, "/sys/devices/system", hostSysDevicesSystemMount.MountPath)
+	assert.Empty(t, hostSysDevicesSystemMount.SubPath)
+}
+
 func TestDriverHostNetwork(t *testing.T) {
 	const (
 		testName = "driver-hostnetwork"

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -240,8 +240,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -358,8 +358,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -258,8 +258,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -381,8 +381,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -312,8 +312,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -532,8 +532,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -242,8 +242,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -412,8 +412,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -242,8 +242,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -412,8 +412,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-hostnetwork.yaml
+++ b/internal/state/testdata/golden/driver-hostnetwork.yaml
@@ -240,8 +240,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -351,8 +351,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -240,8 +240,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -349,8 +349,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -310,8 +310,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -468,8 +468,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -242,8 +242,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -352,8 +352,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -244,8 +244,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -432,8 +432,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -242,8 +242,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -426,8 +426,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-secret-env.yaml
+++ b/internal/state/testdata/golden/driver-secret-env.yaml
@@ -247,8 +247,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -444,8 +444,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -275,8 +275,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -437,8 +437,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -227,8 +227,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -343,8 +343,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
@@ -240,8 +240,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -355,8 +355,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -240,8 +240,8 @@ spec:
           name: run-mellanox-drivers
         - mountPath: /sys/module/firmware_class/parameters/path
           name: firmware-search-path
-        - mountPath: /sys/devices/system/memory/auto_online_blocks
-          name: sysfs-memory-online
+        - mountPath: /sys/devices/system
+          name: host-sys-devices-system
         - mountPath: /lib/firmware
           name: nv-firmware
         - mountPath: /usr/local/bin/startup-probe.sh
@@ -355,8 +355,9 @@ spec:
           path: /sys/module/firmware_class/parameters/path
         name: firmware-search-path
       - hostPath:
-          path: /sys/devices/system/memory/auto_online_blocks
-        name: sysfs-memory-online
+          path: /sys/devices/system
+          type: Directory
+        name: host-sys-devices-system
       - hostPath:
           path: /run/nvidia/driver/lib/firmware
           type: DirectoryOrCreate

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -325,8 +325,8 @@ spec:
             mountPropagation: HostToContainer
           - name: firmware-search-path
             mountPath: /sys/module/firmware_class/parameters/path
-          - name: sysfs-memory-online
-            mountPath: /sys/devices/system/memory/auto_online_blocks
+          - name: host-sys-devices-system
+            mountPath: /sys/devices/system
           - name: nv-firmware
             mountPath: /lib/firmware
           - name: driver-startup-probe-script
@@ -687,9 +687,10 @@ spec:
         - name: firmware-search-path
           hostPath:
             path: /sys/module/firmware_class/parameters/path
-        - name: sysfs-memory-online
+        - name: host-sys-devices-system
           hostPath:
-            path: /sys/devices/system/memory/auto_online_blocks
+            path: /sys/devices/system
+            type: Directory
         - name: nv-firmware
           hostPath:
             path: /run/nvidia/driver/lib/firmware


### PR DESCRIPTION
## Description
This PR is created in response to this [bug](https://github.com/NVIDIA/gpu-operator/issues/2463). Essentially, on some systems the /sys/devices/system/memory/auto_online_blocks files is not present and cannot be mounted as a hostvolume for systems that don't have _CONFIG_MEMORY_HOTPLUG=y_. auto_online_blocks is a Linux sysfs knob for memory hotplug.

Solution:

In manifests/state-driver/0500_daemonset.yaml and assets/state-driver/0500_daemonset.yaml switch to using a wider mountpath on /sys/devices/system rather than directly mounting /sys/devices/system/memory/auto_online_blocks.

## Checklist

- [ x] No secrets, sensitive information, or unrelated changes
- [ x] Lint checks passing (`make lint`)
- [ x] Generated assets in-sync (`make validate-generated-assets`)
- [ x] Go mod artifacts in-sync (`make validate-modules`)
- [ x] Test cases are added for new code paths

## Testing

Added TestDriverSysfsMemoryOnlineVolumeUsesStableParentDirectory, which verifies the rendered driver DaemonSet has the /sys/devices/system mount. It finds the volume named sysfs-memory-online and checks:

HostPath.Path == "/sys/devices/system"
HostPath.Type == corev1.HostPathDirectory
Finds the nvidia-driver-ctr container.

Finds that container’s sysfs-memory-online volume mount and checks:

MountPath == "/sys/devices/system"
SubPath == ""
So the test protects the exact behavior we want: the operator should mount the stable parent directory, not the optional /sys/devices/system/memory/auto_online_blocks file.