### PR TITLE
[ci] fix codeql-action version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action/*

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -32,7 +32,7 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
       with:
         languages: go
         build-mode: manual


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
Previously, dependabot considered codeql-action/init and codeql-action/analyze as two different action dependencies. They both are tied together and should be bumped together.

Fixed the outdated codeql-action/init version and also added dependabot rule to group them.
## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

