### PR TITLE
use prometheus native duration for timestamp arithmetic

### DIFF
--- a/assets/state-operator-metrics/0400_prometheus_rule_openshift.yaml
+++ b/assets/state-operator-metrics/0400_prometheus_rule_openshift.yaml
@@ -10,10 +10,8 @@ spec:
   - name: Alert on GPU Operator operator reconciliation failure
     rules:
     - alert: GPUOperatorReconciliationFailed
-      expr: |
-        gpu_operator_reconciliation_status != 1
-        AND
-        (time() - gpu_operator_reconciliation_last_success_ts_seconds > 3600)
+      expr: gpu_operator_reconciliation_status != 1
+      for: 1h
       labels:
         severity: warning
       annotations:
@@ -30,9 +28,8 @@ spec:
       expr: |
         gpu_operator_reconciliation_status != 1
         AND
-        (time() - gpu_operator_reconciliation_last_success_ts_seconds > 1800)
-        AND
         gpu_operator_reconciliation_has_nfd_labels == 0
+      for: 30m
       labels:
         severity: warning
       annotations:


### PR DESCRIPTION
## Description

Fix false-positive GPU Operator reconciliation alerts by using Prometheus alert durations instead of the age of the last successful reconciliation timestamp.
Both GPUOperatorReconciliationFailed and GPUOperatorReconciliationFailedNfdLabelsMissing now use for: 1h and for: 30m, respectively. This ensures they fire only when the reconciliation failure condition persists for the configured duration.

`gpu_operator_reconciliation_last_success_ts_seconds` is reset on operator restart and is only updated after a fully successful reconcile. As a result, its age does not accurately represent how long reconciliation has been failing, causing alerts to fire after restarts or brief transient status changes during normal steady-state operation.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

