### PR TITLE
[ci] ignore cooldown for nvidia controlled packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      exclude:
+        - github.com/NVIDIA/*
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -23,6 +26,9 @@ updates:
     directory: "/tools"
     schedule:
       interval: "daily"
+    cooldown:
+      exclude:
+        - github.com/NVIDIA/*
     labels:
       - dependencies
 


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This PR makes dependabot to ignore cooldown for nvidia controlled packages.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

