### PR TITLE
Add unit tests for internal/render

### DIFF
--- a/internal/render/render_suite_test.go
+++ b/internal/render/render_suite_test.go
@@ -14,7 +14,7 @@
 # limitations under the License.
 **/
 
-package render_test
+package render
 
 import (
 	"testing"

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -14,18 +14,19 @@
 # limitations under the License.
 **/
 
-package render_test
+package render
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/NVIDIA/gpu-operator/internal/render"
 	"github.com/NVIDIA/gpu-operator/internal/utils"
 )
 
@@ -52,21 +53,30 @@ func getFilesFromDir(dirPath string) []string {
 	return files
 }
 
+// writeTempManifest writes the provided template content to a file in a
+// per-spec temporary directory and returns its path.
+func writeTempManifest(name, content string) string {
+	dir := GinkgoT().TempDir()
+	f := filepath.Join(dir, name)
+	Expect(os.WriteFile(f, []byte(content), 0o600)).To(Succeed())
+	return f
+}
+
 var _ = Describe("Test Renderer via API", func() {
-	t := &render.TemplatingData{
+	t := &TemplatingData{
 		Funcs: nil,
 		Data:  &templateData{"foo", "bar", "baz"},
 	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		panic("Failed to get CWD")
+		panic(fmt.Sprintf("Failed to get CWD: %v", err))
 	}
 	manifestsTestDir := filepath.Join(cwd, "testdata")
 
 	Context("Render objects without files", func() {
 		It("Should return no objects", func() {
-			r := render.NewRenderer([]string{})
+			r := NewRenderer([]string{})
 			objs, err := r.RenderObjects(t)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(objs).To(BeEmpty())
@@ -75,7 +85,7 @@ var _ = Describe("Test Renderer via API", func() {
 
 	Context("Render objects from non-existent files", func() {
 		It("Should fail", func() {
-			r := render.NewRenderer([]string{filepath.Join(manifestsTestDir, "doesNotExist.yaml")})
+			r := NewRenderer([]string{filepath.Join(manifestsTestDir, "doesNotExist.yaml")})
 			objs, err := r.RenderObjects(t)
 			Expect(err).To(HaveOccurred())
 			Expect(objs).To(BeNil())
@@ -86,7 +96,7 @@ var _ = Describe("Test Renderer via API", func() {
 		It("Should fail", func() {
 			files := getFilesFromDir(filepath.Join(manifestsTestDir, "badManifests"))
 			for _, file := range files {
-				r := render.NewRenderer([]string{file})
+				r := NewRenderer([]string{file})
 				objs, err := r.RenderObjects(t)
 				Expect(err).To(HaveOccurred())
 				Expect(objs).To(BeNil())
@@ -96,7 +106,7 @@ var _ = Describe("Test Renderer via API", func() {
 
 	Context("Render objects from template with invalid template data", func() {
 		It("Should fail", func() {
-			r := render.NewRenderer(getFilesFromDir(filepath.Join(manifestsTestDir, "invalidManifests")))
+			r := NewRenderer(getFilesFromDir(filepath.Join(manifestsTestDir, "invalidManifests")))
 			objs, err := r.RenderObjects(t)
 			Expect(err).To(HaveOccurred())
 			Expect(objs).To(BeNil())
@@ -105,7 +115,7 @@ var _ = Describe("Test Renderer via API", func() {
 
 	Context("Render objects from valid manifests dir", func() {
 		It("Should return objects in order as appear in the directory lexicographically", func() {
-			r := render.NewRenderer(getFilesFromDir(filepath.Join(manifestsTestDir, "manifests")))
+			r := NewRenderer(getFilesFromDir(filepath.Join(manifestsTestDir, "manifests")))
 			objs, err := r.RenderObjects(t)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(objs)).To(Equal(3))
@@ -115,11 +125,162 @@ var _ = Describe("Test Renderer via API", func() {
 
 	Context("Render objects from valid manifests dir with mixed file suffixes", func() {
 		It("Should return objects in order as appear in the directory lexicographically", func() {
-			r := render.NewRenderer(getFilesFromDir(filepath.Join(manifestsTestDir, "mixedManifests")))
+			r := NewRenderer(getFilesFromDir(filepath.Join(manifestsTestDir, "mixedManifests")))
 			objs, err := r.RenderObjects(t)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(objs)).To(Equal(3))
 			checkRenderedUnstructured(objs, t.Data.(*templateData))
+		})
+	})
+})
+
+var _ = Describe("Test Renderer builtin template functions and edge cases", func() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get CWD: %v", err))
+	}
+	manifestsTestDir := filepath.Join(cwd, "testdata")
+
+	Context("Render template using the builtin 'yaml' function", func() {
+		It("Should marshal the provided data structure to yaml", func() {
+			content := strings.Join([]string{
+				"apiVersion: v1",
+				"kind: TestObjYaml",
+				"metadata:",
+				"  name: myname",
+				"spec:",
+				"{{ .Spec | yaml | indent 2 }}",
+			}, "\n")
+			file := writeTempManifest("yamlFunc.yaml", content)
+
+			data := &TemplatingData{
+				Data: struct {
+					Spec map[string]interface{}
+				}{
+					Spec: map[string]interface{}{"attribute": "value"},
+				},
+			}
+
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0].GetKind()).To(Equal("TestObjYaml"))
+			spec := objs[0].Object["spec"].(map[string]interface{})
+			Expect(spec["attribute"]).To(Equal("value"))
+		})
+	})
+
+	Context("Render template using the builtin 'deref' function", func() {
+		renderDeref := func(ptr *bool) []map[string]interface{} {
+			content := strings.Join([]string{
+				"apiVersion: v1",
+				"kind: TestObjDeref",
+				"metadata:",
+				"  name: deref",
+				"spec:",
+				"  enabled: {{ deref .Ptr }}",
+			}, "\n")
+			file := writeTempManifest("derefFunc.yaml", content)
+
+			data := &TemplatingData{
+				Data: struct{ Ptr *bool }{Ptr: ptr},
+			}
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objs).To(HaveLen(1))
+			specs := make([]map[string]interface{}, 0, len(objs))
+			for _, o := range objs {
+				specs = append(specs, o.Object["spec"].(map[string]interface{}))
+			}
+			return specs
+		}
+
+		It("Should return false for a nil pointer", func() {
+			specs := renderDeref(nil)
+			Expect(specs[0]["enabled"]).To(BeFalse())
+		})
+
+		It("Should return the dereferenced value for a non-nil pointer", func() {
+			trueVal := true
+			specs := renderDeref(&trueVal)
+			Expect(specs[0]["enabled"]).To(BeTrue())
+		})
+	})
+
+	Context("Render template using additional user-provided Funcs", func() {
+		It("Should apply the custom function during rendering", func() {
+			content := strings.Join([]string{
+				"apiVersion: v1",
+				"kind: TestObjFunc",
+				"metadata:",
+				"  name: {{ myUpper .Name }}",
+			}, "\n")
+			file := writeTempManifest("customFunc.yaml", content)
+
+			data := &TemplatingData{
+				Funcs: template.FuncMap{
+					"myUpper": strings.ToUpper,
+				},
+				Data: struct{ Name string }{Name: "lowered"},
+			}
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objs).To(HaveLen(1))
+			name := objs[0].Object["metadata"].(map[string]interface{})["name"].(string)
+			Expect(name).To(Equal("LOWERED"))
+		})
+	})
+
+	Context("Render template that fails to parse", func() {
+		It("Should fail with a parse error", func() {
+			// Unclosed template action triggers a parse-time error.
+			file := writeTempManifest("parseError.yaml", "kind: {{ .Foo")
+
+			data := &TemplatingData{
+				Data: struct{ Foo string }{Foo: "bar"},
+			}
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse manifest file"))
+			Expect(objs).To(BeNil())
+		})
+	})
+
+	Context("Render manifests that produce no objects", func() {
+		It("Should skip files whose rendered content is entirely whitespace", func() {
+			// The rendered output is whitespace only and deliberately contains a
+			// tab. Without renderFile's explicit whitespace-skip, this content
+			// would reach the YAML decoder and fail ("character that cannot start
+			// any token"), so this spec genuinely exercises the skip branch and
+			// would fail if it were removed.
+			file := writeTempManifest("whitespace.yaml", "{{/* renders nothing */}}\n \t \n")
+			data := &TemplatingData{Data: struct{}{}}
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objs).To(BeEmpty())
+		})
+
+		It("Should skip an empty file", func() {
+			file := filepath.Join(manifestsTestDir, "emptyManifests", "emptyTemplate.yaml")
+			data := &TemplatingData{Data: struct{}{}}
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objs).To(BeEmpty())
+		})
+
+		It("Should skip documents that decode to an object without a kind", func() {
+			file := filepath.Join(manifestsTestDir, "emptyManifests", "zeroObj.yaml")
+			data := &TemplatingData{Data: struct{}{}}
+			r := NewRenderer([]string{file})
+			objs, err := r.RenderObjects(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(objs).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
## Description

Adds unit tests to bring `internal/render` from 76.9% to **100%** statement coverage. Tests only — no production source changed.

The new tests cover the previously-untested paths in `renderFile`:
- the builtin `yaml` template function
- the builtin `deref` function (both nil and non-nil pointer branches)
- installation of user-provided template funcs (`data.Funcs != nil`)
- the template parse-error path (an unclosed action in a temp-file template)
- the whitespace-only render skip
- the empty-kind decoded-object skip

Tests follow the package's existing Ginkgo/Gomega convention, reuse the `testdata/emptyManifests` fixtures, and use `TempDir` for templates generated on the fly.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

```
go test ./internal/render/... -covermode=count    # coverage: 100.0% of statements
golangci-lint run ./internal/render/...            # 0 issues (GOOS=linux)
```