### PR TITLE
quote driver version so that its not considered integer/float

### DIFF
--- a/deployments/gpu-operator/templates/nvidiadriver.yaml
+++ b/deployments/gpu-operator/templates/nvidiadriver.yaml
@@ -8,7 +8,7 @@ spec:
   default: true
   repository: {{ .Values.driver.repository }}
   image: {{ .Values.driver.image }}
-  version: {{ .Values.driver.version }}
+  version: {{ .Values.driver.version | quote }}
   kernelModuleType: {{ .Values.driver.kernelModuleType }}
   usePrecompiled: {{ .Values.driver.usePrecompiled }}
   driverType: {{ .Values.driver.nvidiaDriverCRD.driverType | default "gpu" }}


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Quote `driver.version` in the default NVIDIADriver Helm template.

Without quoting, versions such as `620.15` are rendered as YAML numbers, but the CRD requires a string. This allows `--set-string driver.version=620.15` to work as expected.

Thanks to @rajathagasthya for finding this gap and suggesting the fix.
## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

