### PR TITLE
feat: add affinity and nodeSelector to common daemonset config

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -308,6 +308,21 @@ type DaemonsetsSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:io.kubernetes:Tolerations"
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// Optional: Set nodeSelector merged with operand nodeSelector labels
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="NodeSelector for all Daemonsets"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:nodeSelector"
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Optional: Set affinity for all Daemonsets
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Affinity for all Daemonsets"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:affinity"
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="PriorityClassName"

--- a/api/nvidia/v1/zz_generated.deepcopy.go
+++ b/api/nvidia/v1/zz_generated.deepcopy.go
@@ -525,6 +525,18 @@ func (in *DaemonsetsSpec) DeepCopyInto(out *DaemonsetsSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(corev1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
 		*out = new(RollingUpdateSpec)

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -160,6 +160,10 @@ spec:
               daemonsets:
                 description: Daemonset defines common configuration for all Daemonsets
                 properties:
+                  affinity:
+                    description: 'Optional: Set affinity for all Daemonsets'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   annotations:
                     additionalProperties:
                       type: string
@@ -175,6 +179,12 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Set nodeSelector merged with operand nodeSelector
+                      labels'
                     type: object
                   podSecurityContext:
                     description: 'Optional: Set pod-level security context for all

--- a/bundle/manifests/nvidia.com_gpuclusters.yaml
+++ b/bundle/manifests/nvidia.com_gpuclusters.yaml
@@ -57,6 +57,10 @@ spec:
                   Daemonsets defines the common configuration applied to all DaemonSets deployed
                   by the GPUCluster controller.
                 properties:
+                  affinity:
+                    description: 'Optional: Set affinity for all Daemonsets'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   annotations:
                     additionalProperties:
                       type: string
@@ -72,6 +76,12 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Set nodeSelector merged with operand nodeSelector
+                      labels'
                     type: object
                   podSecurityContext:
                     description: 'Optional: Set pod-level security context for all

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -160,6 +160,10 @@ spec:
               daemonsets:
                 description: Daemonset defines common configuration for all Daemonsets
                 properties:
+                  affinity:
+                    description: 'Optional: Set affinity for all Daemonsets'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   annotations:
                     additionalProperties:
                       type: string
@@ -175,6 +179,12 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Set nodeSelector merged with operand nodeSelector
+                      labels'
                     type: object
                   podSecurityContext:
                     description: 'Optional: Set pod-level security context for all

--- a/config/crd/bases/nvidia.com_gpuclusters.yaml
+++ b/config/crd/bases/nvidia.com_gpuclusters.yaml
@@ -57,6 +57,10 @@ spec:
                   Daemonsets defines the common configuration applied to all DaemonSets deployed
                   by the GPUCluster controller.
                 properties:
+                  affinity:
+                    description: 'Optional: Set affinity for all Daemonsets'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   annotations:
                     additionalProperties:
                       type: string
@@ -72,6 +76,12 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Set nodeSelector merged with operand nodeSelector
+                      labels'
                     type: object
                   podSecurityContext:
                     description: 'Optional: Set pod-level security context for all

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -836,6 +836,19 @@ func applyCommonDaemonsetConfig(obj *appsv1.DaemonSet, config *gpuv1.ClusterPoli
 		obj.Spec.Template.Spec.Tolerations = config.Daemonsets.Tolerations
 	}
 
+	if len(config.Daemonsets.NodeSelector) > 0 {
+		if obj.Spec.Template.Spec.NodeSelector == nil {
+			obj.Spec.Template.Spec.NodeSelector = make(map[string]string)
+		}
+		for key, value := range config.Daemonsets.NodeSelector {
+			obj.Spec.Template.Spec.NodeSelector[key] = value
+		}
+	}
+
+	if config.Daemonsets.Affinity != nil {
+		obj.Spec.Template.Spec.Affinity = config.Daemonsets.Affinity
+	}
+
 	// set pod-level security context if specified (applies as defaults to all containers in the pod)
 	if config.Daemonsets.PodSecurityContext != nil {
 		obj.Spec.Template.Spec.SecurityContext = config.Daemonsets.PodSecurityContext

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -149,6 +149,16 @@ func (d Daemonset) WithTolerations(tolerations []corev1.Toleration) Daemonset {
 	return d
 }
 
+func (d Daemonset) WithNodeSelector(nodeSelector map[string]string) Daemonset {
+	d.Spec.Template.Spec.NodeSelector = nodeSelector
+	return d
+}
+
+func (d Daemonset) WithAffinity(affinity *corev1.Affinity) Daemonset {
+	d.Spec.Template.Spec.Affinity = affinity
+	return d
+}
+
 func (d Daemonset) WithPodSecurityContext(psc *corev1.PodSecurityContext) Daemonset {
 	d.Spec.Template.Spec.SecurityContext = psc
 	return d
@@ -686,6 +696,61 @@ func TestApplyCommonDaemonSetConfig(t *testing.T) {
 					Key:      "test-key",
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}),
+		},
+		{
+			description: "nodeSelector configured",
+			ds: NewDaemonset().WithNodeSelector(map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin": "true",
+			}),
+			dsSpec: gpuv1.DaemonsetsSpec{
+				NodeSelector: map[string]string{
+					"karpenter.sh/nodepool": "gpu",
+				},
+			},
+			expectedDs: NewDaemonset().WithNodeSelector(map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin": "true",
+				"karpenter.sh/nodepool":               "gpu",
+			}),
+		},
+		{
+			description: "affinity configured",
+			ds:          NewDaemonset(),
+			dsSpec: gpuv1.DaemonsetsSpec{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      "karpenter.sh/nodepool",
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"gpu"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDs: NewDaemonset().WithAffinity(&corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "karpenter.sh/nodepool",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"gpu"},
+									},
+								},
+							},
+						},
+					},
 				},
 			}),
 		},

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -160,6 +160,10 @@ spec:
               daemonsets:
                 description: Daemonset defines common configuration for all Daemonsets
                 properties:
