### PR TITLE
add new deploy label to manage third-party gpu client pods

### DIFF
--- a/assets/state-mig-manager/0210_clusterrole.yaml
+++ b/assets/state-mig-manager/0210_clusterrole.yaml
@@ -13,3 +13,9 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list

--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -94,6 +94,7 @@ var gpuStateLabels = map[string]map[string]string{
 		"nvidia.com/gpu.deploy.dcgm-exporter":         "true",
 		"nvidia.com/gpu.deploy.node-status-exporter":  "true",
 		"nvidia.com/gpu.deploy.operator-validator":    "true",
+		"nvidia.com/gpu.deploy.client":                "true",
 	},
 	gpuWorkloadConfigVMPassthrough: {
 		"nvidia.com/gpu.deploy.sandbox-device-plugin": "true",
@@ -101,6 +102,7 @@ var gpuStateLabels = map[string]map[string]string{
 		"nvidia.com/gpu.deploy.vfio-manager":          "true",
 		"nvidia.com/gpu.deploy.kata-manager":          "true",
 		"nvidia.com/gpu.deploy.cc-manager":            "true",
+		"nvidia.com/gpu.deploy.client":                "true",
 	},
 	gpuWorkloadConfigVMVgpu: {
 		"nvidia.com/gpu.deploy.sandbox-device-plugin": "true",
@@ -108,6 +110,7 @@ var gpuStateLabels = map[string]map[string]string{
 		"nvidia.com/gpu.deploy.vgpu-device-manager":   "true",
 		"nvidia.com/gpu.deploy.sandbox-validator":     "true",
 		"nvidia.com/gpu.deploy.cc-manager":            "true",
+		"nvidia.com/gpu.deploy.client":                "true",
 	},
 }
 


### PR DESCRIPTION
This PR introduces a new node label `"nvidia.com/gpu.deploy.client": "true"` to designate pods that are gpu clients (like our operands `dcgm`, `mig-manager`, `device-plugin`, `gpu-feature-discovery`) which are not first-class components of the gpu-operator.

### Motivation

Advanced users bring in their own gpu client pods that require management/admin access to the GPUs so they too need to bypass the device plugin for gpu allocation much like the gpu-operator's operands. Today, users who bring their own gpu client pods will face issues during driver upgrades as the gpu-operator is unaware of the existence of these pods which actively hold gpu device handles thus interrupting a driver upgrade. Users today will have to manually evict these pods during these gpu client pods so that the upgrade can proceed. This scales poorly and also entails heavy operational overhead as it involves human intervention.

### Solution

Users who bring their own gpu client pods can now take advantage of this feature by adding the  `"nvidia.com/gpu.deploy.client": "true"` label to the **nodeSelector** of their gpu client's resource manifest (whether Daemonset/Deployment/StatefulSet/Job). With this new label added to the nodeSelector, the gpu-operator will then be able to bounce gpu-client pods automatically during a driver upgrade without any human intervention.

Related PRs:

- https://github.com/NVIDIA/k8s-driver-manager/pull/205
- https://github.com/NVIDIA/mig-parted/pull/426 
