### PR TITLE
Fix nvidia-vgpu-device-manager DaemonSet's priorityClassName

### DIFF
--- a/assets/state-vgpu-device-manager/0600_daemonset.yaml
+++ b/assets/state-vgpu-device-manager/0600_daemonset.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       nodeSelector:
         nvidia.com/gpu.deploy.vgpu-device-manager: "true"
+      priorityClassName: system-node-critical
       serviceAccountName: nvidia-vgpu-device-manager
       initContainers:
         - name: vgpu-manager-validation


### PR DESCRIPTION
## Description

This fixes the bug addressed in #2709 . nvidia-vgpu-device-manager's DaemonSet did not have a priorityClassName, unlike every other DaemonSet, which introduced issues when proceeding with installations without Helm.

This PR adds `priorityClassName: system-node-critical` to  nvidia-vgpu-device-manager's DaemonSet. 

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Successful in manual testing on a single node GPU cluster (no Openshift testing).