### PR TITLE
[DRA Driver] sync operator clusterrole with that of state-dra-driver

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -876,14 +876,6 @@ spec:
           - resource.nvidia.com
           resources:
           - computedomains
-          verbs:
-          - get
-          - list
-          - watch
-          - update
-        - apiGroups:
-          - resource.nvidia.com
-          resources:
           - computedomains/status
           verbs:
           - get

--- a/deployments/gpu-operator/templates/clusterrole.yaml
+++ b/deployments/gpu-operator/templates/clusterrole.yaml
@@ -171,14 +171,6 @@ rules:
   - resource.nvidia.com
   resources:
   - computedomains
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - resource.nvidia.com
-  resources:
   - computedomains/status
   verbs:
   - get


### PR DESCRIPTION
This bug should address the following error thrown when deploying a GPUCluster resource.

```
  status:                                                                                                                                                                                                                                        
    conditions:                                                                                                                                                                                                                                  
    - lastTransitionTime: "2026-07-24T00:18:36Z"                                                                                                                                                                                                 
      message: ""                                                                                                                                                                                                                                
      reason: Error                                                                                                                                                                                                                              
      status: "False"                                                                                                                                                                                                                            
      type: Ready                                                                                                                                                                                                                                
    - lastTransitionTime: "2026-07-24T00:18:36Z"                                                                                                                                                                                                 
      message: |-                                                                                                                                                                                                                                
        Error syncing state state-dra-driver: failed to create/update objects: clusterroles.rbac.authorization.k8s.io "compute-domain-daemon" is forbidden: user "system:serviceaccount:gpu-operator:gpu-operator" (groups=["system:serviceacco  
  nts" "system:serviceaccounts:gpu-operator" "system:authenticated"[]) is attempting to grant RBAC permissions not currently held:                                                                                                               
        {APIGroups:["resource.nvidia.com"], Resources:["computedomains"], Verbs:["patch"]}
```

This change aligns the ClusterRole used by the gpu-operator controller with the ClusterRole directly provisioned through the `state-dra-driver` templates.