### PR TITLE
feat(vgpu-manager): default Fabric Manager to vGPU multitenancy mode

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -173,6 +173,15 @@ const (
 	OpenKernelModulesEnabledEnvName = "OPEN_KERNEL_MODULES_ENABLED"
 	// KernelModuleTypeEnvName is the name of the driver-container envvar to set the desired kernel module type
 	KernelModuleTypeEnvName = "KERNEL_MODULE_TYPE"
+	// FabricModeEnvName is the name of the vGPU-manager-container envvar that
+	// selects the NVIDIA Fabric Manager mode (the FABRIC_MODE key in
+	// fabricmanager.cfg) on NVSwitch systems.
+	FabricModeEnvName = "FABRIC_MODE"
+	// FabricModeVGPUMultitenancy is the FABRIC_MODE value that starts Fabric
+	// Manager in vGPU multitenancy mode, required for SR-IOV vGPU on NVSwitch
+	// (HGX) systems. FABRIC_MODE=0 (bare-metal/passthrough) is the packaged
+	// default; FABRIC_MODE=1 is shared-NVSwitch multitenancy.
+	FabricModeVGPUMultitenancy = "2"
 	// MPSRootEnvName is the name of the envvar for configuring the MPS root
 	MPSRootEnvName = "MPS_ROOT"
 	// DefaultMPSRoot is the default MPS root path on the host
@@ -3894,6 +3903,18 @@ func transformVGPUManagerContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterP
 		for _, env := range config.VGPUManager.Env {
 			setContainerEnv(&(obj.Spec.Template.Spec.Containers[0]), env.Name, env.Value)
 		}
+	}
+
+	// On NVSwitch (HGX) systems, SR-IOV vGPU requires NVIDIA Fabric Manager to
+	// run in vGPU multitenancy mode (FABRIC_MODE=2) rather than the packaged
+	// bare-metal default (FABRIC_MODE=0); otherwise a whole-card vGPU guest
+	// cannot initialize CUDA. Default the vGPU Manager container to
+	// FABRIC_MODE=2 so its entrypoint can configure fabricmanager.cfg
+	// accordingly on NVSwitch hosts. Non-NVSwitch vGPU hosts do not start Fabric
+	// Manager, so the value is ignored there. A user-provided FABRIC_MODE in
+	// VGPUManager.Env is applied above and takes precedence.
+	if getContainerEnv(container, FabricModeEnvName) == "" {
+		setContainerEnv(container, FabricModeEnvName, FabricModeVGPUMultitenancy)
 	}
 
 	// mount any custom kernel module configuration parameters at /drivers

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -182,6 +182,17 @@ const (
 	OpenKernelModulesEnabledEnvName = "OPEN_KERNEL_MODULES_ENABLED"
 	// KernelModuleTypeEnvName is the name of the driver-container envvar to set the desired kernel module type
 	KernelModuleTypeEnvName = "KERNEL_MODULE_TYPE"
+	// FabricModeEnvName is the name of the vGPU-manager-container envvar that
+	// selects the NVIDIA Fabric Manager mode (the FABRIC_MODE key in
+	// fabricmanager.cfg) on NVSwitch systems.
+	FabricModeEnvName = "FABRIC_MODE"
+	// FabricModeVGPUMultitenancy is the FABRIC_MODE value that starts Fabric
+	// Manager in vGPU multitenancy mode, required for SR-IOV vGPU on NVSwitch
+	// (HGX) systems. The Fabric Manager User Guide documents FABRIC_MODE=0
+	// (bare metal or full passthrough virtualization) as the default,
+	// FABRIC_MODE=1 as Shared NVSwitch multi-tenancy, and FABRIC_MODE=2 as
+	// vGPU multitenancy.
+	FabricModeVGPUMultitenancy = "2"
 	// MPSRootEnvName is the name of the envvar for configuring the MPS root
 	MPSRootEnvName = "MPS_ROOT"
 	// DefaultMPSRoot is the default MPS root path on the host
@@ -3863,6 +3874,18 @@ func transformVGPUManagerContainer(obj *appsv1.DaemonSet, config *gpuv1.ClusterP
 		for _, env := range config.VGPUManager.Env {
 			setContainerEnv(&(obj.Spec.Template.Spec.Containers[0]), env.Name, env.Value)
 		}
+	}
+
+	// On NVSwitch (HGX) systems, SR-IOV vGPU requires NVIDIA Fabric Manager to
+	// run in vGPU multitenancy mode (FABRIC_MODE=2) rather than the bare-metal
+	// default (FABRIC_MODE=0); otherwise a whole-card vGPU guest cannot
+	// initialize CUDA. Default the vGPU Manager container to FABRIC_MODE=2 so
+	// its entrypoint can configure fabricmanager.cfg accordingly on NVSwitch
+	// hosts. Non-NVSwitch vGPU hosts do not start Fabric Manager, so the value
+	// is ignored there. A user-provided FABRIC_MODE in VGPUManager.Env is
+	// applied above and takes precedence.
+	if getContainerEnv(container, FabricModeEnvName) == "" {
+		setContainerEnv(container, FabricModeEnvName, FabricModeVGPUMultitenancy)
 	}
 
 	// mount any custom kernel module configuration parameters at /drivers

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -4233,6 +4233,81 @@ func TestTransformVGPUManager(t *testing.T) {
 	}
 }
 
