### PR TITLE
Grant the dcgm-exporter DRA role read access to ConfigMaps

### DIFF
--- a/internal/state/testdata/golden/gpucluster-dcgm-exporter-embedded.yaml
+++ b/internal/state/testdata/golden/gpucluster-dcgm-exporter-embedded.yaml
@@ -18,6 +18,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/state/testdata/golden/gpucluster-dcgm-exporter-pod-metadata.yaml
+++ b/internal/state/testdata/golden/gpucluster-dcgm-exporter-pod-metadata.yaml
@@ -18,6 +18,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/state/testdata/golden/gpucluster-dcgm-exporter-remote-engine.yaml
+++ b/internal/state/testdata/golden/gpucluster-dcgm-exporter-remote-engine.yaml
@@ -18,6 +18,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/state-dcgm-exporter/0200_role.yaml
+++ b/manifests/state-dcgm-exporter/0200_role.yaml
@@ -12,3 +12,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->

`DCGM_EXPORTER_CONFIGMAP_DATA` set through `dcgmExporter.env` points the
exporter at a ConfigMap of custom metrics that it reads from the Kubernetes
API. On the GPUCluster path neither the namespaced Role nor the ClusterRole
granted `configmaps`, so the read failed with a forbidden error and the
exporter fell back to its built-in metrics without crashing. The ClusterPolicy
path has granted this since before the feature existed.

Add `configmaps` get/list to the namespaced Role. The Role is bound in the
operator namespace only, so a `namespace:name` value pointing elsewhere is
still denied.

Verified on a DRA cluster: the ServiceAccount can read ConfigMaps and the
custom metric set is served. Golden fixtures updated to match.

Follow-up to #2721, which fixes the equivalent problem on the ClusterPolicy
path.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths