### PR TITLE
nvd: update nodeSelector to only use major version for rhel-like distros

### DIFF
--- a/internal/state/driver.go
+++ b/internal/state/driver.go
@@ -50,8 +50,9 @@ import (
 )
 
 const (
-	nfdOSReleaseIDLabelKey = "feature.node.kubernetes.io/system-os_release.ID"
-	nfdOSVersionIDLabelKey = "feature.node.kubernetes.io/system-os_release.VERSION_ID"
+	nfdOSReleaseIDLabelKey      = "feature.node.kubernetes.io/system-os_release.ID"
+	nfdOSVersionIDLabelKey      = "feature.node.kubernetes.io/system-os_release.VERSION_ID"
+	nfdOSVersionIDMajorLabelKey = "feature.node.kubernetes.io/system-os_release.VERSION_ID.major"
 
 	// AppComponentLabelKey indicates the label key of the component
 	AppComponentLabelKey = "app.kubernetes.io/component"

--- a/internal/state/nodepool.go
+++ b/internal/state/nodepool.go
@@ -84,18 +84,17 @@ func getNodePools(ctx context.Context, k8sClient client.Client, cr *nvidiav1alph
 
 		osID, ok := nodeLabels[nfdOSReleaseIDLabelKey]
 		if !ok {
-			logger.Info("WARNING: Could not find NFD labels for node. Is NFD installed?", "Node", node.Name)
+			logger.Info("WARNING: Could not find NFD label for node. Is NFD installed?", "Node", node.Name, "Label", nfdOSReleaseIDLabelKey)
 			continue
 		}
 		nodePool.nodeSelector[nfdOSReleaseIDLabelKey] = osID
+		nodePool.osRelease = osID
 
 		osVersion, ok := nodeLabels[nfdOSVersionIDLabelKey]
 		if !ok {
-			logger.Info("WARNING: Could not find NFD labels for node. Is NFD installed?", "Node", node.Name)
+			logger.Info("WARNING: Could not find NFD label for node. Is NFD installed?", "Node", node.Name, "Label", nfdOSVersionIDLabelKey)
 			continue
 		}
-		nodePool.nodeSelector[nfdOSVersionIDLabelKey] = osVersion
-		nodePool.osRelease = osID
 		nodePool.osVersion = osVersion
 
 		osTag, err := getOSTag(osID, osVersion)
@@ -104,6 +103,20 @@ func getNodePools(ctx context.Context, k8sClient client.Client, cr *nvidiav1alph
 		}
 		nodePool.osTag = osTag
 		nodePool.name = osTag
+
+		// For certain distros, we omit the minor version from the os tag.
+		// In such cases, we ensure the nodeSelector for the node pool targets
+		// all nodes with the same major version.
+		if !strings.HasSuffix(osTag, osVersion) {
+			osMajor, ok := nodeLabels[nfdOSVersionIDMajorLabelKey]
+			if !ok {
+				logger.Info("WARNING: Could not find NFD label for node. Is NFD installed?", "Node", node.Name, "Label", nfdOSVersionIDMajorLabelKey)
+				continue
+			}
+			nodePool.nodeSelector[nfdOSVersionIDMajorLabelKey] = osMajor
+		} else {
+			nodePool.nodeSelector[nfdOSVersionIDLabelKey] = osVersion
+		}
 
 		if cr.Spec.UsePrecompiledDrivers() {
 			kernelVersion, ok := nodeLabels[nfdKernelLabelKey]

--- a/internal/state/nodepool_test.go
+++ b/internal/state/nodepool_test.go
@@ -119,13 +119,25 @@ func TestGetNodePoolsGroupsNodesByOSTag(t *testing.T) {
 		WithScheme(scheme.Scheme).
 		WithObjects(
 			&corev1.Node{ObjectMeta: metav1.ObjectMeta{
-				Name: "rhel-node",
+				Name: "rhel9.4-node",
 				Labels: map[string]string{
 					"pool":                        "gold",
 					consts.GPUPresentLabel:        "true",
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "rhel",
 					nfdOSVersionIDLabelKey:        "9.4",
+					nfdOSVersionIDMajorLabelKey:   "9",
+				},
+			}},
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: "rhel9.5-node",
+				Labels: map[string]string{
+					"pool":                        "gold",
+					consts.GPUPresentLabel:        "true",
+					consts.NVIDIADriverOwnerLabel: "driver-a",
+					nfdOSReleaseIDLabelKey:        "rhel",
+					nfdOSVersionIDLabelKey:        "9.5",
+					nfdOSVersionIDMajorLabelKey:   "9",
 				},
 			}},
 			&corev1.Node{ObjectMeta: metav1.ObjectMeta{
@@ -136,6 +148,7 @@ func TestGetNodePoolsGroupsNodesByOSTag(t *testing.T) {
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "ubuntu",
 					nfdOSVersionIDLabelKey:        "22.04",
+					nfdOSVersionIDMajorLabelKey:   "22",
 				},
 			}},
 			&corev1.Node{ObjectMeta: metav1.ObjectMeta{
@@ -146,6 +159,7 @@ func TestGetNodePoolsGroupsNodesByOSTag(t *testing.T) {
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "ubuntu",
 					nfdOSVersionIDLabelKey:        "20.04",
+					nfdOSVersionIDMajorLabelKey:   "20",
 				},
 			}},
 		).
@@ -165,13 +179,16 @@ func TestGetNodePoolsGroupsNodesByOSTag(t *testing.T) {
 	poolsByName := nodePoolsByName(nodePools)
 	require.Contains(t, poolsByName, "rhel9")
 	require.Equal(t, "rhel", poolsByName["rhel9"].osRelease)
-	require.Equal(t, "9.4", poolsByName["rhel9"].osVersion)
 	require.Equal(t, "gold", poolsByName["rhel9"].nodeSelector["pool"])
 	require.Equal(t, "driver-a", poolsByName["rhel9"].nodeSelector[consts.NVIDIADriverOwnerLabel])
+	require.Equal(t, "", poolsByName["rhel9"].nodeSelector[nfdOSVersionIDLabelKey])
+	require.Equal(t, "9", poolsByName["rhel9"].nodeSelector[nfdOSVersionIDMajorLabelKey])
 
 	require.Contains(t, poolsByName, "ubuntu22.04")
 	require.Equal(t, "ubuntu", poolsByName["ubuntu22.04"].osRelease)
 	require.Equal(t, "22.04", poolsByName["ubuntu22.04"].osVersion)
+	require.Equal(t, "22.04", poolsByName["ubuntu22.04"].nodeSelector[nfdOSVersionIDLabelKey])
+	require.Equal(t, "", poolsByName["ubuntu22.04"].nodeSelector[nfdOSVersionIDMajorLabelKey])
 }
 
 func TestGetNodePoolsSkipsNodesMissingNFDOSLabels(t *testing.T) {
@@ -221,6 +238,7 @@ func TestGetNodePoolsPartitionsPrecompiledNodesByKernel(t *testing.T) {
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "ubuntu",
 					nfdOSVersionIDLabelKey:        "22.04",
+					nfdOSVersionIDMajorLabelKey:   "22",
 					nfdKernelLabelKey:             "5.15.0-70-generic_x86_64",
 				},
 			}},
@@ -231,6 +249,7 @@ func TestGetNodePoolsPartitionsPrecompiledNodesByKernel(t *testing.T) {
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "ubuntu",
 					nfdOSVersionIDLabelKey:        "22.04",
+					nfdOSVersionIDMajorLabelKey:   "22",
 				},
 			}},
 		).
