### PR TITLE
Fix state tracking when NVIDIA driver DaemonSet cleanup fails

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -965,13 +965,13 @@ func (n *ClusterPolicyController) step() (gpuv1.State, error) {
 	if (n.stateNames[n.idx] == "state-driver" || n.stateNames[n.idx] == "state-vgpu-manager") &&
 		n.singleton.Spec.Driver.UseNvidiaDriverCRDType() {
 		n.logger.Info("NVIDIADriver CRD is enabled, cleaning up all NVIDIA driver daemonsets owned by ClusterPolicy")
-		n.idx++
 		// Cleanup all driver daemonsets owned by ClusterPolicy while keeping the
 		// running driver pods available until NVIDIADriver rolls replacements.
 		err := n.cleanupAllDriverDaemonSets(n.ctx, metav1.DeletePropagationOrphan)
 		if err != nil {
 			return gpuv1.NotReady, fmt.Errorf("failed to cleanup all NVIDIA driver daemonsets owned by ClusterPolicy: %w", err)
 		}
+		n.idx++
 		return gpuv1.Disabled, nil
 	}
 

--- a/controllers/state_manager_test.go
+++ b/controllers/state_manager_test.go
@@ -165,6 +165,80 @@ func TestGetGPUNodeOSInfoListError(t *testing.T) {
 	require.Contains(t, err.Error(), "unable to list nodes with GPU present")
 }
 
+func TestStep(t *testing.T) {
+	expectedErr := errors.New("step failed")
+	driverCRDPolicy := &gpuv1.ClusterPolicy{
+		Spec: gpuv1.ClusterPolicySpec{
+			Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: ptr.To(true)},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		controller     ClusterPolicyController
+		expectedStatus gpuv1.State
+		expectedIndex  int
+		expectedError  error
+	}{
+		{
+			name: "normal state advances on success",
+			controller: ClusterPolicyController{
+				controls:   []controlFunc{{func(ClusterPolicyController) (gpuv1.State, error) { return gpuv1.Ready, nil }}},
+				stateNames: []string{"test-state"},
+			},
+			expectedStatus: gpuv1.Ready,
+			expectedIndex:  1,
+		},
+		{
+			name: "normal state does not advance on error",
+			controller: ClusterPolicyController{
+				controls:   []controlFunc{{func(ClusterPolicyController) (gpuv1.State, error) { return gpuv1.NotReady, expectedErr }}},
+				stateNames: []string{"test-state"},
+			},
+			expectedStatus: gpuv1.NotReady,
+			expectedIndex:  0,
+			expectedError:  expectedErr,
+		},
+		{
+			name: "driver cleanup advances on success",
+			controller: ClusterPolicyController{
+				ctx:        context.Background(),
+				client:     errorListClient{},
+				singleton:  driverCRDPolicy,
+				stateNames: []string{"state-driver"},
+			},
+			expectedStatus: gpuv1.Disabled,
+			expectedIndex:  1,
+		},
+		{
+			name: "driver cleanup does not advance on error",
+			controller: ClusterPolicyController{
+				ctx:        context.Background(),
+				client:     errorListClient{err: expectedErr},
+				singleton:  driverCRDPolicy,
+				stateNames: []string{"state-driver"},
+			},
+			expectedStatus: gpuv1.NotReady,
+			expectedIndex:  0,
+			expectedError:  expectedErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, err := tc.controller.step()
+
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedStatus, status)
+			require.Equal(t, tc.expectedIndex, tc.controller.idx)
+		})
+	}
+}
+
 func TestGetGPUNodeOSInfoNoGPUNodes(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
## Description

Fix state tracking when NVIDIA driver DaemonSet cleanup fails. The controller now advances to the next state only after cleanup succeeds, ensuring errors are attributed to the correct state.

Adds table-driven tests covering state advancement for normal and driver-cleanup success and error paths.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

- Added unit tests to test the fix


