### PR TITLE
[renovate] ignore go version in go.mod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,11 +56,10 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "go.mod",
-        "tools/go.mod"
+        "versions.mk"
       ],
       "matchStrings": [
-        "go (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "GOLANG_VERSION \\?= (?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "go",
       "datasourceTemplate": "golang-version",
@@ -69,10 +68,10 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "versions.mk"
+        "docker/Dockerfile"
       ],
       "matchStrings": [
-        "GOLANG_VERSION \\?= (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "FROM golang:(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "go",
       "datasourceTemplate": "golang-version",


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This PR now makes renovate ignore go version in go.mod file.

Sample detected change with this PR:
```
versions.mk
GOLANG_VERSION ?= 1.26.4 -> 1.26.5

docker/Dockerfile
FROM golang:1.26.4 -> FROM golang:1.26.5
```

Code drafted using codex
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

