### PR TITLE
docs: fix duplicate anchor so Documentation TOC link resolves

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ The GPU Operator releases follow [calendar versioning](https://calver.org/).
 
 The NVIDIA GPU Operator source code is available on GitHub at https://github.com/NVIDIA/gpu-operator
 
-### <a name="source-code"></a> Documentation
+### <a name="documentation"></a> Documentation
 
 The official NVIDIA GPU Operator documentation is available at https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The "Artifacts" table of contents in `CONTRIBUTING.md` links to `[Documentation](#documentation)`, but the Documentation section reused the same anchor as the Source Code section directly above it:

```html
### <a name="source-code"></a> Source Code
...
### <a name="source-code"></a> Documentation   <!-- duplicate anchor -->
```

Because the anchor was duplicated, the `#documentation` TOC entry did not resolve to its section. This renames the anchor to `documentation` so the TOC link points to the correct heading. The other three TOC anchors (`source-code`, `container-images`, `helm-charts`) already match their sections and are unchanged.

**Which issue(s) this PR fixes**:

N/A (trivial docs fix, no tracking issue)

**Special notes for your reviewer**:

Documentation-only, single-line change. Verified all five anchors in the file are now unique and that each of the four TOC links resolves to its section.
