### PR TITLE
Enable DCGM exporter DRA attribution when pod metadata is enabled

### DIFF
--- a/internal/state/gpucluster_render_test.go
+++ b/internal/state/gpucluster_render_test.go
@@ -131,6 +131,18 @@ func TestGPUClusterRenderGolden(t *testing.T) {
 			},
 		},
 		{
+			// enablePodLabels: pod metadata mounts the ServiceAccount token and adds
+			// the DRA/pod-labels env and the read-pods ClusterRole/Binding.
+			name: "gpucluster-dcgm-exporter-pod-metadata",
+			render: func(t *testing.T) []*unstructured.Unstructured {
+				s := newTestDCGMExporterState(t, false)
+				cr := exporterCR(&nvidiav1.DCGMExporterSpec{EnablePodLabels: ptr.To(true)})
+				objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
+				require.NoError(t, err)
+				return objs
+			},
+		},
+		{
 			// dcgm enabled: the exporter wires DCGM_REMOTE_HOSTENGINE_INFO to the
 			// standalone hostengine Service.
 			name: "gpucluster-dcgm-exporter-remote-engine",

--- a/internal/state/testdata/golden/gpucluster-dcgm-exporter-pod-metadata.yaml
+++ b/internal/state/testdata/golden/gpucluster-dcgm-exporter-pod-metadata.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+rules:
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra-read-pods
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nvidia-dcgm-exporter-dra
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra-read-pods
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nvidia-dcgm-exporter-dra-read-pods
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: nvidia-dcgm-exporter-admin
+  namespace: test-operator
+spec:
+  spec:
+    devices:
+      requests:
+      - exactly:
+          adminAccess: true
+          allocationMode: All
+          deviceClassName: gpu.nvidia.com
+        name: admin-gpus
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+spec:
+  ports:
+  - name: gpu-metrics
+    port: 9400
+    protocol: TCP
+    targetPort: 9400
+  selector:
+    app: nvidia-dcgm-exporter-dra
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter-dra
+  template:
+    metadata:
+      labels:
+        app: nvidia-dcgm-exporter-dra
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - env:
+        - name: DCGM_EXPORTER_LISTEN
+          value: :9400
+        - name: DCGM_EXPORTER_KUBERNETES
+          value: "true"
+        - name: DCGM_EXPORTER_COLLECTORS
+          value: /etc/dcgm-exporter/dcp-metrics-included.csv
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: KUBERNETES_ENABLE_DRA
+          value: "true"
+        - name: DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS
+          value: "true"
+        image: nvcr.io/nvidia/k8s/dcgm-exporter:test
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9400
+          initialDelaySeconds: 45
+          periodSeconds: 5
+        name: nvidia-dcgm-exporter-dra
+        ports:
+        - containerPort: 9400
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9400
+          initialDelaySeconds: 45
+        resources:
+          claims:
+          - name: admin-gpus
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/pod-resources
+          name: pod-gpu-resources
+          readOnly: true
+      nodeSelector:
+        nvidia.com/gpu-operator.resource-allocation.mode: dra
+        nvidia.com/gpu.deploy.dcgm-exporter: "true"
+      priorityClassName: system-node-critical
+      resourceClaims:
+      - name: admin-gpus
+        resourceClaimTemplateName: nvidia-dcgm-exporter-admin
+      serviceAccountName: nvidia-dcgm-exporter-dra
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/pod-resources
+        name: pod-gpu-resources
+  updateStrategy:
+    type: RollingUpdate
+---

--- a/manifests/state-dcgm-exporter/0210_clusterrole.yaml
+++ b/manifests/state-dcgm-exporter/0210_clusterrole.yaml
@@ -14,4 +14,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/manifests/state-dcgm-exporter/0700_daemonset.yaml
+++ b/manifests/state-dcgm-exporter/0700_daemonset.yaml
@@ -100,6 +100,10 @@ spec:
         - name: DCGM_HPC_JOB_MAPPING_DIR
           value: {{ .HPCJobMappingDir | quote }}
         {{- end }}
+        {{- if .PodMetadataEnabled }}
+        - name: KUBERNETES_ENABLE_DRA
+          value: "true"
+        {{- end }}
         {{- if .EnablePodLabels }}
         - name: DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS
           value: "true"


### PR DESCRIPTION
The DRA DCGM exporter DaemonSet never sets `KUBERNETES_ENABLE_DRA`, and its ClusterRole has no `resource.k8s.io` read access, so metrics on DRA nodes carry no pod/claim attribution even with `dcgmExporter.enablePodLabels` set.

Render both under the existing `PodMetadataEnabled` gate: the env var on the DaemonSet, and `resourceslices` get/list/watch on the ClusterRole. The grant matches the upstream dcgm-exporter chart's [clusterrole.yaml](https://github.com/NVIDIA/dcgm-exporter/blob/main/deployment/templates/clusterrole.yaml), but as a separate rule: upstream's combined pods+resourceslices rule cross-products into permissions the operator does not hold, so RBAC escalation prevention rejects the create when the operator (rather than an admin running helm) applies it. No `resourceclaims` grant is needed — the exporter's DRA path is a single ResourceSlice informer, and claim attribution comes from the kubelet PodResources socket.

Adds a `gpucluster-dcgm-exporter-pod-metadata` render golden covering the pod-metadata-enabled manifests.

Validated on a T4 node: with `enablePodLabels: true`, the operator renders the ClusterRole without escalation errors and metrics include `pod`, `namespace`, `container`, and `dra_*` labels for DRA-allocated GPUs.