### PR TITLE
Fix DCGM exporter Kubernetes mode override

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -2628,15 +2628,26 @@ func getContainerEnv(c *corev1.Container, key string) string {
 }
 
 func setContainerEnv(c *corev1.Container, key, value string) {
-	for i, val := range c.Env {
-		if val.Name != key {
+	for index := 0; index < len(c.Env); index++ {
+		if c.Env[index].Name != key {
 			continue
 		}
 
-		c.Env[i].Value = value
+		c.Env[index].Value = value
+		c.Env = append(c.Env[:index+1], removeDuplicateEnvVars(c.Env[index+1:], key)...)
 		return
 	}
 	c.Env = append(c.Env, corev1.EnvVar{Name: key, Value: value})
+}
+
+func removeDuplicateEnvVars(env []corev1.EnvVar, key string) []corev1.EnvVar {
+	result := env[:0]
+	for _, variable := range env {
+		if variable.Name != key {
+			result = append(result, variable)
+		}
+	}
+	return result
 }
 
 // findContainerByName returns a pointer to the container with the given name, or nil if not found.

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -1353,6 +1353,37 @@ func TestTransformDCGMExporter(t *testing.T) {
 			}).WithContainer(corev1.Container{Name: "dummy"}).WithPullSecret("pull-secret").WithRuntimeClassName("nvidia").WithHostPID(true),
 		},
 		{
+			description: "transform dcgm exporter overrides kubernetes environment variable",
+			ds: NewDaemonset().
+				WithContainer(corev1.Container{
+					Name: "dcgm-exporter",
+					Env: []corev1.EnvVar{
+						{Name: "DCGM_EXPORTER_KUBERNETES", Value: "true"},
+						{Name: "DCGM_EXPORTER_KUBERNETES", Value: "false"},
+					},
+				}).
+				WithContainer(corev1.Container{Name: "dummy"}),
+			cpSpec: &gpuv1.ClusterPolicySpec{
+				DCGMExporter: gpuv1.DCGMExporterSpec{
+					Repository: "nvcr.io/nvidia/cloud-native",
+					Image:      "dcgm-exporter",
+					Version:    "v1.0.0",
+					Env: []gpuv1.EnvVar{
+						{Name: "DCGM_EXPORTER_KUBERNETES", Value: "false"},
+					},
+				},
+			},
+			expectedDs: NewDaemonset().WithContainer(corev1.Container{
+				Name:            "dcgm-exporter",
+				Image:           "nvcr.io/nvidia/cloud-native/dcgm-exporter:v1.0.0",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Env: []corev1.EnvVar{
+					{Name: "DCGM_EXPORTER_KUBERNETES", Value: "false"},
+					{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "nvidia-dcgm:5555"},
+				},
+			}).WithContainer(corev1.Container{Name: "dummy"}).WithRuntimeClassName("nvidia"),
+		},
+		{
 			description: "transform dcgm exporter with hostPID disabled",
 			ds: NewDaemonset().
 				WithContainer(corev1.Container{Name: "dcgm-exporter"}).


### PR DESCRIPTION
Allow `spec.dcgmExporter.env` to override `DCGM_EXPORTER_KUBERNETES` without leaving duplicate environment variables in the rendered DaemonSet.

Add a regression test covering the default `true` value overridden to `false`.

Fixes #2674