@@ -264,6 +283,7 @@ func TestGetNodePoolsPartitionsOpenShiftNodesByRHCOSVersion(t *testing.T) {
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "rhcos",
 					nfdOSVersionIDLabelKey:        "4.14",
+					nfdOSVersionIDMajorLabelKey:   "4",
 					nfdOSTreeVersionLabelKey:      "414.92.202309282257",
 				},
 			}},
@@ -274,6 +294,7 @@ func TestGetNodePoolsPartitionsOpenShiftNodesByRHCOSVersion(t *testing.T) {
 					consts.NVIDIADriverOwnerLabel: "driver-a",
 					nfdOSReleaseIDLabelKey:        "rhcos",
 					nfdOSVersionIDLabelKey:        "4.14",
+					nfdOSVersionIDMajorLabelKey:   "4",
 				},
 			}},
 		).


### PR DESCRIPTION
## Description

In a prior [commit](https://github.com/NVIDIA/gpu-operator/commit/f49a33978eb03c0a6ed09cbff927f74645274d44), we updated the NVIDIADriver controller so that only one driver daemonset would get created per major version for rhel-like distros (rhel, oracle linux, rocky linux). The image tag and name of the daemonset only contain the major version, for example rhel9 (and not rhel9.x). One item that was not updated was the rendered nodeSelector in the daemonset. The following label is still being set in the nodeSelector:

```
feature.node.kubernetes.io/system-os_release.VERSION_ID
```

This commit updates the nodeSelector so that only the major version is referenced for rhel-like distros. The above label is replaced by the below label in the rendered daemonset:

```
feature.node.kubernetes.io/system-os_release.VERSION_ID.major
```

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Unit tests

