### PR TITLE
Render daemonsets.podSecurityContext in Helm ClusterPolicy template

### DIFF
--- a/deployments/gpu-operator/templates/clusterpolicy.yaml
+++ b/deployments/gpu-operator/templates/clusterpolicy.yaml
@@ -56,6 +56,9 @@ spec:
     rollingUpdate:
       maxUnavailable: {{ .Values.daemonsets.rollingUpdate.maxUnavailable | quote }}
     {{- end }}
+    {{- if .Values.daemonsets.podSecurityContext }}
+    podSecurityContext: {{ toYaml .Values.daemonsets.podSecurityContext | nindent 6 }}
+    {{- end }}
   validator:
     {{- if .Values.validator.repository }}
     repository: {{ .Values.validator.repository }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -54,6 +54,14 @@ daemonsets:
     # maximum number of nodes to simultaneously apply pod updates on.
     # can be specified either as number or percentage of nodes. Default 1.
     maxUnavailable: "1"
+  # Optional: pod-level security context applied to ALL operand DaemonSets.
+  # Example (SELinux):
+  # podSecurityContext:
+  #   seLinuxOptions:
+  #     type: spc_t
+  #     level: s0
+  # Note: This must be rendered into ClusterPolicy by the Helm template.
+  # Per-operand overrides are not supported yet.
 
 validator:
   repository: nvcr.io/nvidia


### PR DESCRIPTION
# Render ClusterPolicy daemonsets.podSecurityContext from Helm values

## Problem

`ClusterPolicy.spec.daemonsets.podSecurityContext` is already supported by the CRD and by the operator controller (`applyCommonDaemonsetConfig`). Helm values such as:

```yaml
daemonsets:
  podSecurityContext:
    seLinuxOptions:
      type: spc_t
      level: s0
```

were silently ignored because `deployments/gpu-operator/templates/clusterpolicy.yaml` never emitted the field.

This breaks SELinux / OpenShift-style deployments that rely on chart values alone (no manual ClusterPolicy edit).

## Change

- Render `daemonsets.podSecurityContext` into the ClusterPolicy when set in values.
- Document the option in `values.yaml`.

## Follow-up request

Global `daemonsets.podSecurityContext` applies to **all** operand DaemonSets. We would also like optional **per-operand** `podSecurityContext` (e.g. under `driver`, `toolkit`, `devicePlugin`) so SELinux types can be scoped without granting every DaemonSet the same domain. Happy to follow up in a separate PR if preferred.

## Test plan

- [ ] `helm template` with `daemonsets.podSecurityContext.seLinuxOptions` set â†’ ClusterPolicy includes the field under `spec.daemonsets`
- [ ] `helm template` without the value â†’ field absent
- [ ] Install / upgrade: operator applies PSC to operand DaemonSet pod templates
