### PR TITLE
Make Renovate update Dockerfile base image digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -72,11 +72,9 @@
         "docker/Dockerfile.devel"
       ],
       "matchStrings": [
-        "FROM golang:(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "FROM (?<depName>\\S+):(?<currentValue>[^\\s@]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version",
-      "versioningTemplate": "semver"
+      "datasourceTemplate": "docker"
     }
   ],
   "labels": [
@@ -170,8 +168,8 @@
     {
       "description": "Group all Go toolchain version bumps",
       "matchManagers": ["custom.regex"],
-      "matchPackageNames": ["go"],
-      "matchDatasources": ["golang-version"],
+      "matchPackageNames": ["go", "golang"],
+      "matchDatasources": ["golang-version", "docker"],
       "groupName": "Go toolchain",
       "groupSlug": "go-toolchain",
       "separateMajorMinor": false,


### PR DESCRIPTION
## Description

Renovate's custom manager for `docker/Dockerfile` matched only the golang version and resolved it via the `golang-version` datasource, which has no notion of image digests — PRs like #2759 bumped the tag but left the pinned `@sha256` digest unchanged. Since the digest takes precedence over the tag at pull time, docker pull silently uses the old image. The other digest-pinned base images (ubi9, debian, distroless/cc) were not managed at all.

Replace the golang-specific manager with a generic one that captures the image name, tag, and digest from every pinned `FROM` line and resolves updates via the `docker` datasource, so tag and digest are updated together. Non-version tags (`ubi9:latest`, `debian:trixie-slim`) get digest-only updates. The Go toolchain group rule is extended so golang image bumps still land in the same PR as the `versions.mk` `GOLANG_VERSION` bump.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

Verified the new `matchStrings` regex captures image name, tag, and digest for all five pinned `FROM` lines across `docker/Dockerfile` and `docker/Dockerfile.devel`.