+// TestTransformVGPUManagerFabricMode verifies that the vGPU Manager container is
+// defaulted to NVIDIA Fabric Manager vGPU multitenancy mode (FABRIC_MODE=2),
+// which SR-IOV vGPU on NVSwitch (HGX) systems requires, and that a
+// user-provided FABRIC_MODE in VGPUManager.Env is preserved.
+func TestTransformVGPUManagerFabricMode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "24.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
+			},
+		},
+	}
+	mockClient := fake.NewFakeClient(node)
+
+	baseSpec := func() *gpuv1.ClusterPolicySpec {
+		return &gpuv1.ClusterPolicySpec{
+			VGPUManager: gpuv1.VGPUManagerSpec{
+				Repository:      "nvcr.io/nvidia",
+				Image:           "vgpu-manager",
+				Version:         "550.90.07",
+				ImagePullPolicy: "IfNotPresent",
+				DriverManager: gpuv1.DriverManagerSpec{
+					Repository:      "nvcr.io/nvidia/cloud-native",
+					Image:           "k8s-driver-manager",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "v0.8.0",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		description        string
+		env                []gpuv1.EnvVar
+		expectedFabricMode string
+	}{
+		{
+			description:        "defaults to vGPU multitenancy mode",
+			env:                nil,
+			expectedFabricMode: "2",
+		},
+		{
+			description:        "user-provided FABRIC_MODE is preserved",
+			env:                []gpuv1.EnvVar{{Name: "FABRIC_MODE", Value: "0"}},
+			expectedFabricMode: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ds := NewDaemonset().
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"}).
+				WithContainer(corev1.Container{Name: "nvidia-vgpu-manager-ctr"})
+			cpSpec := baseSpec()
+			cpSpec.VGPUManager.Env = tc.env
+
+			clusterPolicyCtrl := ClusterPolicyController{
+				logger:            ctrl.Log.WithName("test"),
+				client:            mockClient,
+				operatorNamespace: "test-ns",
+			}
+			err := TransformVGPUManager(ds.DaemonSet, cpSpec, clusterPolicyCtrl)
+			require.NoError(t, err)
+
+			container := findContainerByName(ds.Spec.Template.Spec.Containers, "nvidia-vgpu-manager-ctr")
+			require.NotNil(t, container)
+			require.Equal(t, tc.expectedFabricMode, getContainerEnv(container, "FABRIC_MODE"))
+		})
+	}
+}
+
 func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -4464,6 +4464,81 @@ func TestTransformVGPUManager(t *testing.T) {
 	}
 }
 
