### PR TITLE
[state-driver] check driver daemons startup status through sentinel file

### DIFF
--- a/assets/state-driver/0400_configmap.yaml
+++ b/assets/state-driver/0400_configmap.yaml
@@ -13,12 +13,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+    
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then

--- a/assets/state-driver/0500_daemonset.yaml
+++ b/assets/state-driver/0500_daemonset.yaml
@@ -150,7 +150,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.driver-ctr-ready"]
+              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status"]
       - image: "FILLED BY THE OPERATOR"
         imagePullPolicy: IfNotPresent
         name: nvidia-peermem-ctr

--- a/internal/state/testdata/golden/driver-additional-configs.yaml
+++ b/internal/state/testdata/golden/driver-additional-configs.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -201,7 +210,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-full-spec.yaml
+++ b/internal/state/testdata/golden/driver-full-spec.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -219,7 +228,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy-openshift.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -273,7 +282,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-gdrcopy.yaml
+++ b/internal/state/testdata/golden/driver-gdrcopy.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -203,7 +212,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-gds.yaml
+++ b/internal/state/testdata/golden/driver-gds.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -203,7 +212,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-hostnetwork.yaml
+++ b/internal/state/testdata/golden/driver-hostnetwork.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -201,7 +210,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-minimal.yaml
+++ b/internal/state/testdata/golden/driver-minimal.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -201,7 +210,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
+++ b/internal/state/testdata/golden/driver-openshift-drivertoolkit.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -271,7 +280,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-precompiled.yaml
+++ b/internal/state/testdata/golden/driver-precompiled.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -203,7 +212,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
+++ b/internal/state/testdata/golden/driver-rdma-hostmofed.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -205,7 +214,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-rdma.yaml
+++ b/internal/state/testdata/golden/driver-rdma.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -203,7 +212,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-secret-env.yaml
+++ b/internal/state/testdata/golden/driver-secret-env.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -208,7 +217,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager-openshift.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then

--- a/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-host-manager.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then

--- a/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing-secret.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -201,7 +210,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/internal/state/testdata/golden/driver-vgpu-licensing.yaml
+++ b/internal/state/testdata/golden/driver-vgpu-licensing.yaml
@@ -104,12 +104,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then
@@ -201,7 +210,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -f /run/nvidia/validations/.driver-ctr-ready
+              - rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status
         name: nvidia-driver-ctr
         resources:
           limits:

--- a/manifests/state-driver/0400_configmap.yaml
+++ b/manifests/state-driver/0400_configmap.yaml
@@ -17,12 +17,21 @@ data:
 
     VALIDATIONS_DIR="/run/nvidia/validations"
     READY_FILE="${VALIDATIONS_DIR}/.driver-ctr-ready"
+    DAEMONS_STATUS_FILE="${VALIDATIONS_DIR}/.driver-daemons-status"
 
     mkdir -p "${VALIDATIONS_DIR}"
 
     if [ ! -f /sys/module/nvidia/refcnt ]; then
       echo "NVIDIA kernel module not loaded"
       exit 1
+    fi
+    
+    if [ -f "$DAEMONS_STATUS_FILE" ]; then
+      daemons_status=$(cat "$DAEMONS_STATUS_FILE")
+      if [ "$daemons_status" != "Ready" ]; then
+        echo "NVIDIA driver daemons are not ready; Current status: $daemons_status"
+        exit 1
+      fi
     fi
 
     if ! nvidia-smi; then

--- a/manifests/state-driver/0500_daemonset.yaml
+++ b/manifests/state-driver/0500_daemonset.yaml
@@ -373,7 +373,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.driver-ctr-ready"]
+              command: ["/bin/sh", "-c", "rm -f /run/nvidia/validations/.driver-ctr-ready /run/nvidia/validations/.driver-daemons-status"]
         {{- end }}
       {{- if and (.GPUDirectRDMA) (deref .GPUDirectRDMA.Enabled) }}
       - image: {{ .Driver.ImagePath }}


### PR DESCRIPTION
This change is accompanied by the driver-container PR https://github.com/NVIDIA/gpu-driver-container/pull/913.

We introduce a new sentinel file called `.driver-daemons-status` which will help the driver container ensure that the Fabric Manager and other daemons are all fully up and running before the driver container goes into the `Running` state.

For reasons of backward compatibility, we only enforce this check if the `.driver-daemons-status` file is present. This way, the operator will continue to work with other driver containers that don't have this capability 