### PR TITLE
[OLM] bump minimum supported openshift version to 4.18

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,4 +14,4 @@ annotations:
   operatorframework.io/suggested-namespace: nvidia-gpu-operator
 
   # Annotations to specify OCP versions compatibility.
-  com.redhat.openshift.versions: v4.16-v4.22
+  com.redhat.openshift.versions: v4.18-v4.22


### PR DESCRIPTION
As per the official OpenShift support lifecycle [page](https://access.redhat.com/support/policy/updates/openshift), only OpenShift 4.18 is supported (as of this PR creation's date).

NOTE: We are only required to support an OpenShift version upto its Maintenance Support phase.