### PR TITLE
add workflow for adding helm chart as oci artifact for commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       operator_image: ${{ needs.variables.outputs.operator_image }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,8 +62,18 @@ jobs:
       operator_image: ${{ inputs.operator_image }}
       operator_version: ${{ inputs.operator_version }}
 
-  e2e-tests-containerd:
+  publish-helm-oci-chart:
     needs: [variables]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-helm-oci-chart.yaml
+    with:
+      operator_image: ${{ needs.variables.outputs.operator_image }}
+      operator_version: ${{ needs.variables.outputs.operator_version }}
+
+  e2e-tests-containerd:
+    needs: [variables, publish-helm-oci-chart]
     runs-on: linux-amd64-cpu4
     timeout-minutes: 90
     permissions:
@@ -129,7 +139,7 @@ jobs:
           retention-days: 15
 
   e2e-tests-nvidiadriver:
-    needs: [variables]
+    needs: [variables, publish-helm-oci-chart]
     runs-on: linux-amd64-cpu4
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/publish-helm-oci-chart.yaml
+++ b/.github/workflows/publish-helm-oci-chart.yaml
@@ -1,0 +1,101 @@
+# Copyright NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Helm OCI Chart
+
+on:
+  workflow_call:
+    inputs:
+      operator_image:
+        required: true
+        type: string
+      operator_version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-helm-oci-chart-${{ inputs.operator_version }}
+  cancel-in-progress: false
+
+jobs:
+  publish-helm-chart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        name: Check out code
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.0
+
+      - name: Set chart image repository
+        env:
+          OPERATOR_IMAGE: ${{ inputs.operator_image }}
+        run: echo "OPERATOR_REPOSITORY=${OPERATOR_IMAGE%/*}" >> "${GITHUB_ENV}"
+
+      - name: Update chart image repository
+        uses: mikefarah/yq@v4
+        with:
+          cmd: yq -i '.operator.repository = env(OPERATOR_REPOSITORY) | .validator.repository = env(OPERATOR_REPOSITORY)' deployments/gpu-operator/values.yaml
+
+      - name: Login to GitHub Container Registry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GH_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Package Helm chart
+        id: package
+        env:
+          OPERATOR_VERSION: ${{ inputs.operator_version }}
+        run: |
+          set -euo pipefail
+
+          # Helm chart versions must be SemVer. Prefix the image version so a
+          # numeric short SHA with a leading zero remains a valid prerelease.
+          CHART_VERSION="0.0.0-git-${OPERATOR_VERSION}"
+
+          mkdir -p dist
+          helm lint deployments/gpu-operator
+          helm package \
+            --version "${CHART_VERSION}" \
+            --app-version "${OPERATOR_VERSION}" \
+            --destination dist \
+            deployments/gpu-operator
+
+          CHART_PACKAGE="$(find dist -maxdepth 1 -type f -name 'gpu-operator-*.tgz' | head -n 1)"
+          if [[ -z "${CHART_PACKAGE}" ]]; then
+            echo "::error::Helm chart package was not created"
+            exit 1
+          fi
+
+          echo "chart_package=${CHART_PACKAGE}" >> "${GITHUB_OUTPUT}"
+          echo "chart_version=${CHART_VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish Helm OCI chart
+        env:
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          CHART_PACKAGE: ${{ steps.package.outputs.chart_package }}
+          CHART_VERSION: ${{ steps.package.outputs.chart_version }}
+        run: |
+          set -euo pipefail
+
+          LOWERCASE_REPO_OWNER=$(echo "${GITHUB_REPOSITORY_OWNER}" | awk '{print tolower($0)}')
+          CHART_REPOSITORY="oci://ghcr.io/${LOWERCASE_REPO_OWNER}/gpu-operator/charts"
+
+          helm push "${CHART_PACKAGE}" "${CHART_REPOSITORY}"
+          echo "::notice::Published Helm chart to ${CHART_REPOSITORY}/gpu-operator:${CHART_VERSION}"


### PR DESCRIPTION
## Summary

Adds a reusable workflow to publish the GPU Operator Helm chart as a GHCR OCI artifact.

## Changes

- Adds `.github/workflows/publish-helm-oci-chart.yaml`.
- Defines the workflow as `workflow_call` so it can be triggered from `e2e-tests.yaml`.
- Packages `deployments/gpu-operator` as a Helm chart.
- Uses the operator image version as chart metadata:
  - chart version: `0.0.0-git-<commit_sha>`
  - app version: `<commit_sha>`
- Publishes the chart to `oci://ghcr.io/nvidia/gpu-operator/charts`.

## Notes

The workflow is intended to run after the matching GPU Operator image has been built and pushed, so the published chart points to an image tag that exists.

<!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->
Downloaded and installed the oci artifact built for this PR on a k8s cluster and everything comes up fine as expected.
