### PR TITLE
bump gpu-operator to v26.7.0

### DIFF
--- a/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    olm.skipRange: '>=1.9.0 <26.3.3'
+    olm.skipRange: '>=1.9.0 <26.7.0'
     alm-examples: |-
       [
         {
@@ -241,7 +241,7 @@ metadata:
     provider: NVIDIA
     repository: http://github.com/NVIDIA/gpu-operator
     support: NVIDIA
-  name: gpu-operator-certified.v26.3.3
+  name: gpu-operator-certified.v26.7.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1175,5 +1175,5 @@ spec:
   maturity: stable
   provider:
     name: NVIDIA Corporation
-  version: 26.3.3
-  replaces: gpu-operator-certified.v26.3.2
+  version: 26.7.0
+  replaces: gpu-operator-certified.v26.3.3

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: stable,v26.3
-  operators.operatorframework.io.bundle.channel.default.v1: v26.3
+  operators.operatorframework.io.bundle.channels.v1: stable,v26.7
+  operators.operatorframework.io.bundle.channel.default.v1: v26.7
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/versions.mk
+++ b/versions.mk
@@ -17,7 +17,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= v26.3.3
+VERSION ?= v26.7.0
 
 GOLANG_VERSION ?= 1.26.6
 


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Bump gpu-operator to v26.7.0

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

