### PR TITLE
allow package write permission to push helm oci artifacts

### DIFF
--- a/.github/workflows/forward-compatibility.yaml
+++ b/.github/workflows/forward-compatibility.yaml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       operator_image: ghcr.io/nvidia/gpu-operator


### PR DESCRIPTION
## Description

Currently, it fails with:

> The workflow is not valid. .github/workflows/forward-compatibility.yaml (Line: 70, Col: 3): Error calling workflow 'NVIDIA/gpu-operator/.github/workflows/e2e-tests.yaml@fed0b2a686a2b305d9cb485cd3f7bb343aae5296'. The nested job 'publish-helm-oci-chart' is requesting 'packages: write', but is only allowed 'packages: none'.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

