### PR TITLE
[e2e-tests] set default value for GPU_MODE

### DIFF
--- a/tests/scripts/.definitions.sh
+++ b/tests/scripts/.definitions.sh
@@ -24,3 +24,5 @@ TERRAFORM="terraform -chdir=${TERRAFORM_DIR}"
 : ${CONTAINER_RUNTIME:="docker"}
 
 : ${PRIVATE_REGISTRY:="nvcr.io"}
+
+: ${GPU_MODE:="gpu"}


### PR DESCRIPTION
This change is required to handle the unbound variable error thrown when we run "./tests/scripts/install-operator.sh" locally.

```
./tests/scripts/install-operator.sh: line 84: GPU_MODE: unbound variable
```