### PR TITLE
fix: disable leader election for single replica deployment

### DIFF
--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: "gpu-operator"
     nvidia.com/gpu-driver-upgrade-drain.skip: "true"
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicas | default 1 }}
   selector:
     matchLabels:
       app.kubernetes.io/component: "gpu-operator"
@@ -39,7 +39,9 @@ spec:
         imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
         command: ["gpu-operator"]
         args:
+        {{- if gt (int (.Values.operator.replicas | default 1)) 1 }}
         - --leader-elect
+        {{- end }}
       {{- if .Values.operator.logging.develMode }}
         - --zap-devel
       {{- else }}


### PR DESCRIPTION
This change avoids unnecessary leader-election overhead, removing currently lease renewal failures upon API downtime.

## Description

<!-- Brief description of the change, including context or motivation -->
### Issue Observed 
In single-node clusters, the gpu-operator enters a CrashLoopBackOff cycle after every node reboot due to leader election lease renewal failures during transient API outages. This adds unnecessary recovery time before ClusterPolicy is reconciled.

The --leader-elect flag is unconditionally hardcoded in the Helm Deployment template, even though the default deployment runs a single replica. With only one replica, leader election provides zero availability benefit — there is no second replica to fail over to. Instead, every transient kube-apiserver disruption (expected during SNO MCP reconciliation) triggers a fatal leader election loss → os.Exit(1) → CrashLoopBackOff.

### Change proposal
This PR makes --leader-elect conditional on the replica count. It is only passed as an argument in case replica count is greater than 1. 


As a precedent, the NVIDIA Network Operator - Node Feature Discovery already implemented this pattern in https://github.com/Mellanox/network-operator/pull/2304 


## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths


## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->
- The operator controller image was built
- API Server downtime was performed 
- Node reboot was performed

The logs demonstrate that from previous ~5 pod restarts, after the fix there is a single restart (caused by node rebot). Leader Election logs attempting to acquire the lease, failing to update lock, failing to renew the lease, leader election lost are no longer present.
