### PR TITLE
add support for Oracle Linux

### DIFF
--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -216,6 +216,7 @@ var RepoConfigPathMap = map[string]string{
 	"rhcos":    "/etc/yum.repos.d",
 	"rhel":     "/etc/yum.repos.d",
 	"rocky":    "/etc/yum.repos.d",
+	"ol":       "/etc/yum.repos.d",
 	"sles":     "/etc/zypp/repos.d",
 	"sl-micro": "/etc/zypp/repos.d",
 }
@@ -231,6 +232,7 @@ var CertConfigPathMap = map[string]string{
 	"rhcos":    "/etc/pki/ca-trust/extracted/pem",
 	"rhel":     "/etc/pki/ca-trust/extracted/pem",
 	"rocky":    "/etc/pki/ca-trust/extracted/pem",
+	"ol":       "/etc/pki/ca-trust/extracted/pem",
 	"sles":     "/etc/pki/trust/anchors",
 	"sl-micro": "/etc/pki/trust/anchors",
 }

--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -610,9 +610,9 @@ func (n *ClusterPolicyController) getGPUNodeOSInfo() (string, string, error) {
 	if !ok {
 		return "", "", fmt.Errorf("unable to retrieve OS version from label %s", nfdOSVersionIDLabelKey)
 	}
-	// If the OS is RockyLinux or RHEL, we will omit the minor version when constructing the os image tag
+	// If the OS is RockyLinux, Oracle Linux or RHEL, we will omit the minor version when constructing the os image tag
 	switch osName {
-	case "rocky", "rhel":
+	case "ol", "rocky", "rhel":
 		osVersion = strings.Split(osVersion, ".")[0]
 	}
 	osTag := fmt.Sprintf("%s%s", osName, osVersion)

--- a/controllers/state_manager_test.go
+++ b/controllers/state_manager_test.go
@@ -73,6 +73,12 @@ func TestGetGPUNodeOSInfo(t *testing.T) {
 			expected:  "rocky9",
 		},
 		{
+			name:      "ol omits minor version",
+			osName:    "ol",
+			osVersion: "9.5",
+			expected:  "ol9",
+		},
+		{
 			name:      "ubuntu preserves full version",
 			osName:    "ubuntu",
 			osVersion: "24.04",

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -795,6 +795,14 @@ func TestGetDriverAppName(t *testing.T) {
 	actual = getDriverAppName(cr, pool)
 	assert.Equal(t, "nvidia-gpu-driver-rocky9-59b779bcc5", actual)
 
+	// Oracle Linux
+	pool.osRelease = "ol"
+	pool.osVersion = "9.7"
+	pool.osTag, err = getOSTag(pool.osRelease, pool.osVersion)
+	assert.NoError(t, err)
+	actual = getDriverAppName(cr, pool)
+	assert.Equal(t, "nvidia-gpu-driver-ol9-59b779bcc5", actual)
+
 	// RHEL10
 	pool.osRelease = "rhel"
 	pool.osVersion = "10.1"

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -38,6 +38,7 @@ var RepoConfigPathMap = map[string]string{
 	"rhcos":    "/etc/yum.repos.d",
 	"rhel":     "/etc/yum.repos.d",
 	"rocky":    "/etc/yum.repos.d",
+	"ol":       "/etc/yum.repos.d",
 	"sles":     "/etc/zypp/repos.d",
 	"sl-micro": "/etc/zypp/repos.d",
 }
@@ -53,6 +54,7 @@ var CertConfigPathMap = map[string]string{
 	"rhcos":    "/etc/pki/ca-trust/extracted/pem",
 	"rhel":     "/etc/pki/ca-trust/extracted/pem",
 	"rocky":    "/etc/pki/ca-trust/extracted/pem",
+	"ol":       "/etc/pki/ca-trust/extracted/pem",
 	"sles":     "/etc/pki/trust/anchors",
 	"sl-micro": "/etc/pki/trust/anchors",
 }

--- a/internal/state/nodepool.go
+++ b/internal/state/nodepool.go
@@ -143,9 +143,9 @@ func getNodePools(ctx context.Context, k8sClient client.Client, cr *nvidiav1alph
 
 func getOSTag(osRelease, osVersion string) (string, error) {
 	var osTagSuffix string
-	// If the OS is RockyLinux or RHEL, we will omit the minor version when constructing the os image tag
+	// If the OS is RockyLinux, Oracle Linux or RHEL, we will omit the minor version when constructing the os image tag
 	switch osRelease {
-	case "rocky", "rhel":
+	case "ol", "rocky", "rhel":
 		osTagSuffix = strings.Split(osVersion, ".")[0]
 	default:
 		osTagSuffix = osVersion

--- a/internal/state/nodepool_test.go
+++ b/internal/state/nodepool_test.go
@@ -69,6 +69,13 @@ func TestGetOSTag(t *testing.T) {
 			expectError: false,
 		},
 		{
+			description: "oracle linux",
+			osRelease:   "ol",
+			osVersion:   "9.4",
+			expected:    "ol9",
+			expectError: false,
+		},
+		{
 			description: "RHEL 10",
 			osRelease:   "rhel",
 			osVersion:   "10.1",


### PR DESCRIPTION
This PR is a clone of #2543, the original author has been attributed. With this change, the gpu-operator would be able to render the necessary driver daemonset mounts to run on Oracle Linux systems. 

Description of the original PR below:

## Description

Adds support for Oracle Linux nodes (os-release `ID=ol`), mirroring the existing Rocky Linux support

## Why

Nodes running Oracle Linux are detected via the NFD label `feature.node.kubernetes.io/system-os_release.ID=ol`. So this PR brings support Oracle Linux OS. 

## Testing

* **Tests**: new cases in `TestGetGPUNodeOSInfo` and `TestGetOSTag` covering Oracle Linux 9 and 10.