### PR TITLE
dra: fix HOST_ROOT envvar and add missing mounts for PassthroughSupport

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -111,7 +112,8 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 			}
 			return *b
 		},
-		"getObjectHash": utils.GetObjectHash,
+		"getObjectHash":                          utils.GetObjectHash,
+		"convertStringMapToCommaSeparatedString": convertStringMapToCommaSeparatedString,
 	})
 
 	if data.Funcs != nil {
@@ -151,4 +153,20 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 	}
 
 	return out, nil
+}
+
+// convertStringMapToCommaSeparatedString converts a map[string]bool to a comma-separated
+// "key=value" string with keys in sorted order. Returns "" for a nil or empty map.
+func convertStringMapToCommaSeparatedString(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%t", k, m[k]))
+	}
+	return strings.Join(pairs, ",")
 }

--- a/internal/state/dra_driver.go
+++ b/internal/state/dra_driver.go
@@ -19,8 +19,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -127,7 +125,7 @@ func (s *stateDRADriver) getManifestObjects(ctx context.Context, cr *nvidiav1alp
 		Namespace:             s.namespace,
 		OpenshiftVersion:      openshiftVersion,
 		DeviceClassAPIVersion: apiVersion,
-		FeatureGates:          renderDRAFeatureGates(cr.Spec.DRADriver.FeatureGates),
+		FeatureGates:          cr.Spec.DRADriver.FeatureGates,
 		GPUsHealthcheckPort: resolveHealthcheckPort(
 			cr.Spec.DRADriver.GPUs.KubeletPlugin.Healthcheck, defaultGPUsHealthcheckPort),
 		ComputeDomainsHealthcheckPort: resolveHealthcheckPort(
@@ -210,21 +208,4 @@ func maxResourceList(resourceLists ...corev1.ResourceList) corev1.ResourceList {
 	}
 
 	return result
-}
-
-// renderDRAFeatureGates renders the feature-gate map as the FEATURE_GATES env value
-// (comma-separated Key=Value). Keys are sorted so the rendered value is a pure
-// function of the input and reconciles do not churn the pod spec. Empty when none.
-func renderDRAFeatureGates(gates map[string]bool) string {
-	names := make([]string, 0, len(gates))
-	for name := range gates {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	pairs := make([]string, 0, len(names))
-	for _, name := range names {
-		pairs = append(pairs, fmt.Sprintf("%s=%t", name, gates[name]))
-	}
-	return strings.Join(pairs, ",")
 }

--- a/internal/state/gpucluster_render_test.go
+++ b/internal/state/gpucluster_render_test.go
@@ -92,6 +92,17 @@ func TestGPUClusterRenderGolden(t *testing.T) {
 			},
 		},
 		{
+			name: "gpucluster-dra-driver-passthrough-support",
+			render: func(t *testing.T) []*unstructured.Unstructured {
+				s := newTestDRAState(t)
+				gpuCluster := sampleGPUCluster()
+				gpuCluster.Spec.DRADriver.FeatureGates["PassthroughSupport"] = true
+				objs, err := s.getManifestObjects(context.Background(), gpuCluster, draSupportedCatalog())
+				require.NoError(t, err)
+				return objs
+			},
+		},
+		{
 			name: "gpucluster-dra-driver-full-spec",
 			render: func(t *testing.T) []*unstructured.Unstructured {
 				s := newTestDRAState(t)

--- a/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
@@ -458,6 +458,8 @@ spec:
           value: void
         - name: CDI_ROOT
           value: /var/run/cdi
+        - name: HOST_ROOT
+          value: /host
         - name: NVIDIA_MIG_CONFIG_DEVICES
           value: all
         - name: NODE_NAME

--- a/internal/state/testdata/golden/gpucluster-dra-driver-passthrough-support.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-passthrough-support.yaml
@@ -252,7 +252,7 @@ spec:
         - name: HEALTHCHECK_PORT
           value: "51516"
         - name: FEATURE_GATES
-          value: AdminAccess=false,MPSSupport=true
+          value: AdminAccess=false,MPSSupport=true,PassthroughSupport=true
         image: nvcr.io/nvidia/k8s-dra-driver-gpu:v0.1.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -290,6 +290,16 @@ spec:
         - mountPath: /driver-root
           mountPropagation: HostToContainer
           name: driver-install-dir
+        - mountPath: /lib/modules/
+          mountPropagation: HostToContainer
+          name: lib-modules
+          readOnly: true
+        - mountPath: /sys/
+          mountPropagation: Bidirectional
+          name: sysfs
+        - mountPath: /proc/
+          mountPropagation: Bidirectional
+          name: procfs
       initContainers:
       - command:
         - nvidia-validator
@@ -357,6 +367,18 @@ spec:
           path: /run/nvidia/validations
           type: DirectoryOrCreate
         name: validations
+      - hostPath:
+          path: /lib/modules/
+          type: Directory
+        name: lib-modules
+      - hostPath:
+          path: /sys/
+          type: Directory
+        name: sysfs
+      - hostPath:
+          path: /proc/
+          type: Directory
+        name: procfs
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100%

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -142,8 +142,7 @@ type draDriverRenderData struct {
 	// DeviceClassAPIVersion is the apiVersion to render on DeviceClass objects,
 	// determined from the resource.k8s.io version served by the cluster.
 	DeviceClassAPIVersion string
-	// FeatureGates is the pre-rendered FEATURE_GATES env value (empty when none).
-	FeatureGates string
+	FeatureGates          map[string]bool
 	// GPUsHealthcheckPort and ComputeDomainsHealthcheckPort are the resolved gRPC health
 	// service ports of the two kubelet-plugin containers (the spec value, or the
 	// per-container default); a negative value omits the startup and liveness probes.

--- a/manifests/state-dra-driver/0500_daemonset.yaml
+++ b/manifests/state-dra-driver/0500_daemonset.yaml
@@ -168,6 +168,8 @@ spec:
           value: void
         - name: CDI_ROOT
           value: /var/run/cdi
+        - name: HOST_ROOT
+          value: "/host"
         - name: NVIDIA_MIG_CONFIG_DEVICES
           value: all
         - name: NODE_NAME
@@ -188,7 +190,7 @@ spec:
           value: {{ .GPUsHealthcheckPort | quote }}
         {{- if .FeatureGates }}
         - name: FEATURE_GATES
-          value: {{ .FeatureGates | quote }}
+          value: {{ convertStringMapToCommaSeparatedString .FeatureGates | quote }}
         {{- end }}
         {{- range .DRADriver.Spec.GPUs.KubeletPlugin.Env }}
         - name: {{ .Name }}
@@ -231,6 +233,18 @@ spec:
         - name: driver-install-dir
           mountPath: /driver-root
           mountPropagation: HostToContainer
+        {{- if and .FeatureGates (and (index .FeatureGates "PassthroughSupport") .FeatureGates.PassthroughSupport) }}
+        - name: lib-modules
+          mountPath: /lib/modules/
+          mountPropagation: HostToContainer
+          readOnly: true
+        - name: sysfs
+          mountPath: /sys/
+          mountPropagation: Bidirectional
+        - name: procfs
+          mountPath: /proc/
+          mountPropagation: Bidirectional
+        {{- end }}
       {{- if .DRADriver.Spec.IsComputeDomainsEnabled }}
       - name: compute-domains
         image: {{ .DRADriver.ImagePath }}
@@ -290,7 +304,7 @@ spec:
           value: "true"
         {{- if .FeatureGates }}
         - name: FEATURE_GATES
-          value: {{ .FeatureGates | quote }}
+          value: {{ convertStringMapToCommaSeparatedString .FeatureGates | quote }}
         {{- end }}
         {{- range .DRADriver.Spec.ComputeDomains.KubeletPlugin.Env }}
         - name: {{ .Name }}
@@ -356,3 +370,19 @@ spec:
         hostPath:
           path: /run/nvidia/validations
           type: DirectoryOrCreate
+      {{- if and .FeatureGates (and (index .FeatureGates "PassthroughSupport") .FeatureGates.PassthroughSupport) }}
+      # This is needed by `https://github.com/NVIDIA/go-nvlib/pkg/nvpassthrough` pkg
+      # to detect the vfio-pci driver variant to use with a GPU.
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules/
+          type: Directory
+      - name: sysfs
+        hostPath:
+          path: /sys/
+          type: Directory
+      - name: procfs
+        hostPath:
+          path: /proc/
+          type: Directory
+      {{- end }}

--- a/manifests/state-dra-driver/0600_controller-deployment.yaml
+++ b/manifests/state-dra-driver/0600_controller-deployment.yaml
@@ -124,7 +124,7 @@ spec:
           value: 2s
         {{- if .FeatureGates }}
         - name: FEATURE_GATES
-          value: {{ .FeatureGates | quote }}
+          value: {{ convertStringMapToCommaSeparatedString .FeatureGates | quote }}
         {{- end }}
         {{- range $controller.Env }}
         - name: {{ .Name }}


### PR DESCRIPTION
## Description

This PR fixes a few bugs encountered when enabling the PassthroughSupport feature gate in the NVIDIA DRA Driver for GPUS. First, the `HOST_ROOT` variable was not set correctly, leading to the following error message in the kubelet-plugin:

```
Error: invalid CLI flags: host root is not mounted at "/host-root"
```

After this issue was fixed, the below issue was encountered as we were missing some volume mounts required for the PassthroughSupport feature.

```
Error: error creating driver: error enumerating all possible devices: error enumerating GPU PCI devices: error getting GPU info from PCI device: error finding best VFIO driver for device "0009:01:00.0": failed to get vfio_pci aliases in modules.alias file: failed to read file /lib/modules/5.14.0-687.20.1.el9_8.aarch64/modules.alias: open /lib/modules/5.14.0-687.20.1.el9_8.aarch64/modules.alias: no such file or directory
```

See upstream DRA driver manifest: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/50e0e3568f633d87266e3aabf8afa510843d6c7d/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml#L338-L353

## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [X] Lint checks passing (`make lint`)
- [X] Generated assets in-sync (`make validate-generated-assets`)
- [X] Go mod artifacts in-sync (`make validate-modules`)
- [X] Test cases are added for new code paths

## Testing

Manual testing on a single node OpenShift cluster. Deployed with and without this change. 

