### PR TITLE
Fix: add missing toleration to vgpu-device-manager daemonset manifest

### DIFF
--- a/assets/state-vgpu-device-manager/0600_daemonset.yaml
+++ b/assets/state-vgpu-device-manager/0600_daemonset.yaml
@@ -19,6 +19,10 @@ spec:
       nodeSelector:
         nvidia.com/gpu.deploy.vgpu-device-manager: "true"
       priorityClassName: system-node-critical
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
       serviceAccountName: nvidia-vgpu-device-manager
       initContainers:
         - name: vgpu-manager-validation

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -690,6 +690,24 @@ func TestApplyCommonDaemonSetConfig(t *testing.T) {
 			}),
 		},
 		{
+			description: "existing tolerations preserved when daemonsets spec is empty",
+			ds: NewDaemonset().WithTolerations([]corev1.Toleration{
+				{
+					Key:      "nvidia.com/gpu",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}),
+			dsSpec: gpuv1.DaemonsetsSpec{},
+			expectedDs: NewDaemonset().WithTolerations([]corev1.Toleration{
+				{
+					Key:      "nvidia.com/gpu",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}),
+		},
+		{
 			description: "invalid updatestrategy configured",
 			ds:          NewDaemonset(),
 			dsSpec: gpuv1.DaemonsetsSpec{


### PR DESCRIPTION
## Description

issue: [https://github.com/NVIDIA/gpu-operator/issues/2717](https://github.com/NVIDIA/gpu-operator/issues/2717)
add missing nvidia.com/gpu:NoSchedule toleration to vgpu-device-manager daemonset file.
consistent with all other daemonsets (e.g. `assets/state-driver/0500_daemonset.yaml`)

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

added unit test

