### PR TITLE
add OCI standard image labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,8 @@ build-image:
 		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \
 		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--build-arg GIT_COMMIT_SHA_FULL="$(GIT_COMMIT_SHA_FULL)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--build-arg GOPROXY="$(GOPROXY)" \
 		--file $(DOCKERFILE) $(CURDIR)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,6 +89,8 @@ ENV NVIDIA_VISIBLE_DEVICES=void
 
 ARG VERSION="unknown"
 ARG GIT_COMMIT="unknown"
+ARG GIT_COMMIT_SHA_FULL="unknown"
+ARG BUILD_TIMESTAMP
 
 LABEL io.k8s.display-name="NVIDIA GPU Operator"
 LABEL name="NVIDIA GPU Operator"
@@ -98,6 +100,15 @@ LABEL release="N/A"
 LABEL summary="Automate the management and monitoring of NVIDIA GPUs."
 LABEL description="See summary"
 LABEL vsc-ref=${GIT_COMMIT}
+LABEL org.opencontainers.base.name="nvcr.io/nvidia/distroless/cc"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT_SHA_FULL}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-operator.git"
+LABEL org.opencontainers.image.title="NVIDIA GPU Operator"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpu-operator"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 WORKDIR /
 

--- a/versions.mk
+++ b/versions.mk
@@ -26,3 +26,4 @@ GOLANGCI_LINT_VERSION ?= v2.12.2
 REGCTL_VERSION ?= v0.11.5
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always 2> /dev/null || echo "")
+GIT_COMMIT_SHA_FULL ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")


### PR DESCRIPTION
This PR adds well-known OCI Image labels to the gpu-operator image metadata. 

**Before this PR**
```
{
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA GPU Operator",
  "name": "NVIDIA GPU Operator",
  "org.opencontainers.image.created": "2026-06-11T18:01:15Z",
  "org.opencontainers.image.documentation": "https://developer.download.nvidia.com/distroless-oss/docs.html",
  "org.opencontainers.image.revision": "d5891068bf92407b17825c29f462da9643457b04",
  "org.opencontainers.image.title": "C/C++ Distroless Image",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.version": "v4.0.8",
  "release": "N/A",
  "summary": "Automate the management and monitoring of NVIDIA GPUs.",
  "vendor": "NVIDIA",
  "version": "b0a49c0e-arm64",
  "vsc-ref": "b0a49c0"
}
```

**After**
```
{
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA GPU Operator",
  "name": "NVIDIA GPU Operator",
  "org.opencontainers.base.name": "nvcr.io/nvidia/distroless/cc",
  "org.opencontainers.image.created": "2026-08-12T16:31:35Z",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "8f860a721d9bd6d4018cd957a71d49987c891ecc",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/gpu-operator.git",
  "org.opencontainers.image.title": "NVIDIA GPU Operator",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/gpu-operator",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "8f860a72-amd64",
  "release": "N/A",
  "summary": "Automate the management and monitoring of NVIDIA GPUs.",
  "vendor": "NVIDIA",
  "version": "8f860a72-amd64",
  "vsc-ref": "8f860a7"
}
```