### PR TITLE
[OLM] remove the R535 driver as it is EOL

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -234,8 +234,6 @@ spec:
       image: nvcr.io/nvidia/driver@sha256:3d7ae961d7bce5e193885aa99e91ba87421bccc3d187cd9997083faf021208be
     - name: driver-image-580
       image: nvcr.io/nvidia/driver@sha256:f8e3dc9111c5a7a0cfac73e87d03c0b7b3d1e11f3b61654cca5461847660aa2c
-    - name: driver-image-535
-      image: nvcr.io/nvidia/driver@sha256:659d9315957ffa2a3f2a003716f066f6a1b3c06ae5557192148ed410dc1b9a6e
     - name: device-plugin-image
       image: nvcr.io/nvidia/k8s-device-plugin:v0.19.3@sha256:25cc340fe6fd53c101e16fc452f503e7a92c219c64a80ed5381784b522dbbf77
     - name: gpu-feature-discovery-image
@@ -954,8 +952,6 @@ spec:
                     value: "nvcr.io/nvidia/driver@sha256:3d7ae961d7bce5e193885aa99e91ba87421bccc3d187cd9997083faf021208be"
                   - name: "DRIVER_IMAGE-580"
                     value: "nvcr.io/nvidia/driver@sha256:f8e3dc9111c5a7a0cfac73e87d03c0b7b3d1e11f3b61654cca5461847660aa2c"
-                  - name: "DRIVER_IMAGE-535"
-                    value: "nvcr.io/nvidia/driver@sha256:659d9315957ffa2a3f2a003716f066f6a1b3c06ae5557192148ed410dc1b9a6e"
                   - name: "DRIVER_MANAGER_IMAGE"
                     value: "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.11.0@sha256:8aec215a8b159b0162b55e688065efd58ebfa848ebc999c1797221686ff1243d"
                   - name: "MIG_MANAGER_IMAGE"


### PR DESCRIPTION
As per the official driver docs [page](https://docs.nvidia.com/datacenter/tesla/drivers/latest/supported-drivers-and-cuda-toolkit-versions.html), R535 is EOL as of June 2026 