### PR TITLE
Remove deprecated initContainer in helm template

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -25,24 +25,6 @@ spec:
     {{- if .Values.operator.defaultGPUMode }}
     defaultGPUMode: {{ .Values.operator.defaultGPUMode }}
     {{- end }}
-    {{- if .Values.operator.initContainer }}
-    initContainer:
-      {{- if .Values.operator.initContainer.repository }}
-      repository: {{ .Values.operator.initContainer.repository }}
-      {{- end }}
-      {{- if .Values.operator.initContainer.image }}
-      image: {{ .Values.operator.initContainer.image }}
-      {{- end }}
-      {{- if .Values.operator.initContainer.version }}
-      version: {{ .Values.operator.initContainer.version | quote }}
-      {{- end }}
-      {{- if .Values.operator.initContainer.imagePullPolicy }}
-      imagePullPolicy: {{ .Values.operator.initContainer.imagePullPolicy }}
-      {{- end }}
-      {{- if .Values.operator.initContainer.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.operator.initContainer.imagePullSecrets | nindent 8 }}
-      {{- end }}
-    {{- end }}
     {{- if .Values.operator.use_ocp_driver_toolkit }}
     use_ocp_driver_toolkit: {{ .Values.operator.use_ocp_driver_toolkit }}
     {{- end }}

--- a/tests/scripts/env-to-values.sh
+++ b/tests/scripts/env-to-values.sh
@@ -28,7 +28,6 @@ set -euo pipefail
 #   - TOOLKIT_CONTAINER_IMAGE: container-toolkit image override
 #   - DEVICE_PLUGIN_IMAGE: device-plugin image override
 #   - MIG_MANAGER_IMAGE: mig-manager image override
-#   - CONTAINER_RUNTIME: default runtime (docker, containerd, crio)
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 OUTPUT_FILE" >&2
@@ -67,12 +66,6 @@ if [[ -n "${OPERATOR_VERSION:-}" ]]; then
     OPERATOR_CONFIG="${OPERATOR_CONFIG}  version: \"${OPERATOR_VERSION}\"\n"
     VALIDATOR_CONFIG="${VALIDATOR_CONFIG}  version: \"${OPERATOR_VERSION}\"\n"
     echo "Added operator.version: ${OPERATOR_VERSION}"
-    HAS_VALUES=true
-fi
-
-if [[ -n "${CONTAINER_RUNTIME:-}" ]]; then
-    OPERATOR_CONFIG="${OPERATOR_CONFIG}  defaultRuntime: \"${CONTAINER_RUNTIME}\"\n"
-    echo "Added operator.defaultRuntime: ${CONTAINER_RUNTIME}"
     HAS_VALUES=true
 fi
 

--- a/tests/scripts/install-operator.sh
+++ b/tests/scripts/install-operator.sh
@@ -26,8 +26,6 @@ if [[ "${USE_VALUES_FILE}" == "false" ]]; then
 	if [[ -n "${OPERATOR_VERSION}" ]]; then
 		OPERATOR_OPTIONS="${OPERATOR_OPTIONS} --set operator.version=${OPERATOR_VERSION} --set validator.version=${OPERATOR_VERSION}"
 	fi
-	
-	OPERATOR_OPTIONS="${OPERATOR_OPTIONS} --set operator.defaultRuntime=${CONTAINER_RUNTIME}"
 fi
 
 if [[ "${USE_VALUES_FILE}" == "true" ]]; then


### PR DESCRIPTION
## Description

Remove the dead `operator.initContainer` block from the ClusterPolicy Helm template.

`spec.operator.initContainer` is deprecated and unused — per-component init container images (e.g. `spec.driver.manager`) are configured separately. The field was marked deprecated in [#2092](https://github.com/NVIDIA/gpu-operator/pull/2092) when the last functional use (dcgm-exporter OCP init container) was removed and `operator.initContainer` was dropped from `values.yaml`.

The Helm template still conditionally rendered `spec.operator.initContainer` when values were supplied via `--set`, even though `operator.initContainer` is not defined in the chart's `values.yaml`. This hidden surface caused confusion without providing any functional benefit.

**Scope (updated per maintainer feedback in [#2519](https://github.com/NVIDIA/gpu-operator/pull/2519#issuecomment-4650247679)):**

- Remove `operator.initContainer` references from [`deployments/gpu-operator/templates/clusterpolicy.yaml`](deployments/gpu-operator/templates/clusterpolicy.yaml)

**Intentionally not changed:**

- `spec.operator.defaultRuntime` and `spec.operator.initContainer` remain in the ClusterPolicy API and CRD schema. Removing CRD fields is a breaking API change
- No changes to samples, test scripts, or generated CRD/deepcopy artifacts



## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)

## Testing

`make manifests generate sync-crds`
