### PR TITLE
[renovate] allow renovate to detect toolkit rc releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,10 +69,21 @@
         "nvcr.io/nvidia/cloud-native/nvidia-sandbox-device-plugin",
         "nvcr.io/nvidia/kubevirt-gpu-device-plugin",
         "nvcr.io/nvidia/k8s-device-plugin",
-        "nvcr.io/nvidia/k8s/container-toolkit",
         "nvcr.io/nvidia/cloud-native/k8s-mig-manager"
       ],
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "separateMajorMinor": false
+    },
+    {
+      "matchPaths": [
+        "deployments/gpu-operator/values.yaml",
+        "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
+      ],
+      "matchPackageNames": [
+        "nvcr.io/nvidia/k8s/container-toolkit"
+      ],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>rc\\.\\d+))?$",
+      "ignoreUnstable": false,
       "separateMajorMinor": false
     },
     {


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This change will allow us to bump nvidia-container-toolkit to latest rc versions if they are available.
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

