### PR TITLE
Stop defaulting deprecated cdi.default in ClusterPolicy

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -1966,7 +1966,6 @@ type CDIConfigSpec struct {
 
 	// Deprecated: This field is no longer used. Setting cdi.enabled=true will configure CDI as the default mechanism for making GPUs accessible to containers.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Deprecated: This field is no longer used"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch,urn:alm:descriptor:com.tectonic.ui:hidden"

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -139,7 +139,6 @@ spec:
                   used in the cluster
                 properties:
                   default:
-                    default: false
                     description: 'Deprecated: This field is no longer used. Setting
                       cdi.enabled=true will configure CDI as the default mechanism
                       for making GPUs accessible to containers.'

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -139,7 +139,6 @@ spec:
                   used in the cluster
                 properties:
                   default:
-                    default: false
                     description: 'Deprecated: This field is no longer used. Setting
                       cdi.enabled=true will configure CDI as the default mechanism
                       for making GPUs accessible to containers.'

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -139,7 +139,6 @@ spec:
                   used in the cluster
                 properties:
                   default:
-                    default: false
                     description: 'Deprecated: This field is no longer used. Setting
                       cdi.enabled=true will configure CDI as the default mechanism
                       for making GPUs accessible to containers.'


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/gpu-operator/issues/2795

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

N/A

