### PR TITLE
Fix NVIDIADriver owner assignment after GPU label updates

### DIFF
--- a/controllers/nodelabeling_controller.go
+++ b/controllers/nodelabeling_controller.go
@@ -61,6 +61,56 @@ type nodeLabelingController struct {
 	logger        logr.Logger
 }
 
+// gpuNodeLabelsUpdateResult reports total node patches and the subset where GPU
+// discovery state changed. The discovery state is stored in nvidia.com/gpu.present,
+// which AssignOwners uses to find GPU nodes, so dependent operations are deferred
+// until the informer cache observes those node updates.
+type gpuNodeLabelsUpdateResult struct {
+	totalPatchedNodeCount             int
+	gpuDiscoveryStateChangedNodeCount int
+}
+
+// nodeLabelUpdateReasons captures why a node update event should trigger node-label reconciliation.
+type nodeLabelUpdateReasons struct {
+	gpuCommonLabelMissing        bool
+	gpuCommonLabelOutdated       bool
+	gpuCommonLabelChanged        bool
+	commonOperandsLabelChanged   bool
+	gpuWorkloadConfigChanged     bool
+	migCapableLabelChanged       bool
+	osTreeLabelChanged           bool
+	nvidiaDriverOwnerLabelChange bool
+}
+
+// needsUpdate reports whether any tracked node-label change requires reconciliation.
+func (r nodeLabelUpdateReasons) needsUpdate() bool {
+	return r.gpuCommonLabelMissing ||
+		r.gpuCommonLabelOutdated ||
+		r.gpuCommonLabelChanged ||
+		r.commonOperandsLabelChanged ||
+		r.gpuWorkloadConfigChanged ||
+		r.migCapableLabelChanged ||
+		r.osTreeLabelChanged ||
+		r.nvidiaDriverOwnerLabelChange
+}
+
+// getNodeLabelUpdateReasons compares old and new node labels for changes that affect GPU Operator labels.
+func getNodeLabelUpdateReasons(oldLabels, newLabels map[string]string) nodeLabelUpdateReasons {
+	oldGPUWorkloadConfig, _ := getWorkloadConfig(oldLabels, true)
+	newGPUWorkloadConfig, _ := getWorkloadConfig(newLabels, true)
+
+	return nodeLabelUpdateReasons{
+		gpuCommonLabelMissing:        hasGPULabels(newLabels) && !hasCommonGPULabel(newLabels),
+		gpuCommonLabelOutdated:       !hasGPULabels(newLabels) && hasCommonGPULabel(newLabels),
+		gpuCommonLabelChanged:        oldLabels[commonGPULabelKey] != newLabels[commonGPULabelKey],
+		commonOperandsLabelChanged:   hasOperandsDisabled(oldLabels) != hasOperandsDisabled(newLabels),
+		gpuWorkloadConfigChanged:     oldGPUWorkloadConfig != newGPUWorkloadConfig,
+		migCapableLabelChanged:       hasMIGCapableGPU(oldLabels) != hasMIGCapableGPU(newLabels),
+		osTreeLabelChanged:           oldLabels[nfdOSTreeVersionLabelKey] != newLabels[nfdOSTreeVersionLabelKey],
+		nvidiaDriverOwnerLabelChange: oldLabels[consts.NVIDIADriverOwnerLabel] != newLabels[consts.NVIDIADriverOwnerLabel],
+	}
+}
+
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
 
 // Reconcile applies GPU-Operator related labels and annotations to all cluster nodes.
@@ -90,8 +140,22 @@ func (r *NodeLabelingReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		logger:        r.Log,
 	}
 
