### PR TITLE
[state-device-plugin] infer feature enablement envars from kernel modules

### DIFF
--- a/assets/state-device-plugin/0400_configmap.yaml
+++ b/assets/state-device-plugin/0400_configmap.yaml
@@ -18,6 +18,35 @@ data:
     set -o allexport
     cat /run/nvidia/validations/driver-ready
     . /run/nvidia/validations/driver-ready
+    
+    extra_modules="gdrdrv nvidia_fs"
+    > feature-flags.env
+    for module in ${extra_modules}; do
+        if lsmod | grep -q "^$module "; then
+            case "$module" in
+                "gdrdrv")
+                  if [ -z "$GDRCOPY_ENABLED" ]; then
+                      echo "GDRCOPY_ENABLED=true" >> feature-flags.env
+                  fi
+                ;;
+                "nvidia_fs")
+                  if [ -z "$GDS_ENABLED" ]; then
+                      echo "GDS_ENABLED=true" >> feature-flags.env
+                  fi
+                  if [ -z "$MOFED_ENABLED" ]; then
+                      echo "MOFED_ENABLED=true" >> feature-flags.env
+                  fi
+                ;;
+            esac
+        fi
+    done
+    
+    if [ -s "feature-flags.env" ]; then
+        echo "Enabling nvidia-device-plugin feature flags..."
+        cat feature-flags.env
+        . ./feature-flags.env
+    fi
 
     echo "Starting nvidia-device-plugin"
     exec nvidia-device-plugin
+    


### PR DESCRIPTION
### Problem

This PR is linked to https://github.com/NVIDIA/k8s-device-plugin/pull/1837. After PR https://github.com/NVIDIA/k8s-device-plugin/pull/1550 was merged to support `NVIDIADriver` use cases, we observed that default enablement of feature flags especially `MOFED_ENABLED` was leading to disruptive side effects. Users of GPU Operator v26.3.2 (which includes k8s-device-plugin v0.19.2) were observing that GPU workload containers were getting the entire list of `ibverbs` dev nodes injected into them.  This led to failures in RDMA/NCCL-based workloads where the workloads were referencing the wrong NICs as opposed to only picking the appropriate the NICs suited for that workload. See here for an example - https://github.com/NVIDIA/k8s-device-plugin/issues/1692.


### Solution

Instead of unconditionally enabling the feature flags, we enable them dynamically based on the kernel modules that are currently loaded on the node. This dynamic enablement of feature flags will ensure that `ClusterPolicy`, `NVIDIADriver`  and pre-installed driver use cases are supported without depending on a cluster-wide setting in the daemonset spec.