+                  affinity:
+                    description: 'Optional: Set affinity for all Daemonsets'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   annotations:
                     additionalProperties:
                       type: string
@@ -175,6 +179,12 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Set nodeSelector merged with operand nodeSelector
+                      labels'
                     type: object
                   podSecurityContext:
                     description: 'Optional: Set pod-level security context for all

--- a/deployments/gpu-operator/crds/nvidia.com_gpuclusters.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_gpuclusters.yaml
@@ -57,6 +57,10 @@ spec:
                   Daemonsets defines the common configuration applied to all DaemonSets deployed
                   by the GPUCluster controller.
                 properties:
+                  affinity:
+                    description: 'Optional: Set affinity for all Daemonsets'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   annotations:
                     additionalProperties:
                       type: string
@@ -72,6 +76,12 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'Optional: Set nodeSelector merged with operand nodeSelector
+                      labels'
                     type: object
                   podSecurityContext:
                     description: 'Optional: Set pod-level security context for all

--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -46,6 +46,12 @@ spec:
     {{- if .Values.daemonsets.tolerations }}
     tolerations: {{ toYaml .Values.daemonsets.tolerations | nindent 6 }}
     {{- end }}
+    {{- if .Values.daemonsets.nodeSelector }}
+    nodeSelector: {{ toYaml .Values.daemonsets.nodeSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.daemonsets.affinity }}
+    affinity: {{ toYaml .Values.daemonsets.affinity | nindent 6 }}
+    {{- end }}
     {{- if .Values.daemonsets.priorityClassName }}
     priorityClassName: {{ .Values.daemonsets.priorityClassName }}
     {{- end }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -41,6 +41,8 @@ hostPaths:
 daemonsets:
   labels: {}
   annotations: {}
+  nodeSelector: {}
+  affinity: {}
   priorityClassName: system-node-critical
   tolerations:
   - key: nvidia.com/gpu


### PR DESCRIPTION
Fixes #2626

ClusterPolicy already exposes common tolerations for operand daemonsets but there was no matching knob for affinity or nodeSelector. This adds both under `spec.daemonsets` and surfaces them in Helm as `daemonsets.affinity` and `daemonsets.nodeSelector`.

User nodeSelector labels are merged into the operand nodeSelector, so the existing `nvidia.com/gpu.deploy.*` labels stay put.

The affinity CRD field is schemaless so we accept a normal Kubernetes affinity object without inlining the full OpenAPI schema into the ClusterPolicy CRD.

## Testing

- go test ./controllers/... -run TestApplyCommonDaemonSetConfig
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-cloud.devinenterprise.com/review/nvidia/gpu-operator/pull/2645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->