### PR TITLE
Decouple host drivers and shutdown

### DIFF
--- a/assets/state-mig-manager/0420_configmap.yaml
+++ b/assets/state-mig-manager/0420_configmap.yaml
@@ -14,13 +14,13 @@ data:
       echo "waiting for the driver validations to be ready..."
       sleep 5
     done
-    
+
     set -o allexport
     cat /run/nvidia/validations/driver-ready
     . /run/nvidia/validations/driver-ready
       
     # manually export additional envs required by mig-manager
-    export WITH_SHUTDOWN_HOST_GPU_CLIENTS=$IS_HOST_DRIVER
+    export WITH_SHUTDOWN_HOST_GPU_CLIENTS=${WITH_SHUTDOWN_HOST_GPU_CLIENTS:-$IS_HOST_DRIVER}
     echo "WITH_SHUTDOWN_HOST_GPU_CLIENTS=$WITH_SHUTDOWN_HOST_GPU_CLIENTS"
 
     echo "Starting nvidia-mig-manager"


### PR DESCRIPTION
## Description

Decouple the host shutdown flag from the host driver flag. This adds support for systems that have the NVIDIA drivers installed locally but do not run `systemd`, for example Talos. The user can install the drivers via system extension but set `WITH_SHUTDOWN_HOST_GPU_CLIENTS=false` via Helm values to disable all code paths in the MIG manager that depend on `systemd`.

This requires a change to the chart because the entrypoint for the MIG manager is managed by the operator and the variable is set here. The user can't override the value or modify the `ConfigMap`; the former approach would have no effect and the latter approach would be immediately reverted by the operator.

See discussions in https://github.com/NVIDIA/mig-parted/pull/382 and the parent issue https://github.com/NVIDIA/mig-parted/issues/356.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
  - Skipped since no Go changes
- [ ] Generated assets in-sync (`make validate-generated-assets`)
  - Didn't work, although not sure why
     ```
      - Generating CRDs from the codebase
      $PATH_TO_REPO/bin/controller-gen rbac:roleName=gpu-operator-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
      -: build constraints exclude all Go files in $PATH_TO_REPO/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite
      Error: not all generators ran successfully
      run `controller-gen rbac:roleName=gpu-operator-role crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen rbac:roleName=gpu-operator-role crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
      make: *** [manifests] Error 1
      ```

- [ ] Go mod artifacts in-sync (`make validate-modules`)
  - Again, no code changes
- [ ] Test cases are added for new code paths
  - No new code paths

## Testing

Tested manually on a Kubernetes cluster running the aforementioned patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly configured GPU client shutdown behavior while providing a fallback based on the host driver status when no value is supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->