### PR TITLE
add finalizer directly to the GPUCluster manifest

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -158,7 +158,10 @@ metadata:
           "apiVersion": "nvidia.com/v1alpha1",
           "kind": "GPUCluster",
           "metadata": {
-            "name": "gpu-cluster"
+            "name": "gpu-cluster",
+            "finalizers": [
+              "gpucluster.nvidia.com/dra-resourceclaim"
+            ]
           },
           "spec": {
             "draDriver": {

--- a/deployments/gpu-operator/templates/gpucluster.yaml
+++ b/deployments/gpu-operator/templates/gpucluster.yaml
@@ -10,6 +10,8 @@ metadata:
   # keep helm from also deleting it.
   annotations:
     "helm.sh/resource-policy": keep
+  finalizers:
+  - gpucluster.nvidia.com/dra-resourceclaim
 spec:
   draDriver:
     {{- if .Values.draDriver.repository }}


### PR DESCRIPTION
This PR adds the finaliser inline to the GPUCluster resource manifests. This is done for readability reasons and it also shaves off an kube client UPDATE call