### PR TITLE
bump openshift version compability list

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,4 +14,4 @@ annotations:
   operatorframework.io/suggested-namespace: nvidia-gpu-operator
 
   # Annotations to specify OCP versions compatibility.
-  com.redhat.openshift.versions: v4.14-v4.21
+  com.redhat.openshift.versions: v4.16-v4.22


### PR DESCRIPTION
We bump the minimum supported OpenShift version to 4.16 (odd numbered minor versions don't typically receive extended/long term support). OCP 4.14 maps to Kubernetes 1.27 which is very old at this point. This change aligns with our current K8s version supported more closely.

We also bump the maximum supported openshift version to 4.22

