### PR TITLE
[state-dcgm-exporter][clusterpolicy] remove pods from Role

### DIFF
--- a/assets/state-dcgm-exporter/0200_role.yaml
+++ b/assets/state-dcgm-exporter/0200_role.yaml
@@ -18,7 +18,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
   - get
   - list


### PR DESCRIPTION
The ClusterRole already provides get, list and watch privileges to the dcgm-exporter daemonset. The privileges in the namespace-scoped are therefore redundant and unnecessary.

