### PR TITLE
Expand nvidia-smi symlink resolution to additional host paths

### DIFF
--- a/cmd/nvidia-validator/main.go
+++ b/cmd/nvidia-validator/main.go
@@ -245,6 +245,15 @@ const (
 	NVIDIAPEERMEM = "nvidia-peermem"
 )
 
+var hostNvidiaSMISearchPaths = []string{
+	"/usr/bin/nvidia-smi",
+	"/usr/sbin/nvidia-smi",
+	"/bin/nvidia-smi",
+	"/sbin/nvidia-smi",
+	wslNvidiaSMIPath,
+	"/opt/bin/nvidia-smi",
+}
+
 func main() {
 	c := cli.Command{}
 
@@ -743,20 +752,34 @@ func isDriverManagedByOperator(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-// resolveHostNvidiaSMI opens and stats nvidia-smi within the mounted host root.
-func resolveHostNvidiaSMI(hostRootCtrPath string) (os.FileInfo, error) {
-	f, err := pathrs.OpenInRoot(hostRootCtrPath, "/usr/bin/nvidia-smi")
-	if err != nil {
-		return nil, fmt.Errorf("failed to open 'nvidia-smi' on the host: %w", err)
-	}
-	defer f.Close()
+// resolveHostNvidiaSMI searches common nvidia-smi locations within the mounted
+// host root and returns the resolved path relative to the host root. A candidate
+// is only accepted if it resolves to a regular, non-empty, executable file, so
+// the privileged validator never execs a bogus binary from a non-standard path.
+func resolveHostNvidiaSMI(hostRootCtrPath string) (string, error) {
+	for _, nvidiaSMIPath := range hostNvidiaSMISearchPaths {
+		f, err := pathrs.OpenInRoot(hostRootCtrPath, nvidiaSMIPath)
+		if err != nil {
+			log.Debugf("failed to open '%s' on the host: %v", nvidiaSMIPath, err)
+			continue
+		}
 
-	fileInfo, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat 'nvidia-smi' on the host: %w", err)
+		fileInfo, err := f.Stat()
+		_ = f.Close()
+		if err != nil {
+			log.Debugf("failed to stat '%s' on the host: %v", nvidiaSMIPath, err)
+			continue
+		}
+
+		if !fileInfo.Mode().IsRegular() || fileInfo.Size() == 0 || fileInfo.Mode().Perm()&0o111 == 0 {
+			log.Debugf("skipping '%s' on the host: not a non-empty executable regular file", nvidiaSMIPath)
+			continue
+		}
+
+		return nvidiaSMIPath, nil
 	}
 
-	return fileInfo, nil
+	return "", fmt.Errorf("failed to find an executable 'nvidia-smi' on the host")
 }
 
 func validateHostDriver(silent bool) error {
@@ -767,15 +790,12 @@ func validateHostDriver(silent bool) error {
 		return nil
 	}
 
-	fileInfo, err := resolveHostNvidiaSMI("/host")
+	nvidiaSMIPath, err := resolveHostNvidiaSMI("/host")
 	if err != nil {
 		return err
 	}
-	if fileInfo.Size() == 0 {
-		return fmt.Errorf("empty 'nvidia-smi' file found on the host")
-	}
 	command := "chroot"
-	args := []string{"/host", "nvidia-smi"}
+	args := []string{"/host", nvidiaSMIPath}
 
 	return runCommand(command, args, silent)
 }
@@ -1771,8 +1791,8 @@ func (v *VGPUManager) runValidation(silent bool) (hostDriver bool, err error) {
 	args := []string{"/run/nvidia/driver", "nvidia-smi"}
 
 	// check if driver is pre-installed on the host and use host path for validation
-	if _, err := resolveHostNvidiaSMI("/host"); err == nil {
-		args = []string{"/host", "nvidia-smi"}
+	if nvidiaSMIPath, err := resolveHostNvidiaSMI("/host"); err == nil {
+		args = []string{"/host", nvidiaSMIPath}
 		hostDriver = true
 	}
 

--- a/cmd/nvidia-validator/main_test.go
+++ b/cmd/nvidia-validator/main_test.go
@@ -32,6 +32,8 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 	testCases := []struct {
 		description  string
 		contents     map[string]string
+		perms        map[string]os.FileMode
+		expectedPath string
 		expectsError bool
 	}{
 		{
@@ -39,6 +41,7 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 			contents: map[string]string{
 				"/usr/bin/nvidia-smi": "fake nvidia-smi",
 			},
+			expectedPath: "/usr/bin/nvidia-smi",
 		},
 		{
 			description: "nvidia-smi exists through absolute /usr/bin symlink",
@@ -46,6 +49,7 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 				"/run/current-system/sw/bin/nvidia-smi": "fake nvidia-smi",
 				"/usr/bin":                              "symlink=/run/current-system/sw/bin",
 			},
+			expectedPath: "/usr/bin/nvidia-smi",
 		},
 		{
 			description: "nvidia-smi exists through relative /usr/bin symlink",
@@ -53,6 +57,84 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 				"/run/current-system/sw/bin/nvidia-smi": "fake nvidia-smi",
 				"/usr/bin":                              "symlink=../run/current-system/sw/bin",
 			},
+			expectedPath: "/usr/bin/nvidia-smi",
+		},
+		{
+			description: "nvidia-smi exists in /opt/bin",
+			contents: map[string]string{
+				"/opt/bin/nvidia-smi": "fake nvidia-smi",
+			},
+			expectedPath: "/opt/bin/nvidia-smi",
+		},
+		{
+			description: "nvidia-smi exists in /bin",
+			contents: map[string]string{
+				"/bin/nvidia-smi": "fake nvidia-smi",
+			},
+			expectedPath: "/bin/nvidia-smi",
+		},
+		{
+			description: "nvidia-smi exists in /usr/sbin",
+			contents: map[string]string{
+				"/usr/sbin/nvidia-smi": "fake nvidia-smi",
+			},
+			expectedPath: "/usr/sbin/nvidia-smi",
+		},
+		{
+			description: "nvidia-smi exists through absolute /usr/sbin symlink",
+			contents: map[string]string{
+				"/run/current-system/sw/bin/nvidia-smi": "fake nvidia-smi",
+				"/usr/sbin":                             "symlink=/run/current-system/sw/bin",
+			},
+			expectedPath: "/usr/sbin/nvidia-smi",
+		},
+		{
+			description: "nvidia-smi exists in WSL path",
+			contents: map[string]string{
+				"/usr/lib/wsl/lib/nvidia-smi": "fake nvidia-smi",
+			},
+			expectedPath: "/usr/lib/wsl/lib/nvidia-smi",
+		},
+		{
+			description: "nvidia-smi exists through absolute WSL path symlink",
+			contents: map[string]string{
+				"/run/wsl/lib/nvidia-smi": "fake nvidia-smi",
+				"/usr/lib/wsl/lib":        "symlink=/run/wsl/lib",
+			},
+			expectedPath: "/usr/lib/wsl/lib/nvidia-smi",
+		},
+		{
+			description: "earlier search path is preferred when multiple exist",
+			contents: map[string]string{
+				"/usr/bin/nvidia-smi":  "fake nvidia-smi in usr/bin",
+				"/usr/sbin/nvidia-smi": "fake nvidia-smi in usr/sbin",
+			},
+			expectedPath: "/usr/bin/nvidia-smi",
+		},
+		{
+			description: "/opt/bin is searched last",
+			contents: map[string]string{
+				"/opt/bin/nvidia-smi":  "fake nvidia-smi in opt/bin",
+				"/usr/sbin/nvidia-smi": "fake nvidia-smi in usr/sbin",
+			},
+			expectedPath: "/usr/sbin/nvidia-smi",
+		},
+		{
+			description: "non-executable nvidia-smi is skipped",
+			contents: map[string]string{
+				"/usr/bin/nvidia-smi": "fake nvidia-smi",
+			},
+			perms: map[string]os.FileMode{
+				"/usr/bin/nvidia-smi": 0600,
+			},
+			expectsError: true,
+		},
+		{
+			description: "empty nvidia-smi is skipped",
+			contents: map[string]string{
+				"/usr/bin/nvidia-smi": "",
+			},
+			expectsError: true,
 		},
 		{
 			description: "parent dir is symlink to path not within root",
@@ -81,17 +163,21 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 					continue
 				}
 
-				require.NoError(t, os.WriteFile(target, []byte(contents), 0600))
+				mode := os.FileMode(0755)
+				if m, ok := tc.perms[name]; ok {
+					mode = m
+				}
+				require.NoError(t, os.WriteFile(target, []byte(contents), mode))
 			}
 
-			fileInfo, err := resolveHostNvidiaSMI(hostRoot)
+			nvidiaSMIPath, err := resolveHostNvidiaSMI(hostRoot)
 			if tc.expectsError {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.NotZero(t, fileInfo.Size())
+			require.Equal(t, tc.expectedPath, nvidiaSMIPath)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes #2506.

PR #2464 updated host `nvidia-smi` validation to resolve symlinks under `/usr/bin/nvidia-smi` using `pathrs.OpenInRoot`. Review feedback noted that other common locations are also used in the wild and should be searched in a follow-up:

- `/usr/sbin/nvidia-smi` — Talos and similar distros
- `/usr/lib/wsl/lib/nvidia-smi` — WSL

This change expands `resolveHostNvidiaSMI` to search multiple host paths (aligned with `getNvidiaSMIPath()` in `find.go` and the [DRA driver prestart script](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/510086482c09c9cdde2886c292fc0006fc9df926/hack/kubelet-plugin-prestart.sh#L44-L52)):

```bash
/opt/bin/nvidia-smi
/usr/bin/nvidia-smi
/usr/sbin/nvidia-smi
/bin/nvidia-smi
/sbin/nvidia-smi
/usr/lib/wsl/lib/nvidia-smi
```
Each path is resolved via pathrs.OpenInRoot, so symlink handling remains scoped to the mounted host root. The function now returns the resolved path, and validateHostDriver / runValidation use that path in chroot instead of relying on PATH lookup.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Unit tests added/extended in `cmd/nvidia-validator/main_test.go` (`TestResolveHostNvidiaSMI`), covering:

- `nvidia-smi` present at each search path (`/opt/bin, /bin, /usr/bin, /usr/sbin`, WSL)
- Symlink resolution for /usr/bin, /usr/sbin, and WSL paths
- Search order preference when multiple paths exist
- Error when `nvidia-smi` is missing or resolves outside the host root

`go test ./cmd/nvidia-validator -run TestResolveHostNvidiaSMI -v`

Note: `pathrs-lite` is Linux-only (`//go:build linux`), so tests must be run on Linux or via Docker:
  
```bash
❯ docker run --rm \
  -v "$(pwd)":/src -w /src \
  golang:1.26.3 \
  go test ./cmd/nvidia-validator -run TestResolveHostNvidiaSMI -v
=== RUN   TestResolveHostNvidiaSMI
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/usr/bin
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_through_absolute_/usr/bin_symlink
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_through_relative_/usr/bin_symlink
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/opt/bin
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/bin
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/usr/sbin
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_through_absolute_/usr/sbin_symlink
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_in_WSL_path
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_exists_through_absolute_WSL_path_symlink
=== RUN   TestResolveHostNvidiaSMI/earlier_search_path_is_preferred_when_multiple_exist
=== RUN   TestResolveHostNvidiaSMI/parent_dir_is_symlink_to_path_not_within_root
=== RUN   TestResolveHostNvidiaSMI/nvidia-smi_does_not_exist
--- PASS: TestResolveHostNvidiaSMI (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/usr/bin (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_through_absolute_/usr/bin_symlink (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_through_relative_/usr/bin_symlink (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/opt/bin (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/bin (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_in_/usr/sbin (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_through_absolute_/usr/sbin_symlink (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_in_WSL_path (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_exists_through_absolute_WSL_path_symlink (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/earlier_search_path_is_preferred_when_multiple_exist (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/parent_dir_is_symlink_to_path_not_within_root (0.00s)
    --- PASS: TestResolveHostNvidiaSMI/nvidia-smi_does_not_exist (0.00s)
PASS
ok      github.com/NVIDIA/gpu-operator/cmd/nvidia-validator     0.012s
```


