### PR TITLE
[release-26.3][OLM] add OCP 4.22 as a supported version

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,4 +14,4 @@ annotations:
   operatorframework.io/suggested-namespace: nvidia-gpu-operator
 
   # Annotations to specify OCP versions compatibility.
-  com.redhat.openshift.versions: v4.14-v4.21
+  com.redhat.openshift.versions: v4.14-v4.22


### PR DESCRIPTION
NOTE: This change is only being made in the `release-26.3` branch. The `main` branch will have a narrower OCP support window