### PR TITLE
Fix gpuop-cfg panic when validating a ClusterPolicy with no GDS configuration

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -2128,8 +2128,10 @@ func ImagePath(spec interface{}) (string, error) {
 		config := spec.(*DriverManagerSpec)
 		return imagePath(config.Repository, config.Image, config.Version, "DRIVER_MANAGER_IMAGE")
 	case *GPUDirectStorageSpec:
-		config := spec.(*GPUDirectStorageSpec)
-		return imagePath(config.Repository, config.Image, config.Version, "GDS_IMAGE")
+		if v == nil {
+			return "", fmt.Errorf("invalid nil GPUDirectStorageSpec to construct image path")
+		}
+		return imagePath(v.Repository, v.Image, v.Version, "GDS_IMAGE")
 	case *GDRCopySpec:
 		config := spec.(*GDRCopySpec)
 		return imagePath(config.Repository, config.Image, config.Version, "GDRCOPY_IMAGE")

--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	kata_v1alpha1 "github.com/NVIDIA/k8s-kata-manager/api/v1alpha1/config"
@@ -2087,6 +2088,14 @@ func imagePath(repository string, image string, version string, imagePathEnvName
 
 // ImagePath sets image path for given component type
 func ImagePath(spec interface{}) (string, error) {
+	if spec == nil {
+		return "", fmt.Errorf("invalid nil spec to construct image path")
+	}
+	value := reflect.ValueOf(spec)
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		return "", fmt.Errorf("invalid nil spec to construct image path: %T", spec)
+	}
+
 	switch v := spec.(type) {
 	case *DriverSpec:
 		config := spec.(*DriverSpec)
@@ -2128,9 +2137,6 @@ func ImagePath(spec interface{}) (string, error) {
 		config := spec.(*DriverManagerSpec)
 		return imagePath(config.Repository, config.Image, config.Version, "DRIVER_MANAGER_IMAGE")
 	case *GPUDirectStorageSpec:
-		if v == nil {
-			return "", fmt.Errorf("invalid nil GPUDirectStorageSpec to construct image path")
-		}
 		return imagePath(v.Repository, v.Image, v.Version, "GDS_IMAGE")
 	case *GDRCopySpec:
 		config := spec.(*GDRCopySpec)

--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -2092,7 +2092,7 @@ func ImagePath(spec interface{}) (string, error) {
 		return "", fmt.Errorf("invalid nil spec to construct image path")
 	}
 	value := reflect.ValueOf(spec)
-	if value.Kind() == reflect.Ptr && value.IsNil() {
+	if value.Kind() == reflect.Pointer && value.IsNil() {
 		return "", fmt.Errorf("invalid nil spec to construct image path: %T", spec)
 	}
 

--- a/api/nvidia/v1/clusterpolicy_types_test.go
+++ b/api/nvidia/v1/clusterpolicy_types_test.go
@@ -72,13 +72,17 @@ func TestImagePath(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid type to construct image path")
 	})
 
-	t.Run("nil GDS spec errors", func(t *testing.T) {
-		var spec *GPUDirectStorageSpec
-
-		path, err := ImagePath(spec)
-
+	t.Run("nil spec errors", func(t *testing.T) {
+		path, err := ImagePath(nil)
 		require.Error(t, err)
 		assert.Empty(t, path)
-		assert.ErrorContains(t, err, "invalid nil GPUDirectStorageSpec")
+		assert.ErrorContains(t, err, "invalid nil spec")
+	})
+
+	t.Run("typed nil spec errors", func(t *testing.T) {
+		path, err := ImagePath((*GPUDirectStorageSpec)(nil))
+		require.Error(t, err)
+		assert.Empty(t, path)
+		assert.ErrorContains(t, err, "invalid nil spec")
 	})
 }

--- a/api/nvidia/v1/clusterpolicy_types_test.go
+++ b/api/nvidia/v1/clusterpolicy_types_test.go
@@ -71,4 +71,14 @@ func TestImagePath(t *testing.T) {
 		assert.Empty(t, path)
 		assert.ErrorContains(t, err, "invalid type to construct image path")
 	})
+
+	t.Run("nil GDS spec errors", func(t *testing.T) {
+		var spec *GPUDirectStorageSpec
+
+		path, err := ImagePath(spec)
+
+		require.Error(t, err)
+		assert.Empty(t, path)
+		assert.ErrorContains(t, err, "invalid nil GPUDirectStorageSpec")
+	})
 }

--- a/cmd/gpuop-cfg/validate/clusterpolicy/images.go
+++ b/cmd/gpuop-cfg/validate/clusterpolicy/images.go
@@ -106,17 +106,19 @@ func validateImages(ctx context.Context, spec *v1.ClusterPolicySpec) error {
 		return fmt.Errorf("failed to validate image %s: %v", path, err)
 	}
 
-	// GPUDirectStorage
-	path, err = v1.ImagePath(spec.GPUDirectStorage)
-	if err != nil {
-		return fmt.Errorf("failed to construct the image path: %v", err)
-	}
-	// For GDS driver, we must append the os-tag
-	path += "-ubuntu22.04"
+	// GPUDirectStorage is optional and nil when GDS is omitted from the ClusterPolicy.
+	if spec.GPUDirectStorage != nil {
+		path, err = v1.ImagePath(spec.GPUDirectStorage)
+		if err != nil {
+			return fmt.Errorf("failed to construct the image path: %v", err)
+		}
+		// For GDS driver, we must append the os-tag
+		path += "-ubuntu22.04"
 
-	err = validateImage(ctx, path)
-	if err != nil {
-		return fmt.Errorf("failed to validate image %s: %v", path, err)
+		err = validateImage(ctx, path)
+		if err != nil {
+			return fmt.Errorf("failed to validate image %s: %v", path, err)
+		}
 	}
 
 	// VFIOManager


### PR DESCRIPTION
## Description

Fix gpuop-cfg panic when validating a ClusterPolicy with no GDS configuration. Skip validation for an omitted GDS spec and make ImagePath return an error instead of dereferencing a typed-nil pointer.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing

Added unit tests also tested the CLI locally 

