### PR TITLE
[renovate] allow renovate to bump golang versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,31 @@
       "depNameTemplate": "{{repo}}/{{image}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "go.mod",
+        "tools/go.mod"
+      ],
+      "matchStrings": [
+        "go (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "versions.mk"
+      ],
+      "matchStrings": [
+        "GOLANG_VERSION \\?= (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
     }
   ],
   "labels": [
@@ -60,7 +85,7 @@
   ],
   "packageRules": [
     {
-      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchFileNames": ["deployments/gpu-operator/values.yaml"],
       "matchPackageNames": [
         "nvcr.io/nvidia/cloud-native/k8s-driver-manager",
         "nvcr.io/nvidia/cloud-native/k8s-kata-manager",
@@ -75,7 +100,7 @@
       "separateMajorMinor": false
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "deployments/gpu-operator/values.yaml",
         "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
       ],
@@ -87,7 +112,7 @@
       "separateMajorMinor": false
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "deployments/gpu-operator/values.yaml",
         "bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"
       ],
@@ -98,7 +123,7 @@
       "separateMajorMinor": false
     },
     {
-      "matchPaths": ["deployments/gpu-operator/values.yaml"],
+      "matchFileNames": ["deployments/gpu-operator/values.yaml"],
       "matchPackageNames": [
        "nvcr.io/nvidia/cuda"
       ],
@@ -112,6 +137,16 @@
     {
       "matchDatasources": ["*"],
       "groupName": "{{depName}}"
+    },
+    {
+      "description": "Group all Go toolchain version bumps",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["go"],
+      "matchDatasources": ["golang-version"],
+      "groupName": "Go toolchain",
+      "groupSlug": "go-toolchain",
+      "separateMajorMinor": false,
+      "separateMinorPatch": false
     }
   ]
 }


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This PR adds rules so that renovate now manages and bumps golang version in go.mod, versions.mk file.

It also changes `matchPaths` to `matchFileNames` based on the deprecation warnings seen:
```
WARN: Config needs migrating
      "configType": ".github/renovate.json",
      ...
      "migratedConfig": {
        ...
        "packageRules": [
          {
            "matchFileNames": ["deployments/gpu-operator/values.yaml"],
            ...
          }
        ]
      }
```

See:
https://github.com/renovatebot/renovate/blob/main/lib/config/migrations/custom/package-rules-migration.ts#L5-L8
https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing
Run this from repo root:
```
docker run --rm \
  -v "$PWD:/tmp/repo:ro" \
  -w /tmp/repo \
  -e LOG_LEVEL=debug \
  -e RENOVATE_CONFIG_FILE=.github/renovate.json \
  -e RENOVATE_PLATFORM=local \
  -e RENOVATE_DRY_RUN=full \
  -e RENOVATE_REQUIRE_CONFIG=ignored \
  -e RENOVATE_ONBOARDING=false \
  renovate/renovate:latest
```
It correctly detects go 1.26.5 now.
<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

