### PR TITLE
[helm] validate devicePlugin custom configMap settings

### DIFF
--- a/deployments/gpu-operator/templates/validations.yaml
+++ b/deployments/gpu-operator/templates/validations.yaml
@@ -5,3 +5,11 @@
 {{- if and (eq .Values.cdi.nriPluginEnabled true) (eq .Values.toolkit.enabled false)  }}
 {{ fail "the NRI Plugin cannot be enabled when the Container Toolkit is disabled" }}
 {{- end }}
+
+{{- if and (.Values.devicePlugin.config.create) (empty .Values.devicePlugin.config.data) }}
+{{ fail "devicePlugin.config.data cannot be empty when devicePlugin.config.create is set to true" }}
+{{- end }}
+
+{{- if and (.Values.devicePlugin.config.create) (empty .Values.devicePlugin.config.name) }}
+{{ fail "devicePlugin.config.name cannot be empty when devicePlugin.config.create is set to true" }}
+{{- end }}


### PR DESCRIPTION
This fixes a bug where the rendered device-plugin daemonset ends up in a bad state when the user enables custom configmap creation but provides empty configmap data as input.

Closes #2641    