### PR TITLE
[state-dra-driver][compute-domain] set GPU_CLIQUE_LABEL_ENABLED to true by default

### DIFF
--- a/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
@@ -571,6 +571,8 @@ spec:
           value: /var/lib/kubelet/plugins
         - name: HEALTHCHECK_PORT
           value: "51515"
+        - name: GPU_CLIQUE_LABEL_ENABLED
+          value: "true"
         - name: FEATURE_GATES
           value: AdminAccess=false,MPSSupport=true
         - name: CD_PLUGIN_EXTRA

--- a/manifests/state-dra-driver/0500_daemonset.yaml
+++ b/manifests/state-dra-driver/0500_daemonset.yaml
@@ -286,6 +286,8 @@ spec:
           value: {{ printf "%s/plugins" (.HostPaths.KubeletRootDir | default "/var/lib/kubelet") | quote }}
         - name: HEALTHCHECK_PORT
           value: {{ .ComputeDomainsHealthcheckPort | quote }}
+        - name: GPU_CLIQUE_LABEL_ENABLED
+          value: "true"
         {{- if .FeatureGates }}
         - name: FEATURE_GATES
           value: {{ .FeatureGates | quote }}


### PR DESCRIPTION
With `GPUCluster`, we no longer deploy the GFD which generates the clique label depended on by the compute domain kubelet plugin. The `GPU_CLIQUE_LABEL_ENABLED` is an env var which configures the compute domain to set the clique node label instead of GFD. Given that GFD is no longer an operator component in the DRA mode, we always set env var to true when rendering the compute domain kubelet plugin daemonset manifest.