### PR TITLE
[renovate] fix version detection for gds images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -145,6 +145,13 @@
       "versioning": "loose"
     },
     {
+      "description": "Keep only the base GDS version as the OS suffix is added at runtime",
+      "matchFileNames": ["deployments/gpu-operator/values.yaml"],
+      "matchPackageNames": ["nvcr.io/nvidia/cloud-native/nvidia-fs"],
+      "extractVersion": "^(?<version>v?\\d+\\.\\d+(?:\\.\\d+)?)(?:-.*)?$",
+      "versioning": "loose"
+    },
+    {
       "matchFileNames": ["bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml"],
       "matchPackageNames": ["nvcr.io/nvidia/cloud-native/gdrdrv"],
       "enabled": false


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Since OS info is appended at runtime, this fix makes renovate suggest right update for values.yaml file for GDS images.
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

