### PR TITLE
Revert "build(deps): Bump github/codeql-action/analyze from 4.37.7 to 4.37.8"

### DIFF
--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -42,6 +42,6 @@ jobs:
         make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
       with:
         category: "/language:go"


### PR DESCRIPTION
Reverts NVIDIA/gpu-operator#2786

This change didn't worked. It requires codeql-action to also be updated. Reverting this change