### PR TITLE
[renovate] add rule for bumping version for dcgm in bundle as well

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -122,6 +122,14 @@
       "separateMajorMinor": false
     },
     {
+      "matchFileNames": ["bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"],
+      "matchPackageNames": [
+        "nvcr.io/nvidia/cloud-native/dcgm"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-ubi\\d+$",
+      "separateMajorMinor": false
+    },
+    {
       "matchFileNames": ["deployments/gpu-operator/values.yaml"],
       "matchPackageNames": [
        "nvcr.io/nvidia/cuda"


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Newer tags: https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/dcgm/-/tags

This PR enables us to update bundle as well with newer version.

Dry run detected these changes:
For values.yaml:
```
{
  "currentValue": "4.5.2-1-ubuntu22.04",
  "newValue": "4.6.0-1-ubuntu24.04"
}
```
For bundle:
```
{
  "packageName": "nvcr.io/nvidia/cloud-native/dcgm",
  "currentValue": "4.5.2-1-ubi9",
  "currentDigest": "sha256:d7558fa75ed7b703665cbc6ba6360ef4e53ecdefe65c1881c165d2ac816c674a",
  "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-ubi\\d+$",
  "updates": [
    {
      "newVersion": "4.6.0-1-ubi10",
      "newValue": "4.6.0-1-ubi10",
      "newDigest": "sha256:92080d86d04c265f7fc0b8e1cd95dff94d3ab57de6a6474c3c483e4c2ada5dea",
      "updateType": "minor",
      "branchName": "renovate/nvcr.ionvidiacloud-nativedcgm"
    }
  ]
}
```
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

