### PR TITLE
Add Oracle Linux (ol) support

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -221,6 +221,7 @@ var RepoConfigPathMap = map[string]string{
 	"rhcos":    "/etc/yum.repos.d",
 	"rhel":     "/etc/yum.repos.d",
 	"rocky":    "/etc/yum.repos.d",
+	"ol":    "/etc/yum.repos.d",
 	"sles":     "/etc/zypp/repos.d",
 	"sl-micro": "/etc/zypp/repos.d",
 }
@@ -236,6 +237,7 @@ var CertConfigPathMap = map[string]string{
 	"rhcos":    "/etc/pki/ca-trust/extracted/pem",
 	"rhel":     "/etc/pki/ca-trust/extracted/pem",
 	"rocky":    "/etc/pki/ca-trust/extracted/pem",
+	"ol":    "/etc/pki/ca-trust/extracted/pem",
 	"sles":     "/etc/pki/trust/anchors",
 	"sl-micro": "/etc/pki/trust/anchors",
 }

--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -664,9 +664,9 @@ func (n *ClusterPolicyController) getGPUNodeOSInfo() (string, string, error) {
 	}
 	osMajorVersion := strings.Split(osVersion, ".")[0]
 
-	// If the OS is RockyLinux or RHEL 10 & above, we will omit the minor version when constructing the os image tag
+	// If the OS is RockyLinux, Oracle Linux, or RHEL 10 & above, we will omit the minor version when constructing the os image tag
 	switch osName {
-	case "rocky":
+	case "rocky", "ol":
 		osVersion = osMajorVersion
 	case "rhel":
 		osMajorNumber, err := parseOSMajorVersion(osVersion)

--- a/controllers/state_manager_test.go
+++ b/controllers/state_manager_test.go
@@ -59,6 +59,12 @@ func TestGetGPUNodeOSInfo(t *testing.T) {
 			expected:  "rocky9",
 		},
 		{
+			name:      "ol omits minor version",
+			osName:    "ol",
+			osVersion: "9.5",
+			expected:  "ol9",
+		},
+		{
 			name:      "ubuntu preserves full version",
 			osName:    "ubuntu",
 			osVersion: "24.04",

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -686,6 +686,14 @@ func TestGetDriverAppName(t *testing.T) {
 	actual = getDriverAppName(cr, pool)
 	assert.Equal(t, "nvidia-gpu-driver-rocky9-59b779bcc5", actual)
 
+	// Oracle Linux
+	pool.osRelease = "ol"
+	pool.osVersion = "9.7"
+	pool.osTag, err = getOSTag(pool.osRelease, pool.osVersion)
+	assert.NoError(t, err)
+	actual = getDriverAppName(cr, pool)
+	assert.Equal(t, "nvidia-gpu-driver-ol9-59b779bcc5", actual)
+
 	// RHEL10
 	pool.osRelease = "rhel"
 	pool.osVersion = "10.1"

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -38,6 +38,7 @@ var RepoConfigPathMap = map[string]string{
 	"rhcos":    "/etc/yum.repos.d",
 	"rhel":     "/etc/yum.repos.d",
 	"rocky":    "/etc/yum.repos.d",
+	"ol":       "/etc/yum.repos.d",
 	"sles":     "/etc/zypp/repos.d",
 	"sl-micro": "/etc/zypp/repos.d",
 }
@@ -53,6 +54,7 @@ var CertConfigPathMap = map[string]string{
 	"rhcos":    "/etc/pki/ca-trust/extracted/pem",
 	"rhel":     "/etc/pki/ca-trust/extracted/pem",
 	"rocky":    "/etc/pki/ca-trust/extracted/pem",
+	"ol":       "/etc/pki/ca-trust/extracted/pem",
 	"sles":     "/etc/pki/trust/anchors",
 	"sl-micro": "/etc/pki/trust/anchors",
 }

--- a/internal/state/nodepool.go
+++ b/internal/state/nodepool.go
@@ -144,9 +144,9 @@ func getOSTag(osRelease, osVersion string) (string, error) {
 	osMajorVersion := strings.Split(osVersion, ".")[0]
 
 	var osTagSuffix string
-	// If the OS is RockyLinux or RHEL 10 & above, we will omit the minor version when constructing the os image tag
+	// If the OS is RockyLinux, Oracle Linux, or RHEL 10 & above, we will omit the minor version when constructing the os image tag
 	switch osRelease {
-	case "rocky":
+	case "rocky", "ol":
 		osTagSuffix = osMajorVersion
 	case "rhel":
 		osMajorNumber, err := parseOSMajorVersion(osVersion)

--- a/internal/state/nodepool_test.go
+++ b/internal/state/nodepool_test.go
@@ -53,6 +53,13 @@ func TestGetOSTag(t *testing.T) {
 			expectError: false,
 		},
 		{
+			description: "oracle linux",
+			osRelease:   "ol",
+			osVersion:   "9.4",
+			expected:    "ol9",
+			expectError: false,
+		},
+		{
 			description: "RHEL 10",
 			osRelease:   "rhel",
 			osVersion:   "10.1",


### PR DESCRIPTION
## Description

Adds support for Oracle Linux nodes (os-release `ID=ol`), mirroring the existing Rocky Linux support

## Why

Nodes running Oracle Linux are detected via the NFD label `feature.node.kubernetes.io/system-os_release.ID=ol`. So this PR brings support Oracle Linux OS. 

## Testing

* **Tests**: new cases in `TestGetGPUNodeOSInfo` and `TestGetOSTag` covering Oracle Linux 9 and 10.