### PR TITLE
Add unit test for gpuPodSpecFilter container resource-list branch

### DIFF
--- a/cmd/gpu-operator/main_test.go
+++ b/cmd/gpu-operator/main_test.go
@@ -135,3 +135,77 @@ func TestGPUPodSpecFilterResourceClaims(t *testing.T) {
 		})
 	}
 }
+
+func resourcePod(phase corev1.PodPhase, containers ...corev1.Container) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: containers},
+		Status:     corev1.PodStatus{Phase: phase},
+	}
+}
+
+func gpuContainer(limits, requests corev1.ResourceList) corev1.Container {
+	return corev1.Container{Resources: corev1.ResourceRequirements{Limits: limits, Requests: requests}}
+}
+
+// TestGPUPodSpecFilterResourceList covers the container resource-list branch of
+// gpuPodSpecFilter (nvidia.com/gpu and nvidia.com/mig- in a container's
+// limits/requests, plus the Running/Pending phase gate). The sibling
+// TestGPUPodSpecFilterResourceClaims only exercises the DRA/ResourceClaims
+// branch, leaving this branch uncovered.
+//
+// gpuPodSpecFilter returns true when a pod should be treated as a GPU pod, so
+// each case's wantGPUPod field states the expected classification.
+func TestGPUPodSpecFilterResourceList(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	testCases := []struct {
+		name       string
+		pod        corev1.Pod
+		wantGPUPod bool
+	}{
+		{
+			name:       "running pod requesting nvidia.com/gpu in limits -> GPU pod",
+			pod:        resourcePod(corev1.PodRunning, gpuContainer(corev1.ResourceList{"nvidia.com/gpu": {}}, nil)),
+			wantGPUPod: true,
+		},
+		{
+			name:       "pending pod requesting nvidia.com/gpu in requests -> GPU pod",
+			pod:        resourcePod(corev1.PodPending, gpuContainer(nil, corev1.ResourceList{"nvidia.com/gpu": {}})),
+			wantGPUPod: true,
+		},
+		{
+			name:       "running pod requesting an nvidia.com/mig- resource -> GPU pod",
+			pod:        resourcePod(corev1.PodRunning, gpuContainer(corev1.ResourceList{"nvidia.com/mig-1g.5gb": {}}, nil)),
+			wantGPUPod: true,
+		},
+		{
+			name: "running pod where only a later container requests a gpu -> GPU pod",
+			pod: resourcePod(corev1.PodRunning,
+				gpuContainer(corev1.ResourceList{"cpu": {}}, nil),
+				gpuContainer(corev1.ResourceList{"nvidia.com/gpu": {}}, nil)),
+			wantGPUPod: true,
+		},
+		{
+			name:       "running pod requesting only cpu/memory -> not a GPU pod",
+			pod:        resourcePod(corev1.PodRunning, gpuContainer(corev1.ResourceList{"cpu": {}, "memory": {}}, nil)),
+			wantGPUPod: false,
+		},
+		{
+			name:       "succeeded pod requesting a gpu -> not a GPU pod (phase gate rejects it)",
+			pod:        resourcePod(corev1.PodSucceeded, gpuContainer(corev1.ResourceList{"nvidia.com/gpu": {}}, nil)),
+			wantGPUPod: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			gotGPUPod := gpuPodSpecFilter(t.Context(), c)(tc.pod)
+
+			require.Equal(t, tc.wantGPUPod, gotGPUPod)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`gpuPodSpecFilter` decides whether a pod is a GPU pod via two branches:
1. **container resource-list** — a container requesting `nvidia.com/gpu*` or `nvidia.com/mig-*` in its `limits`/`requests` (gated on the pod being `Running`/`Pending`), and
2. **DRA / ResourceClaims** — `PodHasNVIDIAGPUClaim(...)`.

The existing `TestGPUPodSpecFilterResourceClaims` covers only branch (2). Per the coverage report, branch (1) — the `nvidia.com/gpu` / `nvidia.com/mig-` prefix match and the container-loop `return true` — was **uncovered**.

This PR adds `TestGPUPodSpecFilterResourceList` to `cmd/gpu-operator/main_test.go` covering branch (1):
- `nvidia.com/gpu` in a container's `limits` and in `requests`
- the `nvidia.com/mig-` prefix
- a multi-container pod where only a later container requests a GPU
- a pod with only cpu/memory resources (not a GPU pod)
- the phase gate (a `Succeeded` pod with a GPU resource is ignored)

The pods carry no `ResourceClaims`, so the DRA branch resolves to `false` and only the resource-list branch is exercised. This complements the existing DRA test rather than duplicating it, bringing **`gpuPodSpecFilter` to 100% statement coverage**.

Tests only — no production changes.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

```
go test ./cmd/gpu-operator/... -covermode=count    # gpuPodSpecFilter: 100.0%
golangci-lint run ./cmd/gpu-operator/...           # 0 issues (GOOS=linux)
```