### PR TITLE
fix driver toolkit alerts, KPI values, and metric documentation

### DIFF
--- a/assets/state-operator-metrics/0400_prometheus_rule_openshift.yaml
+++ b/assets/state-operator-metrics/0400_prometheus_rule_openshift.yaml
@@ -48,11 +48,12 @@ spec:
       labels:
         severity: warning
       annotations:
-        summary: GPU Operator DriverToolkit is enabled but NFD too old to support it
+        summary: GPU Operator DriverToolkit was requested but could not be enabled because NFD is too old
         description: |
-          The DriverToolkit is enabled in the GPU Operator
-          ClusterPolicy, but the NFD version deployed in the cluster
-          is too old to support it.
+          The DriverToolkit was requested in the GPU Operator
+          ClusterPolicy, but it could not be enabled because the NFD
+          version deployed in the cluster does not expose the required
+          OSTREE labels.
     - alert: GPUOperatorOpenshiftDriverToolkitEnabledImageStreamMissing
       expr: |
         gpu_operator_openshift_driver_toolkit_enabled == -1
@@ -62,11 +63,12 @@ spec:
       labels:
         severity: warning
       annotations:
-        summary: GPU Operator DriverToolkit is enabled but the driver-toolkit imagestream is missing
+        summary: GPU Operator DriverToolkit was requested but could not be enabled because the driver-toolkit imagestream is missing
         description: |
-          The DriverToolkit is enabled in the GPU Operator
-          ClusterPolicy, but this version of OpenShift does not
-          support it (driver-toolkit imagestream is not available).
+          The DriverToolkit was requested in the GPU Operator
+          ClusterPolicy, but it could not be enabled because the
+          driver-toolkit imagestream is not available in this version
+          of OpenShift.
 
     - alert: GPUOperatorOpenshiftDriverToolkitEnabledImageStreamBroken
       expr: |

--- a/controllers/operator_metrics.go
+++ b/controllers/operator_metrics.go
@@ -128,14 +128,14 @@ func InitOperatorMetrics() *OperatorMetrics {
 			promcli.GaugeOpts{
 				Namespace: operatorMetricsNamespace,
 				Name:      "openshift_driver_toolkit_nfd_too_old",
-				Help:      "1 if OCP DriverToolkit is enabled but NFD doesn't expose OSTREE labels, 0 otherwise",
+				Help:      "1 if OCP DriverToolkit was requested but NFD does not expose the required OSTREE labels, 0 otherwise",
 			},
 		),
 		openshiftDriverToolkitIsMissing: promcli.NewGauge(
 			promcli.GaugeOpts{
 				Namespace: operatorMetricsNamespace,
 				Name:      "openshift_driver_toolkit_imagestream_missing",
-				Help:      "1 if OCP DriverToolkit is enabled but its imagestream is not available, 0 otherwise",
+				Help:      "1 if OCP DriverToolkit was requested but its imagestream is not available, 0 otherwise",
 			},
 		),
 		openshiftDriverToolkitRhcosTagsMissing: promcli.NewGauge(


### PR DESCRIPTION
## Issue: 
Two OpenShift DriverToolkit alerts fired when the feature was requested but could not be enabled (`gpu_operator_openshift_driver_toolkit_enabled == -1`). However, their alert text and metric descriptions said the DriverToolkit “`is enabled,`” which contradicted the KPI value and made fault analysis misleading.

## Changed:
- Updated the NFD-too-old alert to state that DriverToolkit was requested but could not be enabled because NFD lacks the required OSTREE labels.
- Updated the missing-imagestream alert to state that DriverToolkit was requested but could not be enabled because the OpenShift driver-toolkit imagestream is unavailable.
- Updated the corresponding Prometheus metric help text to use the same accurate state description.

This aligns the alerts, KPI values, and metric documentation for future diagnosis.
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

