### PR TITLE
Mount host /lib/modules for precompiled drivers on SUSE

### DIFF
--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -91,6 +91,33 @@ func getYAMLString(objs []*unstructured.Unstructured) (string, error) {
 	return sb.String(), nil
 }
 
+func findVolumeByName(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMountByName(volumeMounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range volumeMounts {
+		if volumeMounts[i].Name == name {
+			return &volumeMounts[i]
+		}
+	}
+	return nil
+}
+
+func findContainerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
 func hasSubscriptionVolumeMount(volumeMounts []corev1.VolumeMount) bool {
 	for _, volumeMount := range volumeMounts {
 		if strings.HasPrefix(volumeMount.Name, "subscription-config-") {
@@ -653,6 +680,119 @@ func TestDriverAdditionalConfigsSubscriptionMounts(t *testing.T) {
 
 			assertSubscriptionHostPathVolumes(t, configs.Volumes, tc.expectedSubscriptionHostMap)
 			assert.Equal(t, tc.expectSubscriptionMounts, hasSubscriptionVolumeMount(configs.VolumeMounts))
+		})
+	}
+}
+
+func TestDriverPrecompiledLibModules(t *testing.T) {
+	const (
+		libModulesVolumeName     = "lib-modules"
+		driverContainerName      = "nvidia-driver-ctr"
+		precompiledKernelVersion = "5.14.21-150500.55.44-default"
+	)
+
+	state, err := NewStateDriver(
+		fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+		"test-ns",
+		scheme.Scheme,
+		manifestDir)
+	require.NoError(t, err)
+	stateDriver, ok := state.(*stateDriver)
+	require.True(t, ok)
+
+	clusterInfo := testClusterInfo{runtime: consts.Containerd}
+
+	testCases := []struct {
+		description             string
+		osRelease               string
+		osVersion               string
+		usePrecompiled          bool
+		expectLibModulesMounted bool
+	}{
+		{
+			description:             "sles with precompiled drivers mounts host /lib/modules",
+			osRelease:               "sles",
+			osVersion:               "15.6",
+			usePrecompiled:          true,
+			expectLibModulesMounted: true,
+		},
+		{
+			description:             "sl-micro with precompiled drivers mounts host /lib/modules",
+			osRelease:               "sl-micro",
+			osVersion:               "6.0",
+			usePrecompiled:          true,
+			expectLibModulesMounted: true,
+		},
+		{
+			description:             "sles without precompiled drivers does not mount host /lib/modules",
+			osRelease:               "sles",
+			osVersion:               "15.6",
+			usePrecompiled:          false,
+			expectLibModulesMounted: false,
+		},
+		{
+			description:             "ubuntu with precompiled drivers does not mount host /lib/modules",
+			osRelease:               "ubuntu",
+			osVersion:               "22.04",
+			usePrecompiled:          true,
+			expectLibModulesMounted: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			driver := &nvidiav1alpha1.NVIDIADriver{}
+			driver.Spec.UsePrecompiled = ptr.To(tc.usePrecompiled)
+
+			additionalConfigs, err := stateDriver.getDriverAdditionalConfigs(
+				context.Background(),
+				driver,
+				clusterInfo,
+				nodePool{osRelease: tc.osRelease, osVersion: tc.osVersion},
+			)
+			require.NoError(t, err)
+
+			renderData := getMinimalDriverRenderData()
+			renderData.Driver.Spec.UsePrecompiled = ptr.To(tc.usePrecompiled)
+			renderData.AdditionalConfigs = additionalConfigs
+			if tc.usePrecompiled {
+				renderData.Precompiled = &precompiledSpec{
+					KernelVersion:          precompiledKernelVersion,
+					SanitizedKernelVersion: precompiledKernelVersion,
+				}
+			}
+
+			objs, err := stateDriver.renderer.RenderObjects(
+				&render.TemplatingData{
+					Data: renderData,
+				})
+			require.NoError(t, err)
+
+			ds, err := getDaemonsetFromObjects(objs)
+			require.NoError(t, err)
+
+			libModulesVolume := findVolumeByName(ds.Spec.Template.Spec.Volumes, libModulesVolumeName)
+
+			driverContainer := findContainerByName(ds.Spec.Template.Spec.Containers, driverContainerName)
+			require.NotNil(t, driverContainer)
+
+			libModulesMount := findVolumeMountByName(driverContainer.VolumeMounts, libModulesVolumeName)
+
+			if !tc.expectLibModulesMounted {
+				assert.Nil(t, libModulesVolume, "unexpected lib-modules volume on the driver pod spec")
+				assert.Nil(t, libModulesMount, "unexpected lib-modules volume mount on nvidia-driver-ctr")
+				return
+			}
+
+			require.NotNil(t, libModulesVolume, "expected a lib-modules volume on the driver pod spec")
+			require.NotNil(t, libModulesVolume.HostPath)
+			assert.Equal(t, "/lib/modules", libModulesVolume.HostPath.Path)
+			require.NotNil(t, libModulesVolume.HostPath.Type)
+			assert.Equal(t, corev1.HostPathDirectory, *libModulesVolume.HostPath.Type)
+
+			require.NotNil(t, libModulesMount, "expected a lib-modules volume mount on nvidia-driver-ctr")
+			assert.Equal(t, "/run/host/lib/modules", libModulesMount.MountPath)
+			assert.True(t, libModulesMount.ReadOnly)
 		})
 	}
 }

