### PR TITLE
Fix NVIDIADriver status state during initial owner assignment

### DIFF
--- a/controllers/nvidiadriver_controller.go
+++ b/controllers/nvidiadriver_controller.go
@@ -225,6 +225,14 @@ func (r *NVIDIADriverReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *NVIDIADriverReconciler) updateCrStatus(
 	ctx context.Context, cr *nvidiav1alpha1.NVIDIADriver, status state.Results) error {
 	reqLogger := log.FromContext(ctx)
+	desiredState := nvidiav1alpha1.State(status.Status)
+
+	// Keep the reconcile object in sync with the status about to be persisted.
+	// The condition updater is invoked immediately after this function and uses
+	// cr.Status.State when writing an error condition. Without this assignment,
+	// it can overwrite the new state with the value that was present when this
+	// reconcile started.
+	cr.Status.State = desiredState
 
 	// Fetch latest instance and update state to avoid version mismatch
 	instance := &nvidiav1alpha1.NVIDIADriver{}
@@ -235,10 +243,10 @@ func (r *NVIDIADriverReconciler) updateCrStatus(
 	}
 
 	// Update global State
-	if instance.Status.State == nvidiav1alpha1.State(status.Status) {
+	if instance.Status.State == desiredState {
 		return nil
 	}
-	instance.Status.State = nvidiav1alpha1.State(status.Status)
+	instance.Status.State = desiredState
 
 	// send status update request to k8s API
 	reqLogger.V(consts.LogLevelInfo).Info("Updating CR Status", "Status", instance.Status)

--- a/controllers/nvidiadriver_controller_test.go
+++ b/controllers/nvidiadriver_controller_test.go
@@ -39,6 +39,8 @@ import (
 
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
+	"github.com/NVIDIA/gpu-operator/internal/conditions"
+	"github.com/NVIDIA/gpu-operator/internal/state"
 	"github.com/NVIDIA/gpu-operator/internal/validator"
 )
 
@@ -269,6 +271,43 @@ func TestReconcileConflictSetsNotReadyState(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, nvidiav1alpha1.NotReady, updater.LastErrorState)
+}
+
+func TestUpdateCrStatusPreservesNotReadyStateWhenSettingErrorCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiav1alpha1.AddToScheme(scheme))
+
+	driver := &nvidiav1alpha1.NVIDIADriver{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-driver"},
+		Status:     nvidiav1alpha1.NVIDIADriverStatus{State: nvidiav1alpha1.Ready},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(driver).
+		WithStatusSubresource(driver).
+		Build()
+	reconciler := &NVIDIADriverReconciler{Client: k8sClient}
+
+	require.NoError(t, reconciler.updateCrStatus(context.Background(), driver, state.Results{
+		Status: state.SyncStateNotReady,
+	}))
+	require.Equal(t, nvidiav1alpha1.NotReady, driver.Status.State)
+
+	updater := conditions.NewNvDriverUpdater(k8sClient)
+	require.NoError(t, updater.SetConditionsError(
+		context.Background(), driver, conditions.DriverNotReady, "Waiting for driver pod to be ready"))
+
+	updated := &nvidiav1alpha1.NVIDIADriver{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: driver.Name}, updated))
+	require.Equal(t, nvidiav1alpha1.NotReady, updated.Status.State)
+	require.Conditionf(t, func() bool {
+		for _, condition := range updated.Status.Conditions {
+			if condition.Type == conditions.Error && condition.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, "expected an Error=True condition")
 }
 
 func TestEnqueueAllNVIDIADrivers(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix an incorrect `NVIDIADriver.status.state` transition during initial driver deployment when node ownership labeling is handled by the separate node-labeling controller.

The fix synchronizes the in-memory `NVIDIADriver` object with the state persisted by `updateCrStatus`. This prevents the following condition update from using a stale state and overwriting the newly persisted value.

## Problem

Each driver DaemonSet selects Nodes using the operator-managed owner label:

```text
nvidia.com/gpu-operator.driver.owner=<NVIDIADriver name>
```

The node-labeling controller assigns this label independently of the NVIDIADriver controller.

During initial deployment, the following sequence is possible:

1. Helm creates `NVIDIADriver/default`.
2. NVIDIADriver reconciliation runs before the node-labeling controller assigns `owner=default` to GPU Nodes.
3. Driver node-pool discovery finds no matching Nodes.
4. No driver DaemonSet objects are rendered.
5. The state manager treats the empty object set as ready, so `status.state` becomes `ready`.
6. The node-labeling controller assigns `owner=default` to GPU Nodes.
7. The Node update re-enqueues NVIDIADriver reconciliation.
8. The next reconciliation discovers matching node pools, creates the driver DaemonSet, and observes that its pods are not yet ready.
9. The desired state is now `notReady`.

### Status overwrite flow

The not-ready reconciliation performs separate state and condition updates using different in-memory CR objects:

```text
1. Reconcile GETs NVIDIADriver -> object A
   A.Status.State = Ready

2. updateCrStatus GETs NVIDIADriver -> object B
   B.Status.State = NotReady
   Status().Update(B)
   API state is now NotReady

3. SetConditionsError receives object A
   updateConditions GETs NVIDIADriver -> object C
   C.Status.State = NotReady

   updateConditions then assigns:
     C.Status.State = A.Status.State  // Ready

   Status().Update(C)
   API state becomes Ready again
```

`updateConditions` fetches object C to update conditions safely, but it also copies `status.state` from the original reconcile object A:

```go
instance.Status.State = cr.Status.State
```

Because object A was read before `updateCrStatus` persisted `notReady`, it still contains the prior `ready` state. The condition update therefore overwrites the correct `notReady` state.

## Fix

`updateCrStatus` now updates the passed reconcile object before persisting the state:

```go
desiredState := nvidiav1alpha1.State(status.Status)
cr.Status.State = desiredState
```

This ensures the subsequent condition update receives the same state that `updateCrStatus` persists.

The corrected flow is:

```text
updateCrStatus:
  reconcile object state = notReady
  persisted CR state = notReady

SetConditionsError:
  caller-provided state = notReady
  persisted CR state remains notReady
  Ready=False and Error=True conditions are updated
```

## Scope

This is intentionally a focused NVIDIADriver-only change.

- Does not change the shared `conditions.Updater` interface.
- Does not change ClusterPolicy condition handling.
- Does not change node-labeling behavior.
- Preserves the existing status update and retry behavior.

## Validation

- Verified that an initial reconciliation with no owner-labeled Nodes can render no driver DaemonSet objects and report `ready`.
- Verified that owner-label assignment re-enqueues NVIDIADriver reconciliation.
- Verified that the subsequent DaemonSet rollout requires `notReady` while driver pods are unavailable.
- Confirmed that the condition updater previously copied `status.state` from the reconcile-start object and could overwrite `notReady` with stale `ready`.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

Tested this change on a 3 node cluster and can see that nvidiadriver correctly gets marked as notReady when it should be. Previously, for a brief moment, it was marked as ready when switching from clusterpolicy to nvidiadriver.

Note: Code is drafted with the help from codex