-	if err := nlc.labelGPUNodes(ctx); err != nil {
+	gpuLabelUpdateResult, err := nlc.labelGPUNodes(ctx)
+	if err != nil {
+		if gpuLabelUpdateResult.totalPatchedNodeCount > 0 {
+			r.Log.Error(err, "GPU node label update failed after partially updating nodes",
+				"totalPatchedNodeCount", gpuLabelUpdateResult.totalPatchedNodeCount,
+				"gpuDiscoveryStateChangedNodeCount", gpuLabelUpdateResult.gpuDiscoveryStateChangedNodeCount,
+			)
+		}
 		return reconcile.Result{}, err
+	}
+	if gpuLabelUpdateResult.gpuDiscoveryStateChangedNodeCount > 0 {
+		r.Log.V(consts.LogLevelDebug).Info("GPU discovery state used by owner assignment updated; dependent node label operations will run after the node update event",
+			"totalPatchedNodeCount", gpuLabelUpdateResult.totalPatchedNodeCount,
+			"gpuDiscoveryStateChangedNodeCount", gpuLabelUpdateResult.gpuDiscoveryStateChangedNodeCount,
+		)
+		return reconcile.Result{}, nil
 	}
 
 	if nlc.clusterPolicy.Spec.Driver.UseNvidiaDriverCRDType() {
@@ -110,34 +174,42 @@ func (r *NodeLabelingReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return reconcile.Result{}, nil
 }
 
-func (nlc *nodeLabelingController) labelGPUNodes(ctx context.Context) error {
+// labelGPUNodes reconciles GPU-related labels and reports which node labels were patched.
+func (nlc *nodeLabelingController) labelGPUNodes(ctx context.Context) (gpuNodeLabelsUpdateResult, error) {
+	result := gpuNodeLabelsUpdateResult{}
 	nodeList := &corev1.NodeList{}
 	if err := nlc.client.List(ctx, nodeList); err != nil {
-		return fmt.Errorf("unable to list nodes: %w", err)
+		return result, fmt.Errorf("unable to list nodes: %w", err)
 	}
 
 	for _, node := range nodeList.Items {
 		original := node.DeepCopy()
 		labels := node.GetLabels()
-		modified := false
+		gpuDiscoveryStateChanged := false
+		stateLabelsModified := false
 
 		if nlc.reconcileCommonGPULabel(labels, node.Name) {
 			node.SetLabels(labels)
-			modified = true
+			gpuDiscoveryStateChanged = true
 		}
 
 		if nlc.updateGPUStateLabels(labels, node.Name) {
 			node.SetLabels(labels)
-			modified = true
+			stateLabelsModified = true
 		}
 
+		modified := gpuDiscoveryStateChanged || stateLabelsModified
 		if modified {
 			if err := nlc.client.Patch(ctx, &node, client.MergeFrom(original)); err != nil {
-				return fmt.Errorf("unable to label node %s: %w", node.Name, err)
+				return result, fmt.Errorf("unable to label node %s: %w", node.Name, err)
+			}
+			result.totalPatchedNodeCount++
+			if gpuDiscoveryStateChanged {
+				result.gpuDiscoveryStateChangedNodeCount++
 			}
 		}
 	}
-	return nil
+	return result, nil
 }
 
 // reconcileCommonGPULabel keeps nvidia.com/gpu.present in sync with NFD GPU PCI labels.
@@ -406,28 +478,8 @@ func (r *NodeLabelingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 			oldLabels := e.ObjectOld.GetLabels()
 			nodeName := e.ObjectNew.GetName()
 
-			gpuCommonLabelMissing := hasGPULabels(newLabels) && !hasCommonGPULabel(newLabels)
-			gpuCommonLabelOutdated := !hasGPULabels(newLabels) && hasCommonGPULabel(newLabels)
-			commonOperandsLabelChanged := hasOperandsDisabled(oldLabels) != hasOperandsDisabled(newLabels)
-			migCapableLabelChanged := hasMIGCapableGPU(oldLabels) != hasMIGCapableGPU(newLabels)
-
-			oldGPUWorkloadConfig, _ := getWorkloadConfig(oldLabels, true)
-			newGPUWorkloadConfig, _ := getWorkloadConfig(newLabels, true)
-			gpuWorkloadConfigLabelChanged := oldGPUWorkloadConfig != newGPUWorkloadConfig
-
-			oldOSTreeLabel := oldLabels[nfdOSTreeVersionLabelKey]
-			newOSTreeLabel := newLabels[nfdOSTreeVersionLabelKey]
-			osTreeLabelChanged := oldOSTreeLabel != newOSTreeLabel
-
-			nvidiaDriverOwnerLabelChanged := oldLabels[consts.NVIDIADriverOwnerLabel] != newLabels[consts.NVIDIADriverOwnerLabel]
-
-			needsUpdate := gpuCommonLabelMissing ||
-				gpuCommonLabelOutdated ||
-				commonOperandsLabelChanged ||
-				gpuWorkloadConfigLabelChanged ||
-				osTreeLabelChanged ||
-				nvidiaDriverOwnerLabelChanged ||
-				migCapableLabelChanged
+			reasons := getNodeLabelUpdateReasons(oldLabels, newLabels)
+			needsUpdate := reasons.needsUpdate()
 
 			// When an NVIDIADriver daemonset pod is running on the node, check if any
 			// label which is configured in the NVIDIADriver's node selector has changed.
@@ -452,13 +504,14 @@ func (r *NodeLabelingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 			if needsUpdate {
 				r.Log.Info("Node needs an update",
 					"name", nodeName,
-					"gpuCommonLabelMissing", gpuCommonLabelMissing,
-					"gpuCommonLabelOutdated", gpuCommonLabelOutdated,
-					"commonOperandsLabelChanged", commonOperandsLabelChanged,
-					"gpuWorkloadConfigLabelChanged", gpuWorkloadConfigLabelChanged,
-					"migCapableLabelChanged", migCapableLabelChanged,
-					"osTreeLabelChanged", osTreeLabelChanged,
-					"nvidiaDriverOwnerLabelChanged", nvidiaDriverOwnerLabelChanged,
+					"gpuCommonLabelMissing", reasons.gpuCommonLabelMissing,
+					"gpuCommonLabelOutdated", reasons.gpuCommonLabelOutdated,
+					"gpuCommonLabelChanged", reasons.gpuCommonLabelChanged,
+					"commonOperandsLabelChanged", reasons.commonOperandsLabelChanged,
+					"gpuWorkloadConfigLabelChanged", reasons.gpuWorkloadConfigChanged,
+					"migCapableLabelChanged", reasons.migCapableLabelChanged,
+					"osTreeLabelChanged", reasons.osTreeLabelChanged,
+					"nvidiaDriverOwnerLabelChanged", reasons.nvidiaDriverOwnerLabelChange,
 					"nvidiaDriverNodeSelectorLabelChanged", nvidiaDriverNodeSelectorLabelChanged,
 				)
 			}

--- a/controllers/nodelabeling_controller_test.go
+++ b/controllers/nodelabeling_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
@@ -31,6 +32,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
@@ -46,6 +49,206 @@ func mergeLabels(maps ...map[string]string) map[string]string {
 		}
 	}
 	return out
+}
+
+func TestNodeLabelingReconcileDefersDependentOperationsAfterGPULabelChanges(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, gpuv1.AddToScheme(scheme))
+	require.NoError(t, nvidiav1alpha1.AddToScheme(scheme))
+
+	clusterPolicy := &gpuv1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-policy"},
+		Spec: gpuv1.ClusterPolicySpec{
+			Driver: gpuv1.DriverSpec{
+				UseNvidiaDriverCRD: ptr.To(true),
+			},
+		},
+	}
+	driver := &nvidiav1alpha1.NVIDIADriver{
+		ObjectMeta: metav1.ObjectMeta{Name: consts.DefaultNVIDIADriverName},
+		Spec: nvidiav1alpha1.NVIDIADriverSpec{
+			Default: true,
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node",
+			Labels: map[string]string{
+				"feature.node.kubernetes.io/pci-10de.present": "true",
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(clusterPolicy, driver, node).
+		Build()
+
+	reconciler := &NodeLabelingReconciler{
+		Client:    fakeClient,
+		Namespace: "test-ns",
+		Log:       logr.Discard(),
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	updatedNode := &corev1.Node{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "gpu-node"}, updatedNode))
+	assert.Equal(t, commonGPULabelValue, updatedNode.Labels[commonGPULabelKey])
+	assert.NotContains(t, updatedNode.Labels, consts.NVIDIADriverOwnerLabel)
+
+	result, err = reconciler.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "gpu-node"}, updatedNode))
+	assert.Equal(t, consts.DefaultNVIDIADriverName, updatedNode.Labels[consts.NVIDIADriverOwnerLabel])
+}
+
+func TestNodeLabelingReconcileDoesNotDeferDependentOperationsForStateLabelChanges(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, gpuv1.AddToScheme(scheme))
+	require.NoError(t, nvidiav1alpha1.AddToScheme(scheme))
+
+	clusterPolicy := &gpuv1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-policy"},
+		Spec: gpuv1.ClusterPolicySpec{
+			Driver: gpuv1.DriverSpec{
+				UseNvidiaDriverCRD: ptr.To(true),
+			},
+		},
+	}
+	driver := &nvidiav1alpha1.NVIDIADriver{
+		ObjectMeta: metav1.ObjectMeta{Name: consts.DefaultNVIDIADriverName},
+		Spec: nvidiav1alpha1.NVIDIADriverSpec{
+			Default: true,
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node",
+			Labels: map[string]string{
+				"feature.node.kubernetes.io/pci-10de.present": "true",
+				commonGPULabelKey: commonGPULabelValue,
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(clusterPolicy, driver, node).
+		Build()
+
+	reconciler := &NodeLabelingReconciler{
+		Client:    fakeClient,
+		Namespace: "test-ns",
+		Log:       logr.Discard(),
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	updatedNode := &corev1.Node{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "gpu-node"}, updatedNode))
+	assert.Equal(t, "true", updatedNode.Labels["nvidia.com/gpu.deploy.driver"])
+	assert.Equal(t, consts.DefaultNVIDIADriverName, updatedNode.Labels[consts.NVIDIADriverOwnerLabel])
+}
+
+func TestNodeLabelUpdateReasonsDetectsLabelChanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		old    map[string]string
+		new    map[string]string
+		assert func(*testing.T, nodeLabelUpdateReasons)
+	}{
+		{
+			name: "GPU common label changed",
+			old: map[string]string{
+				"feature.node.kubernetes.io/pci-10de.present": "true",
+			},
+			new: map[string]string{
+				"feature.node.kubernetes.io/pci-10de.present": "true",
+				commonGPULabelKey: commonGPULabelValue,
+			},
+			assert: func(t *testing.T, reasons nodeLabelUpdateReasons) {
+				assert.True(t, reasons.gpuCommonLabelChanged)
+			},
+		},
+		{
+			name: "MIG capable label changed",
+			old:  map[string]string{},
+			new: map[string]string{
+				migCapableLabelKey: migCapableLabelValue,
+			},
+			assert: func(t *testing.T, reasons nodeLabelUpdateReasons) {
+				assert.True(t, reasons.migCapableLabelChanged)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reasons := getNodeLabelUpdateReasons(tc.old, tc.new)
+
+			tc.assert(t, reasons)
+			assert.True(t, reasons.needsUpdate())
+		})
+	}
+}
+
+func TestLabelGPUNodesReturnsPartialUpdateCountOnPatchError(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	patchErr := errors.New("patch failed")
+	patchCalls := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-node-a",
+					Labels: map[string]string{
+						"feature.node.kubernetes.io/pci-10de.present": "true",
+					},
+				},
+			},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-node-b",
+					Labels: map[string]string{
+						"feature.node.kubernetes.io/pci-10de.present": "true",
+					},
+				},
+			},
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patchCalls++
+				if patchCalls == 2 {
+					return patchErr
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	nlc := &nodeLabelingController{
+		client:        fakeClient,
+		clusterPolicy: &gpuv1.ClusterPolicy{},
+		logger:        logr.Discard(),
+	}
+
+	result, err := nlc.labelGPUNodes(ctx)
+	require.ErrorIs(t, err, patchErr)
+	assert.Equal(t, 1, result.totalPatchedNodeCount)
+	assert.Equal(t, 1, result.gpuDiscoveryStateChangedNodeCount)
 }
 
 func TestReconcileCommonGPULabel(t *testing.T) {

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -550,7 +550,7 @@ func setup() error {
 	nlc := &nodeLabelingController{
 		client: client,
 	}
-	if err := nlc.labelGPUNodes(ctx); err != nil {
+	if _, err := nlc.labelGPUNodes(ctx); err != nil {
 		return fmt.Errorf("unable to label nodes in cluster: %v", err)
 	}
 


### PR DESCRIPTION
## Description

This change fixes a race in NVIDIADriver CRD mode where driver DaemonSets may never be rendered after a fresh install or migration.

NodeLabeling now defers dependent node-label operations after it patches GPU labels, and the node update predicate now explicitly reconciles when `nvidia.com/gpu.present` changes. This lets the follow-up reconcile run after the informer observes the GPU label update, so NVIDIADriver owner labels can be assigned reliably.

Code is drafted with the help of codex.

 <!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

### To reproduce the issue
a. Had a clean node with no nvidia labels and no gpu-operator running.
b. Installed gpu-operator which had the bug
```
helm install gpu-operator -n gpu-operator --create-namespace oci://ghcr.io/nvidia/gpu-operator/charts/gpu-operator:0.0.0-git-16638954 --set driver.nvidiaDriverCRD.enabled=true --set driver.nvidiaDriverCRD.deployDefaultCR=true
```
c. Waited for driver pod to not show up. If it did, re-ran steps a-c.

I was able to reproduce this issue after running for 2-3 times.

### To test the fix:
Did the same steps as mentioned to reproduce the issue but with the oci helm chart built for this PR. Re-ran them atleast 15-20 times and couldn't reproduce it again.