### PR TITLE
helm: add nodeSelector to upgrade-crd hook Job to prevent Windows scheduling

### DIFF
--- a/deployments/gpu-operator/templates/cleanup_crd.yaml
+++ b/deployments/gpu-operator/templates/cleanup_crd.yaml
@@ -30,6 +30,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       containers:
         - name: cleanup-crd
           image: {{ include "gpu-operator.fullimage" . }}

--- a/deployments/gpu-operator/templates/cleanup_gpucluster.yaml
+++ b/deployments/gpu-operator/templates/cleanup_gpucluster.yaml
@@ -35,6 +35,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       containers:
         - name: cleanup-gpucluster
           image: {{ include "gpu-operator.fullimage" . }}

--- a/deployments/gpu-operator/templates/upgrade_crd.yaml
+++ b/deployments/gpu-operator/templates/upgrade_crd.yaml
@@ -79,6 +79,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       containers:
         - name: upgrade-crd
           image: {{ include "gpu-operator.fullimage" . }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -82,6 +82,8 @@ operator:
   env: []
   priorityClassName: system-node-critical
   runtimeClass: nvidia
+  nodeSelector:
+    kubernetes.io/os: linux
   use_ocp_driver_toolkit: false
   # cleanup CRD on chart un-install
   cleanupCRD: false


### PR DESCRIPTION
**What this PR does / why we need it:**

The pre-upgrade CRD hook Job (`deployments/gpu-operator/templates/upgrade_crd.yaml`) renders `tolerations` from `.Values.operator.tolerations` but no `nodeSelector`, so on mixed-OS clusters with untainted Windows nodes the hook pod can be scheduled onto a Windows node and hang in `ContainerCreating` forever, blocking Helm upgrades.

This commit adds a `nodeSelector` block to the Job's pod template that:
- renders `.Values.operator.nodeSelector` if the user has set it (for consistency with the operator Deployment and user-controlled node targeting)
- defaults to `kubernetes.io/os: linux` when no user nodeSelector is provided, ensuring the hook always lands on Linux

**Which issue(s) this PR fixes:**

Fixes #2608

**Special notes for reviewers:**

- Tested locally with `helm template` (no live cluster available).
- Blast radius: one template file, one pod spec, no user-facing API changes.
- The default `kubernetes.io/os: linux` is safe and standard for Linux-only container images.