--- a/internal/state/driver_volumes.go
+++ b/internal/state/driver_volumes.go
@@ -220,29 +220,27 @@ func (s *stateDriver) getDriverAdditionalConfigs(ctx context.Context, cr *v1alph
 				additionalCfgs.Volumes = append(additionalCfgs.Volumes, subscriptionVol)
 			}
 		}
+	}
 
-		// Mount /lib/modules for precompiled drivers on SUSE distributions.
-		// Those containers need access to host /lib/modules at runtime.
-		if cr.Spec.UsePrecompiledDrivers() && (pool.osRelease == "sles" || pool.osRelease == "sl-micro") {
-			logger.Info("Mounting /lib/modules into the driver container")
-			libModulesVolMount := corev1.VolumeMount{
-				Name:      "lib-modules",
-				MountPath: "/run/host/lib/modules",
-				ReadOnly:  true,
-			}
-			additionalCfgs.VolumeMounts = append(additionalCfgs.VolumeMounts, libModulesVolMount)
-
-			libModulesVol := corev1.Volume{
-				Name: "lib-modules",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/lib/modules",
-						Type: ptr.To(corev1.HostPathDirectory),
-					},
-				},
-			}
-			additionalCfgs.Volumes = append(additionalCfgs.Volumes, libModulesVol)
+	if cr.Spec.UsePrecompiledDrivers() && (pool.osRelease == "sles" || pool.osRelease == "sl-micro") {
+		logger.Info("Mounting /lib/modules into the driver pod")
+		libModulesVolMount := corev1.VolumeMount{
+			Name:      "lib-modules",
+			MountPath: "/run/host/lib/modules",
+			ReadOnly:  true,
 		}
+		additionalCfgs.VolumeMounts = append(additionalCfgs.VolumeMounts, libModulesVolMount)
+
+		libModulesVol := corev1.Volume{
+			Name: "lib-modules",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/lib/modules",
+					Type: ptr.To(corev1.HostPathDirectory),
+				},
+			},
+		}
+		additionalCfgs.Volumes = append(additionalCfgs.Volumes, libModulesVol)
 	}
 
 	// mount any custom kernel module configuration parameters at /drivers


### PR DESCRIPTION
## Description

Fixes #2776.

`getDriverAdditionalConfigs` builds the `lib-modules` volume and mount inside the
`if !cr.Spec.UsePrecompiledDrivers()` branch, and the block itself is guarded by
`if cr.Spec.UsePrecompiledDrivers() && (pool.osRelease == "sles" || pool.osRelease == "sl-micro")`.
The inner condition can never hold in that branch, so an NVIDIADriver with
`usePrecompiled: true` on sles or sl-micro renders a driver pod without
`/run/host/lib/modules`.

Rather than repeat the predicate, the mount now hangs off the non-precompiled
branch as an `else`. The two paths are mutually exclusive, and saying so once
gives precompiled-only logic an obvious home, which is what went wrong here in
the first place. The comment above the mount goes with it: the `else` already
says precompiled, the guard already says SUSE, and the volume literals already
say host module tree.

This only affects the NVIDIADriver path. The equivalent code in
`controllers/object_controls.go` sits before the early return for precompiled
drivers and works as intended. That is also why it went unnoticed, since the
tests that came in with a7323f51 only covered the ClusterPolicy path.

One note for triage: the issue lists v24.9.2 under Environment, but v24.9.2 has
no `lib-modules` handling in either driver path, so the unreachable code
described in the report cannot exist there. The line numbers quoted in the issue
match current main. A v24.9.2 user on precompiled SUSE does see the same missing
mount, but because the feature had not landed yet rather than because of this
bug.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Added `TestDriverPrecompiledLibModules`, a table-driven test covering sles and
sl-micro with precompiled drivers, plus sles without them and ubuntu with them
as negative cases. Each case renders the DaemonSet and checks the pod spec for
the `lib-modules` hostPath volume and `nvidia-driver-ctr` for the mount, so it
covers both the helper and the template threading `AdditionalConfigs` into the
pod.

The two SUSE cases fail against the current code with "expected a lib-modules
volume on the driver pod spec" and pass with the fix. Removing the
`AdditionalConfigs` mounts from the driver container in
`manifests/state-driver/0500_daemonset.yaml` also fails the test, which the
helper-level assertions alone would not have caught.

`go test ./internal/... ./controllers/...` passes, along with `go vet`, gofmt
and `-race`. Lint and the generated-asset check were run with `GOOS=linux`,
since the vendored `filepath-securejoin/pathrs-lite` is linux-only and breaks
the typecheck of `cmd/nvidia-validator` on macOS. Regenerating the CRDs produces
no diff.
