### PR TITLE
Attribute DCGM exporter metrics to pods on DRA nodes by default

### DIFF
--- a/internal/state/dcgm_exporter.go
+++ b/internal/state/dcgm_exporter.go
@@ -131,7 +131,6 @@ func buildDCGMExporterRenderData(ctx context.Context, s *configurableState, cr *
 		Collectors:                   collectors,
 		HPCJobMappingDir:             hpcJobMappingDir,
 		PodLabelAllowlistRegex:       strings.Join(spec.PodLabelAllowlistRegex, ","),
-		PodMetadataEnabled:           spec.IsKubernetesPodMetadataEnabled(),
 		EnablePodLabels:              spec.IsPodLabelsEnabled(),
 		EnablePodUID:                 spec.IsPodUIDEnabled(),
 		HostPID:                      spec.IsHostPIDEnabled(),

--- a/internal/state/dcgm_exporter_test.go
+++ b/internal/state/dcgm_exporter_test.go
@@ -80,8 +80,10 @@ func TestDCGMExporterEnabledByDefault(t *testing.T) {
 	assert.Equal(t, 1, kinds["ResourceClaimTemplate"])
 	assert.Equal(t, 1, kinds["DaemonSet"])
 	assert.Equal(t, 1, kinds["Service"])
-	// No pod-read ClusterRole and no ServiceMonitor by default.
-	assert.Equal(t, 0, kinds["ClusterRole"])
+	// DRA attribution needs the ResourceSlice informer, so the read ClusterRole is
+	// always bound. No ServiceMonitor by default.
+	assert.Equal(t, 1, kinds["ClusterRole"])
+	assert.Equal(t, 1, kinds["ClusterRoleBinding"])
 	assert.Equal(t, 0, kinds["ServiceMonitor"])
 
 	claimHasAdminAccess(t, findByKind(objs, "ResourceClaimTemplate"))
@@ -90,12 +92,16 @@ func TestDCGMExporterEnabledByDefault(t *testing.T) {
 	podSpec := ds.Spec.Template.Spec
 	assert.Equal(t, "true", podSpec.NodeSelector["nvidia.com/gpu.deploy.dcgm-exporter-dra"])
 	require.NotNil(t, podSpec.AutomountServiceAccountToken)
-	assert.False(t, *podSpec.AutomountServiceAccountToken)
+	assert.True(t, *podSpec.AutomountServiceAccountToken)
 
 	ctr := podSpec.Containers[0]
 	assert.Equal(t, "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.3", ctr.Image)
 	env := envMap(ctr.Env)
 	assert.Equal(t, ":9400", env["DCGM_EXPORTER_LISTEN"])
+	// Pod attribution on DRA nodes is on by default; pod labels and UID are not.
+	assert.Equal(t, "true", env["KUBERNETES_ENABLE_DRA"])
+	assert.NotContains(t, env, "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS")
+	assert.NotContains(t, env, "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID")
 	assert.Equal(t, "/etc/dcgm-exporter/dcp-metrics-included.csv", env["DCGM_EXPORTER_COLLECTORS"])
 	// Embedded engine: no remote host-engine env.
 	_, hasRemote := env["DCGM_REMOTE_HOSTENGINE_INFO"]
@@ -138,16 +144,8 @@ func TestDCGMExporterPodMetadataEnrichment(t *testing.T) {
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)
 
-	// The pod-read ClusterRole + binding render only when enrichment is on.
-	kinds := kindCounts(objs)
-	assert.Equal(t, 1, kinds["ClusterRole"])
-	assert.Equal(t, 1, kinds["ClusterRoleBinding"])
-
 	ds := findDaemonSet(t, objs)
 	podSpec := ds.Spec.Template.Spec
-	// Enrichment needs a mounted SA token.
-	require.NotNil(t, podSpec.AutomountServiceAccountToken)
-	assert.True(t, *podSpec.AutomountServiceAccountToken)
 	env := envMap(podSpec.Containers[0].Env)
 	assert.Equal(t, "true", env["DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"])
 	assert.Equal(t, "true", env["DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID"])

--- a/internal/state/gpucluster_render_test.go
+++ b/internal/state/gpucluster_render_test.go
@@ -131,8 +131,8 @@ func TestGPUClusterRenderGolden(t *testing.T) {
 			},
 		},
 		{
-			// enablePodLabels: pod metadata mounts the ServiceAccount token and adds
-			// the DRA/pod-labels env and the read-pods ClusterRole/Binding.
+			// enablePodLabels adds the pod-labels env on top of the pod attribution
+			// that every DRA exporter gets.
 			name: "gpucluster-dcgm-exporter-pod-metadata",
 			render: func(t *testing.T) []*unstructured.Unstructured {
 				s := newTestDCGMExporterState(t, false)

--- a/internal/state/testdata/golden/gpucluster-dcgm-exporter-embedded.yaml
+++ b/internal/state/testdata/golden/gpucluster-dcgm-exporter-embedded.yaml
@@ -20,6 +20,30 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra-read-pods
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nvidia-dcgm-exporter-dra
@@ -28,6 +52,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: nvidia-dcgm-exporter-dra
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra-read-pods
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nvidia-dcgm-exporter-dra-read-pods
 subjects:
 - kind: ServiceAccount
   name: nvidia-dcgm-exporter-dra
@@ -83,7 +122,7 @@ spec:
       labels:
         app: nvidia-dcgm-exporter-dra
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       containers:
       - env:
         - name: DCGM_EXPORTER_LISTEN
@@ -96,6 +135,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBERNETES_ENABLE_DRA
+          value: "true"
         image: nvcr.io/nvidia/k8s/dcgm-exporter:test
         livenessProbe:
           httpGet:

--- a/internal/state/testdata/golden/gpucluster-dcgm-exporter-remote-engine.yaml
+++ b/internal/state/testdata/golden/gpucluster-dcgm-exporter-remote-engine.yaml
@@ -20,6 +20,30 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra-read-pods
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nvidia-dcgm-exporter-dra
@@ -28,6 +52,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: nvidia-dcgm-exporter-dra
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dcgm-exporter-dra
+  namespace: test-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: nvidia-dcgm-exporter-dra
+  name: nvidia-dcgm-exporter-dra-read-pods
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nvidia-dcgm-exporter-dra-read-pods
 subjects:
 - kind: ServiceAccount
   name: nvidia-dcgm-exporter-dra
@@ -83,7 +122,7 @@ spec:
       labels:
         app: nvidia-dcgm-exporter-dra
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       containers:
       - env:
         - name: DCGM_EXPORTER_LISTEN
@@ -98,6 +137,8 @@ spec:
               fieldPath: spec.nodeName
         - name: DCGM_REMOTE_HOSTENGINE_INFO
           value: nvidia-dcgm-dra:5555
+        - name: KUBERNETES_ENABLE_DRA
+          value: "true"
         image: nvcr.io/nvidia/k8s/dcgm-exporter:test
         livenessProbe:
           httpGet:

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -97,13 +97,11 @@ type dcgmExporterRenderData struct {
 	// on vanilla Kubernetes.
 	OpenshiftVersion string
 	// ResourceClaimAPIVersion is the apiVersion to render on ResourceClaimTemplate objects.
-	ResourceClaimAPIVersion string
-	RemoteHostEngine        string
-	Collectors              string
-	HPCJobMappingDir        string
-	PodLabelAllowlistRegex  string
-	// PodMetadataEnabled mounts the ServiceAccount token and binds the pods-read ClusterRole.
-	PodMetadataEnabled           bool
+	ResourceClaimAPIVersion      string
+	RemoteHostEngine             string
+	Collectors                   string
+	HPCJobMappingDir             string
+	PodLabelAllowlistRegex       string
 	EnablePodLabels              bool
 	EnablePodUID                 bool
 	HostPID                      bool

--- a/manifests/state-dcgm-exporter/0210_clusterrole.yaml
+++ b/manifests/state-dcgm-exporter/0210_clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .PodMetadataEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,4 +21,3 @@ rules:
   - get
   - list
   - watch
-{{- end }}

--- a/manifests/state-dcgm-exporter/0310_clusterrolebinding.yaml
+++ b/manifests/state-dcgm-exporter/0310_clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .PodMetadataEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +12,3 @@ subjects:
 - kind: ServiceAccount
   name: nvidia-dcgm-exporter-dra
   namespace: {{ .Namespace }}
-{{- end }}

--- a/manifests/state-dcgm-exporter/0700_daemonset.yaml
+++ b/manifests/state-dcgm-exporter/0700_daemonset.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: nvidia-dcgm-exporter-dra
-      automountServiceAccountToken: {{ .PodMetadataEnabled }}
+      automountServiceAccountToken: true
       # Gate scheduling on the per-component deploy label so the k8s-driver-manager
       # can pause it to drain dcgm-exporter off a node during a driver reload.
       nodeSelector:
@@ -99,10 +99,11 @@ spec:
         - name: DCGM_HPC_JOB_MAPPING_DIR
           value: {{ .HPCJobMappingDir | quote }}
         {{- end }}
-        {{- if .PodMetadataEnabled }}
+        # The kubelet reports DRA-allocated devices as (pool, device) names rather
+        # than GPU UUIDs, so the exporter needs the ResourceSlice informer to resolve
+        # them. Without this the metrics carry no pod, namespace or container label.
         - name: KUBERNETES_ENABLE_DRA
           value: "true"
-        {{- end }}
         {{- if .EnablePodLabels }}
         - name: DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS
           value: "true"


### PR DESCRIPTION
## Description

Under GPUCluster, dcgm-exporter metrics carry only hardware labels (no `pod`, `namespace`, `container` or `dra_*`) unless `dcgmExporter.enablePodLabels` is set. ClusterPolicy has those labels by default, so migrating to GPUCluster silently loses attribution.

The kubelet reports device-plugin allocations as GPU UUIDs, which the exporter gets from the pod-resources socket with no API access. DRA allocations are reported as `(pool, device)` names instead, so the exporter has to read the node's ResourceSlice to resolve them back to a UUID. That needs a ServiceAccount token and read access to `resourceslices` — both of which, along with `KUBERNETES_ENABLE_DRA` itself, were gated behind the pod-labels flag.

Render the DRA env var, token mount and ClusterRole/binding unconditionally. `enablePodLabels` and `enablePodUID` controls their behavior appropriately.

Builds on #2697, which added the env var and the `resourceslices` grant, but gated them behind `PodMetadataEnabled` gate. `PodMetadataEnabled` now has no remaining consumers and is removed.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Verified on a GH200 node, driver 595.71.05, with a single DRA workload holding one GPU.

### With PR changes

#### Default pod attribution (pod label and pod UID false) — matches current ClusterPolicy behavior

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-47dll"' | head -1
DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05",container="trainer",dra_claim_name="gpu-workload-dra-859cdbfb47-47dll-shared-gpu-974nq",dra_claim_namespace="gpu-operator",dra_device_name="gpu-0",dra_driver_name="gpu.nvidia.com",dra_pool_name="<node>",namespace="gpu-operator",pod="gpu-workload-dra-859cdbfb47-47dll"} 0
```

#### No pod label leakage

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-47dll"' | grep -c 'attribution-label'
0
```

#### With pod label and UID enabled (no pod UID?)

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-47dll"' | head -1
DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05",app="gpu-workload-dra",dra="attribution-label",pod_template_hash="859cdbfb47",container="trainer",dra_claim_name="gpu-workload-dra-859cdbfb47-47dll-shared-gpu-974nq",dra_claim_namespace="gpu-operator",dra_device_name="gpu-0",dra_driver_name="gpu.nvidia.com",dra_pool_name="<node>",namespace="gpu-operator",pod="gpu-workload-dra-859cdbfb47-47dll"} 0

$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-47dll"' | grep -c 'attribution-label'
23
```

The absent pod UID is not caused by this change. dcgm-exporter never sets the UID attribute on its DRA path, so `DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID` has no effect on DRA-attributed metrics. The ClusterPolicy run below shows `pod_uid` present on the same exporter build, which confirms the gap in DRA path.

### Without PR changes

#### No match (pod labels and pod UID false) - current bug

v26.7.0-rc.4, which predates #2697 and never sets `KUBERNETES_ENABLE_DRA` so no pods are matched.

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-9g7gs"' | head -1
```

#### All metrics

```console
# HELP DCGM_FI_PROF_PCIE_RX_BYTES The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
# TYPE DCGM_FI_PROF_PCIE_RX_BYTES gauge
DCGM_FI_PROF_PCIE_RX_BYTES{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05"} 167781
# HELP DCGM_FI_PROF_PCIE_TX_BYTES The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
# TYPE DCGM_FI_PROF_PCIE_TX_BYTES gauge
DCGM_FI_PROF_PCIE_TX_BYTES{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05"} 152781
# HELP DCGM_FI_PROF_PIPE_TENSOR_ACTIVE Ratio of cycles the tensor (HMMA) pipe is active.
# TYPE DCGM_FI_PROF_PIPE_TENSOR_ACTIVE gauge
DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05"} 0.853072
```

#### Pod labels (and pod UID) enabled — with PR #2697

Attribution works once `enablePodLabels=true` is set, confirming the gate is the only thing this PR changes.

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-qw5jk"' | head -1
DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05",app="gpu-workload-dra",dra="attribution-label",pod_template_hash="859cdbfb47",container="trainer",dra_claim_name="gpu-workload-dra-859cdbfb47-qw5jk-shared-gpu-rcd7q",dra_claim_namespace="gpu-operator",dra_device_name="gpu-0",dra_driver_name="gpu.nvidia.com",dra_pool_name="<node>",namespace="gpu-operator",pod="gpu-workload-dra-859cdbfb47-qw5jk"} 0

$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-dra-859cdbfb47-qw5jk"' | grep -c 'attribution-label'
23
```

### ClusterPolicy

No regression. 

#### Default attribution

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-5dd46f4645-2nmm7"' | head -1
DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05",container="trainer",namespace="gpu-operator",pod="gpu-workload-5dd46f4645-2nmm7"} 0
```

#### Pod labels and pod uid enabled (app=gpu-workload)

```console
$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-5dd46f4645-2nmm7"' | head -1
DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{gpu="0",UUID="GPU-cbd42015-907e-1554-4c37-4490ecc6216e",pci_bus_id="00000009:01:00.0",device="nvidia0",modelName="NVIDIA GH200 480GB",hostname="<node>",DCGM_FI_DRIVER_VERSION="595.71.05",app="gpu-workload",pod_template_hash="5dd46f4645",container="trainer",namespace="gpu-operator",pod="gpu-workload-5dd46f4645-2nmm7",pod_uid="190f53e6-7b28-4a97-b1e6-112c2dea6b47"} 0

$ curl -s localhost:9400/metrics | grep 'pod="gpu-workload-5dd46f4645-2nmm7"' | grep -c "app="
23
```
