### PR TITLE
fix user to an existing user in distroless image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,7 +124,7 @@ COPY deployments/gpu-operator/crds/nvidia.com_nvidiadrivers.yaml /opt/gpu-operat
 COPY deployments/gpu-operator/crds/nvidia.com_gpuclusters.yaml /opt/gpu-operator/nvidia.com_gpuclusters.yaml
 COPY deployments/gpu-operator/charts/node-feature-discovery/crds/nfd-api-crds.yaml /opt/gpu-operator/nfd-api-crds.yaml
 
-USER 65532:65532
+USER 1000:1000
 
 COPY LICENSE /licenses/
 


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Currently, we were using a user id which doesn't exist in our distroless image. This fix switches it to the user which exists in the distroless image.

```
root@rahulsharm-dev1:~# docker run -it nvcr.io/nvidia/distroless/go:v4.0.9-dev
/app $ cat /etc/passwd
nvs:x:1000:1000:nvs:/home/nvs:/sbin/nologin
/app $
```

Previous user id which we were using was applicable to gcr distroless images only.
```
root@rahulsharm-dev1:~# docker run -it --entrypoint=/busybox/sh gcr.io/distroless/static-debian12:debug
/ # cat /etc/passwd
root:x:0:0:root:/root:/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin
nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin
/ #
```

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

