### PR TITLE
Fix preStop hook command in vfio-manager daemonset

### DIFF
--- a/assets/state-vfio-manager/0500_daemonset.yaml
+++ b/assets/state-vfio-manager/0500_daemonset.yaml
@@ -87,7 +87,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["vfio-manage unbind --all"]
+                command: ["/bin/sh", "-c", "vfio-manage unbind --all"]
       terminationGracePeriodSeconds: 30
       volumes:
         - name: host-sys


### PR DESCRIPTION
## Description

This fixes a regression introduced in https://github.com/NVIDIA/gpu-operator/commit/7de51894b2f777a7d662e9a656cce20b6d87a773. The preStop hook command was malformed and led to the following error when invoked:

err="... exec: \"vfio-manage unbind --all\": executable file not found in $PATH"

## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [X] Lint checks passing (`make lint`)
- [X] Generated assets in-sync (`make validate-generated-assets`)
- [X] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Manual testing on a single node GPU cluster.
