### PR TITLE
fix node permissions for computedomain plugin

### DIFF
--- a/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
@@ -188,6 +188,35 @@ subjects:
   namespace: test-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nvidia-dra-driver-kubeletplugin-computedomain
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nvidia-dra-driver-kubeletplugin-computedomain
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nvidia-dra-driver-kubeletplugin-computedomain
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dra-driver-kubeletplugin
+  namespace: test-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nvidia-dra-driver-kubeletplugin
@@ -306,15 +335,6 @@ rules:
   - create
   - update
   - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-full-spec.yaml
@@ -315,6 +315,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/gpucluster-dra-driver-gpus-only.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-gpus-only.yaml
@@ -102,15 +102,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - get

--- a/internal/state/testdata/golden/gpucluster-dra-driver-gpus-only.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-gpus-only.yaml
@@ -108,6 +108,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/internal/state/testdata/golden/gpucluster-dra-driver-passthrough-support.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-passthrough-support.yaml
@@ -102,15 +102,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - get

--- a/internal/state/testdata/golden/gpucluster-dra-driver-passthrough-support.yaml
+++ b/internal/state/testdata/golden/gpucluster-dra-driver-passthrough-support.yaml
@@ -108,6 +108,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/manifests/state-dra-driver/0130_kubeletplugin-computedomain-role.yaml
+++ b/manifests/state-dra-driver/0130_kubeletplugin-computedomain-role.yaml
@@ -1,5 +1,34 @@
 {{- if .DRADriver.Spec.IsComputeDomainsEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nvidia-dra-driver-kubeletplugin-computedomain
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nvidia-dra-driver-kubeletplugin-computedomain
+subjects:
+- kind: ServiceAccount
+  name: nvidia-dra-driver-kubeletplugin
+  namespace: {{ .Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: nvidia-dra-driver-kubeletplugin-computedomain
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nvidia-dra-driver-kubeletplugin

--- a/manifests/state-dra-driver/0200_kubeletplugin-clusterrole.yaml
+++ b/manifests/state-dra-driver/0200_kubeletplugin-clusterrole.yaml
@@ -33,15 +33,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - get

--- a/manifests/state-dra-driver/0200_kubeletplugin-clusterrole.yaml
+++ b/manifests/state-dra-driver/0200_kubeletplugin-clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
These permissions are coming from: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/9c52a7d50994adbf2fbb5f1ce2f6466fa3f9936f/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml#L17-L19
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->
Verified using:
```
kubectl auth can-i patch nodes   --as=system:serviceaccount:gpu-operator:nvidia-dra-driver-kubeletplugin
Warning: resource 'nodes' is not namespace scoped

yes
```
