### PR TITLE
detect version without OS information, update bundle sha as well

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,11 +34,24 @@
         "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
       ],
       "matchStrings": [
-        "[-\\s]*value:\\s*\"?(?<depName>[^:\"]+)(?::(?<currentValue>[^@\"]+))?@(?<currentDigest>sha256:[a-f0-9]{64})\"?",
-        "[-\\s]*image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]{64})",
-        "- name: (?<suffix>[\\w-]+)[-\\s]*image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "[-\\s]*value:\\s*\"?(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]{64})\"?",
+        "[-\\s]*image: (?<depName>.*?):(?<currentValue>.*?)@(?<currentDigest>sha256:[a-f0-9]{64})",
+        "- name: (?<suffix>[\\w-]+)[-\\s]*image: (?<depName>.*?):(?<currentValue>.*?)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "versioningTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
+      ],
+      "matchStrings": [
+        "(?<prefix>\\s*image:\\s*)(?<depName>nvcr\\.io/nvidia/cloud-native/gdrdrv)(?::(?<currentValue>v?\\d+\\.\\d+(?:\\.\\d+)?-rhel9(?:\\.\\d+)?))?@(?<currentDigest>sha256:[a-f0-9]{64})",
+        "(?<prefix>\\s*value:\\s*\")(?<depName>nvcr\\.io/nvidia/cloud-native/gdrdrv)(?::(?<currentValue>v?\\d+\\.\\d+(?:\\.\\d+)?-rhel9(?:\\.\\d+)?))?@(?<currentDigest>sha256:[a-f0-9]{64})(?<suffix>\")"
+      ],
+      "currentValueTemplate": "{{#if currentValue}}{{{currentValue}}}{{else}}v2.5.2-rhel9.6{{/if}}",
+      "autoReplaceStringTemplate": "{{{prefix}}}{{{depName}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}{{{suffix}}}",
       "datasourceTemplate": "docker"
     },
     {
@@ -60,7 +73,10 @@
   ],
   "packageRules": [
     {
-      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchPaths": [
+        "deployments/gpu-operator/values.yaml",
+        "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
+      ],
       "matchPackageNames": [
         "nvcr.io/nvidia/cloud-native/k8s-driver-manager",
         "nvcr.io/nvidia/cloud-native/k8s-kata-manager",
@@ -92,6 +108,25 @@
        "nvcr.io/nvidia/cuda"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-base-ubi9$",
+      "separateMajorMinor": false
+    },
+    {
+      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": [
+        "nvcr.io/nvidia/cloud-native/nvidia-fs",
+        "nvcr.io/nvidia/cloud-native/gdrdrv"
+      ],
+      "extractVersion": "^(?<version>v?\\d+\\.\\d+(?:\\.\\d+)?)(?:-[A-Za-z0-9_.-]+)?$",
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
+      "separateMajorMinor": false
+    },
+    {
+      "matchPaths": ["bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"],
+      "matchPackageNames": [
+        "nvcr.io/nvidia/cloud-native/gdrdrv"
+      ],
+      "versionCompatibility": "^(?<version>v?\\d+\\.\\d+(?:\\.\\d+)?)(?<compatibility>-rhel9(?:\\.\\d+)?)$",
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
       "separateMajorMinor": false
     },
     {


### PR DESCRIPTION
## Description

Current auto-generated PR doesn't generate correct output, see: https://github.com/NVIDIA/gpu-operator/pull/2585

This PR fixes that for gdrcopy.

Code changes in this PR are drafted with assistance from codex.

To test this PR, one can use:

```
docker run --rm \
  -v /tmp/renovate-gpu-operator:/repo \
  -w /repo \
  -e RENOVATE_PLATFORM=local \
  -e RENOVATE_CONFIG_FILE=.github/renovate.json \
  -e RENOVATE_ONBOARDING=false \
  -e RENOVATE_DRY_RUN=full \
  -e LOG_LEVEL=debug \
  renovate/renovate:latest 2>&1 \
  | grep -E "gdrdrv|gdrcopy|046063|eef1b666|v2\.6|currentValue|newValue|newDigest|packageFiles with updates"
```

Sample detected output:
```
"currentValue": "v2.5.2-rhel9.6",
"packageName": "nvcr.io/nvidia/cloud-native/gdrdrv",

DEBUG: getDigest(https://nvcr.io, nvidia/cloud-native/gdrdrv, v2.6-rhel9.6) (repository=local)
DEBUG: Got docker digest sha256:eef1b6663d78555f0e5c49c156196b67e8a3008bc22aaa02b03dad53887ee0f1 (repository=local)

"depName": "nvcr.io/nvidia/cloud-native/gdrdrv",
"currentValue": "v2.5.2-rhel9.6",
"currentDigest": "sha256:0460630559b0b932c8861237b62e69c2895dace42d37ad3cb02c87e5d751fafc",
"replaceString": "\n      image: nvcr.io/nvidia/cloud-native/gdrdrv@sha256:0460630559b0b932c8861237b62e69c2895dace42d37ad3cb02c87e5d751fafc",
"newVersion": "v2.6",
"newValue": "v2.6-rhel9.6",
"newDigest": "sha256:eef1b6663d78555f0e5c49c156196b67e8a3008bc22aaa02b03dad53887ee0f1",

"depName": "nvcr.io/nvidia/cloud-native/gdrdrv",
"currentValue": "v2.5.2",
"replaceString": "\n  repository: nvcr.io/nvidia/cloud-native\n  image: gdrdrv\n  version: \"v2.5.2\"",
"newVersion": "v2.6",
"newValue": "v2.6",
```

With this change, both version and sha256sum are calculated and updated correctly.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