+// TestTransformVGPUManagerFabricMode verifies that the vGPU Manager container is
+// defaulted to NVIDIA Fabric Manager vGPU multitenancy mode (FABRIC_MODE=2),
+// which SR-IOV vGPU on NVSwitch (HGX) systems requires, and that a
+// user-provided FABRIC_MODE in VGPUManager.Env is preserved.
+func TestTransformVGPUManagerFabricMode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				nfdOSReleaseIDLabelKey: "ubuntu",
+				nfdOSVersionIDLabelKey: "24.04",
+				nfdKernelLabelKey:      "6.8.0-60-generic",
+				commonGPULabelKey:      "true",
+			},
+		},
+	}
+	mockClient := fake.NewFakeClient(node)
+
+	baseSpec := func() *gpuv1.ClusterPolicySpec {
+		return &gpuv1.ClusterPolicySpec{
+			VGPUManager: gpuv1.VGPUManagerSpec{
+				Repository:      "nvcr.io/nvidia",
+				Image:           "vgpu-manager",
+				Version:         "550.90.07",
+				ImagePullPolicy: "IfNotPresent",
+				DriverManager: gpuv1.DriverManagerSpec{
+					Repository:      "nvcr.io/nvidia/cloud-native",
+					Image:           "k8s-driver-manager",
+					ImagePullPolicy: "IfNotPresent",
+					Version:         "v0.8.0",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		description        string
+		env                []gpuv1.EnvVar
+		expectedFabricMode string
+	}{
+		{
+			description:        "defaults to vGPU multitenancy mode",
+			env:                nil,
+			expectedFabricMode: "2",
+		},
+		{
+			description:        "user-provided FABRIC_MODE is preserved",
+			env:                []gpuv1.EnvVar{{Name: "FABRIC_MODE", Value: "0"}},
+			expectedFabricMode: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ds := NewDaemonset().
+				WithInitContainer(corev1.Container{Name: "k8s-driver-manager"}).
+				WithContainer(corev1.Container{Name: "nvidia-vgpu-manager-ctr"})
+			cpSpec := baseSpec()
+			cpSpec.VGPUManager.Env = tc.env
+
+			clusterPolicyCtrl := ClusterPolicyController{
+				logger:            ctrl.Log.WithName("test"),
+				client:            mockClient,
+				operatorNamespace: "test-ns",
+			}
+			err := TransformVGPUManager(ds.DaemonSet, cpSpec, clusterPolicyCtrl)
+			require.NoError(t, err)
+
+			container := findContainerByName(ds.Spec.Template.Spec.Containers, "nvidia-vgpu-manager-ctr")
+			require.NotNil(t, container)
+			require.Equal(t, tc.expectedFabricMode, getContainerEnv(container, "FABRIC_MODE"))
+		})
+	}
+}
+
 func TestTransformDriverWithAdditionalConfig(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

**RFC / Draft — seeking maintainer design direction before completing. Please do not merge.**

On NVSwitch (HGX) systems running SR-IOV vGPU, NVIDIA Fabric Manager must run in vGPU multitenancy mode (`FABRIC_MODE=2`) instead of the default bare-metal / passthrough mode (`FABRIC_MODE=0`). In mode 0 a whole-card vGPU guest cannot initialize CUDA — `cuInit` fails with error 802 because the guest's NVLink fabric never becomes usable. `FABRIC_MODE=1` is the older shared-NVSwitch multitenancy model; `FABRIC_MODE=2` is the mode required for SR-IOV vGPU (see the NVIDIA Fabric Manager User Guide, config-file section).

Today the operator provides no way to select the Fabric Manager mode. On the operator-managed-driver path the driver container starts Fabric Manager from the packaged `fabricmanager.cfg` unchanged (`FABRIC_MODE=0`) and reads no environment variable to override it, so SR-IOV vGPU on NVSwitch cannot be brought up through the operator.

This change defaults the vGPU Manager container (the `vm-vgpu` sandbox-workload path) to `FABRIC_MODE=2`. A user-supplied `FABRIC_MODE` in `vgpuManager.env` takes precedence. The value is scoped to the vGPU Manager container, so container / passthrough / bare-metal workloads are unchanged, and on non-NVSwitch vGPU hosts the driver entrypoint does not start Fabric Manager so the value is ignored.

### Why this is an RFC (honest scope)

This is the operator half of a two-part change and is intentionally inert on its own:

- The operator can only inject an env var; the container entrypoint must consume it. The vGPU Manager container image does not currently install or start Fabric Manager (it is installed only in the non-vGPU driver image), and no entrypoint reads `FABRIC_MODE`. A companion `gpu-driver-container` change is needed to (a) ship Fabric Manager in the vGPU Manager image and (b) write `FABRIC_MODE` into `fabricmanager.cfg` before starting Fabric Manager on NVSwitch hosts.
- Open design question: in a vGPU-on-NVSwitch deployment, which component should own Fabric Manager? On NVSwitch systems it is started today by the driver container, but in a vGPU deployment the vGPU Manager container is what runs on the node (and ships no Fabric Manager). I chose the vGPU Manager container as the injection target because it is the container that actually runs on vGPU nodes, but I would like direction before implementing the driver-container side.
- Out of scope: the host-installed-driver path (`driver.enabled=false`), where the operator manages neither the driver nor Fabric Manager; and per-VM fabric-partition activation, which is a separate device-plugin concern.

Related: #2594 describes the adjacent SR-IOV / vendor-specific VFIO vGPU device-creation gap on the same class of hardware.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`) — the changed package is clean (`golangci-lint run ./controllers/` reports 0 issues). Repo-wide `make lint` could not complete locally on macOS because an unrelated command (`cmd/nvidia-validator`) imports a Linux-only vendored package that is build-excluded on darwin; expected to pass on Linux CI.
- [ ] Generated assets in-sync (`make validate-generated-assets`) — this change adds no API/CRD changes, so no generated assets change. The target could not run to completion on macOS for the same Linux-only-dependency reason.
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

- `go build ./controllers/` and `go test ./controllers/` pass, including a new `TestTransformVGPUManagerFabricMode` that covers the `FABRIC_MODE=2` default and the user-override precedence.
- `golangci-lint run ./controllers/` reports 0 issues.
- End-to-end behavior on NVSwitch hardware is not exercised here — it depends on the companion `gpu-driver-container` change and cannot run in CI.



**Companion (image half):** NVIDIA/gpu-driver-container#854 — ships and starts Fabric Manager in the vGPU Manager image so the `FABRIC_MODE` this PR injects is actually consumed. The two are an RFC pair; please review the design together.
