### PR TITLE
Skip GPU resource validation when device plugin is disabled on the node

### DIFF
--- a/cmd/nvidia-validator/main.go
+++ b/cmd/nvidia-validator/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,6 +49,7 @@ import (
 
 	nvidiav1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
+	"github.com/NVIDIA/gpu-operator/internal/consts"
 	"github.com/NVIDIA/gpu-operator/internal/driver"
 	"github.com/NVIDIA/gpu-operator/internal/info"
 	"github.com/NVIDIA/gpu-operator/internal/utils"
@@ -234,6 +236,10 @@ const (
 	gpuWorkloadConfigVMVgpu        = "vm-vgpu"
 	// CCCapableLabelKey represents NFD label name to indicate if the node is capable to run CC workloads
 	CCCapableLabelKey = "nvidia.com/cc.capable"
+	// devicePluginDeployLabelKey gates whether the nvidia-device-plugin DaemonSet
+	// is scheduled on the node. Users set it to "false" to disable the plugin per
+	// node (for example, to hand GPU allocation off to a DRA driver).
+	devicePluginDeployLabelKey = "nvidia.com/gpu.deploy.device-plugin"
 	// appComponentLabelKey indicates the label key of the component
 	appComponentLabelKey = "app.kubernetes.io/component"
 	// wslNvidiaSMIPath indicates the path to the nvidia-smi binary on WSL
@@ -1193,6 +1199,10 @@ func (p *Plugin) validate() error {
 	p.setKubeClient(kubeClient)
 
 	err = p.validateGPUResource()
+	if errors.Is(err, errDevicePluginDisabled) {
+		log.Info("Device plugin is disabled on this node, skipping GPU resource validation")
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -1444,7 +1454,43 @@ func (p *Plugin) countGPUResources() (int64, error) {
 	return count, nil
 }
 
+// errDevicePluginDisabled signals validate() that the device plugin is not
+// expected to publish GPU capacity on this node, so plugin validation should be
+// skipped without failing the operator-validator pod. Returned by
+// validateGPUResource when isDevicePluginDisabledOnNode holds for the node.
+var errDevicePluginDisabled = errors.New("device plugin is disabled on this node")
+
+// isDevicePluginDisabledOnNode reports whether the nvidia-device-plugin is
+// intentionally not running on the given node, either because a user explicitly
+// disabled it via nvidia.com/gpu.deploy.device-plugin=false or because the node
+// has been switched to the DRA resource-allocation stack. In either case the
+// classic operator-validator's plugin-validation step must not wait for GPU
+// capacity that will never appear.
+func isDevicePluginDisabledOnNode(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	nodeLabels := node.GetLabels()
+	if nodeLabels[devicePluginDeployLabelKey] == "false" {
+		return true
+	}
+	if nodeLabels[consts.GPUAllocationModeLabelKey] == string(consts.GPUAllocationModeDRA) {
+		return true
+	}
+	return false
+}
+
 func (p *Plugin) validateGPUResource() error {
+	// Skip the retry loop entirely when the device plugin is not expected to
+	// advertise GPU capacity on this node (per-node disable or DRA mode).
+	node, err := getNode(p.ctx, p.kubeClient)
+	if err != nil {
+		return fmt.Errorf("unable to fetch node by name %s to check for GPU resources: %s", nodeNameFlag, err)
+	}
+	if isDevicePluginDisabledOnNode(node) {
+		return errDevicePluginDisabled
+	}
+
 	for retry := 1; retry <= gpuResourceDiscoveryWaitRetries; retry++ {
 		// get node info to check discovered GPU resources
 		node, err := getNode(p.ctx, p.kubeClient)

--- a/cmd/nvidia-validator/main_test.go
+++ b/cmd/nvidia-validator/main_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestResolveHostNvidiaSMI(t *testing.T) {
@@ -373,6 +375,87 @@ UNKNOWN_FEATURE: true`,
 					t.Errorf("validateAdditionalDriverComponents() unexpected error: %v", err)
 				}
 			}
+		})
+	}
+}
+
+func TestIsDevicePluginDisabledOnNode(t *testing.T) {
+	tests := []struct {
+		name   string
+		node   *corev1.Node
+		wantOK bool
+	}{
+		{
+			name:   "nil node is treated as plugin-enabled",
+			node:   nil,
+			wantOK: false,
+		},
+		{
+			name:   "node with no labels is plugin-enabled",
+			node:   &corev1.Node{},
+			wantOK: false,
+		},
+		{
+			name: "device-plugin label absent, other labels present",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"foo": "bar",
+			}}},
+			wantOK: false,
+		},
+		{
+			name: "device-plugin explicitly true keeps validation active",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin": "true",
+			}}},
+			wantOK: false,
+		},
+		{
+			name: "device-plugin explicitly false triggers skip",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin": "false",
+			}}},
+			wantOK: true,
+		},
+		{
+			name: "device-plugin empty value is not treated as disabled",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin": "",
+			}}},
+			wantOK: false,
+		},
+		{
+			name: "device-plugin paused value is not treated as disabled",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin": "paused-for-driver-upgrade",
+			}}},
+			wantOK: false,
+		},
+		{
+			name: "resource-allocation mode dra triggers skip",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu-operator.resource-allocation.mode": "dra",
+			}}},
+			wantOK: true,
+		},
+		{
+			name: "resource-allocation mode device-plugin does not skip",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu-operator.resource-allocation.mode": "device-plugin",
+			}}},
+			wantOK: false,
+		},
+		{
+			name: "both signals set to skip still skips",
+			node: &corev1.Node{ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{
+				"nvidia.com/gpu.deploy.device-plugin":              "false",
+				"nvidia.com/gpu-operator.resource-allocation.mode": "dra",
+			}}},
+			wantOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantOK, isDevicePluginDisabledOnNode(tt.node))
 		})
 	}
 }


### PR DESCRIPTION
- Fixes the CrashLoopBackOff of `nvidia-operator-validator` on nodes where the user has intentionally disabled the device plugin via `nvidia.com/gpu.deploy.device-plugin=false`, by short-circuiting `Plugin.validateGPUResource` with a sentinel error when the label is set.
- Also skips validation on nodes labeled `nvidia.com/gpu-operator.resource-allocation.mode=dra`, so the classic validator no-ops cleanly on nodes migrated to the DRA stack (belt-and-suspenders during reconciliation windows).
- No status file is written on the skip path, so the metrics exporter and any downstream reader correctly see "not validated" rather than a false-positive "plugin-ready".

## Test plan
- [x] `go vet ./cmd/nvidia-validator/` clean
- [x] `go test ./cmd/nvidia-validator/` all pass, including 10 new subtests
- [x] End-to-end verified on kind , see session below

### Local tests with kind

<details>
  <summary>Kind local tests output</summary>

```bash

# Build the validator from this branch for the kind node arch
CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
go build -o /tmp/gpu-op-2550-test/nvidia-validator ./cmd/nvidia-validator

DOCKER_BUILDKIT=0 docker build -t nvidia-validator-2550:test /tmp/gpu-op-2550-test

# Cluster + image load
kind create cluster --name gpu-op-2550
kind load docker-image nvidia-validator-2550:test --name gpu-op-2550

# Namespace + SA + ClusterRole granting nodes:get
kubectl apply -f /tmp/gpu-op-2550-test/rbac.yaml

The reused Pod spec runs only the plugin component with
WITH_WAIT=false, WITH_WORKLOAD=false:

apiVersion: v1
kind: Pod
metadata:
name: plugin-validation
namespace: gpu-op-test
spec:
serviceAccountName: validator
restartPolicy: Never
containers:
- name: plugin-validation
    image: nvidia-validator-2550:test
    imagePullPolicy: IfNotPresent
    command: ["sh", "-c"]
    args: ["nvidia-validator 2>&1; echo EXIT=$?"]
    env:
    - {name: COMPONENT, value: plugin}
    - {name: WITH_WAIT, value: "false"}
    - {name: WITH_WORKLOAD, value: "false"}
    - {name: NODE_NAME, valueFrom: {fieldRef: {fieldPath: spec.nodeName}}}
    - {name: OPERATOR_NAMESPACE, value: gpu-op-test}
    - {name: OUTPUT_DIR, value: /tmp}

- Bug validation:

$ kubectl get node gpu-op-2550-control-plane --show-labels | grep -oE 'nvidia\.com/[^,]*'
(no nvidia.com/* labels)

$ kubectl apply -f plugin-validation-pod.yaml
pod/plugin-validation created

$ kubectl -n gpu-op-test logs plugin-validation
time="2026-07-28T12:49:00Z" level=info msg="version: unknown"
time="2026-07-28T12:49:00Z" level=info msg="GPU resources are not yet discovered by the node, retry: 1"
time="2026-07-28T12:49:05Z" level=info msg="GPU resources are not yet discovered by the node, retry: 2"
time="2026-07-28T12:49:10Z" level=info msg="GPU resources are not yet discovered by the node, retry: 3"
time="2026-07-28T12:49:15Z" level=info msg="GPU resources are not yet discovered by the node, retry: 4"
time="2026-07-28T12:49:20Z" level=info msg="GPU resources are not yet discovered by the node, retry: 5"

Matches the symptom in the issue: 30 retries × 5 s → non-zero exit → CrashLoopBackOff.

- Fix path with deploy.device-plugin=false 

$ kubectl label node gpu-op-2550-control-plane \
    nvidia.com/gpu.deploy.device-plugin=false --overwrite node/gpu-op-2550-control-plane labeled

$ kubectl apply -f plugin-validation-pod.yaml
pod/plugin-validation created

$ kubectl -n gpu-op-test get pod plugin-validation
NAME                READY   STATUS      RESTARTS   AGE
plugin-validation   0/1     Completed   0          5s

$ kubectl -n gpu-op-test logs plugin-validation
time="2026-07-28T12:50:42Z" level=info msg="version: unknown"
time="2026-07-28T12:50:42Z" level=info msg="Device plugin is disabled on this node, skipping GPU resource validation"
EXIT=0

Extra check that no plugin-ready status file is created (probe pod runs the validator, then ls /tmp/):

$ kubectl -n gpu-op-test logs probe-b
time="2026-07-28T12:51:08Z" level=info msg="version: unknown"
time="2026-07-28T12:51:08Z" level=info msg="Device plugin is disabled on this node, skipping GPU resource validation"
---
total 8
drwxrwxrwt    2 root     root          4096 Oct  8  2025 .
drwxr-xr-x    1 root     root          4096 Jul 28 12:51 ..
EXIT=0

/tmp is empty, downstream consumers correctly see "not validated."

- Fix path with resource-allocation.mode=dra 

$ kubectl label node gpu-op-2550-control-plane nvidia.com/gpu.deploy.device-plugin-node/gpu-op-2550-control-plane unlabeled

$ kubectl label node gpu-op-2550-control-plane \
    nvidia.com/gpu-operator.resource-allocation.mode=dra --overwrite
node/gpu-op-2550-control-plane labeled

$ kubectl apply -f plugin-validation-pod.yaml
pod/plugin-validation created

$ kubectl -n gpu-op-test get pod plugin-validation
NAME                READY   STATUS      RESTARTS   AGE
plugin-validation   0/1     Completed   0          5s

$ kubectl -n gpu-op-test logs plugin-validation
time="2026-07-28T12:51:43Z" level=info msg="version: unknown"
time="2026-07-28T12:51:43Z" level=info msg="Device plugin is disabled on this node, skipping GPU resource validation"
EXIT=0

- Negative control: deploy.device-plugin=true, old retry behavior preserved

$ kubectl label node gpu-op-2550-control-plane \
    nvidia.com/gpu-operator.resource-allocation.mode-
node/gpu-op-2550-control-plane unlabeled

$ kubectl label node gpu-op-2550-control-plane \
    nvidia.com/gpu.deploy.device-plugin=true --overwrite
node/gpu-op-2550-control-plane labeled

$ kubectl apply -f plugin-validation-pod.yaml
pod/plugin-validation created

$ kubectl -n gpu-op-test get pod plugin-validation
NAME                READY   STATUS    RESTARTS   AGE
plugin-validation   1/1     Running   0          18s

$ kubectl -n gpu-op-test logs plugin-validation | tail -5
time="2026-07-28T12:52:11Z" level=info msg="version: unknown"
time="2026-07-28T12:52:11Z" level=info msg="GPU resources are not yet discovered by the node, retry: 1"
time="2026-07-28T12:52:16Z" level=info msg="GPU resources are not yet discovered by the node, retry: 2"
time="2026-07-28T12:52:21Z" level=info msg="GPU resources are not yet discovered by the node, retry: 3"
time="2026-07-28T12:52:26Z" level=info msg="GPU resources are not yet discovered by the node, retry: 4"

Retry loop unchanged proves the fix is strictly additive.

- Edge case: deploy.device-plugin=paused-for-driver-upgrade, not treated as disabled

$ kubectl label node gpu-op-2550-control-plane \
    nvidia.com/gpu.deploy.device-plugin=paused-for-driver-upgrade --overwrite
node/gpu-op-2550-control-plane labeled

$ kubectl apply -f plugin-validation-pod.yaml
pod/plugin-validation created

$ kubectl -n gpu-op-test get pod plugin-validation
NAME                READY   STATUS    RESTARTS   AGE
plugin-validation   1/1     Running   0          12s

$ kubectl -n gpu-op-test logs plugin-validation | tail -4
time="2026-07-28T12:53:20Z" level=info msg="version: unknown"
time="2026-07-28T12:53:20Z" level=info msg="GPU resources are not yet discovered by the node, retry: 1"
time="2026-07-28T12:53:25Z" level=info msg="GPU resources are not yet discovered by the node, retry: 2"
time="2026-07-28T12:53:30Z" level=info msg="GPU resources are not yet discovered by the node, retry: 3"
```
</details>
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-cloud.devinenterprise.com/review/nvidia/gpu-operator/pull/2686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->