### PR TITLE
Exclude golang from Dependabot's docker ecosystem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
     directory: "/docker"
     schedule:
       interval: "daily"
+    ignore:
+      # golang is managed by Renovate.
+      - dependency-name: "golang"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description

Dependabot's docker ecosystem entry for `/docker` was watching the same
Dockerfiles Renovate's custom regex manager already tracks for golang,
producing duplicate and conflicting PRs (e.g. Dependabot proposing a
tag-only bump like `1.27.0` -> `1.27` while Renovate correctly tracks the
pinned-digest image). Renovate already owns golang version and digest
tracking across `docker/Dockerfile`, `docker/Dockerfile.devel`, and
`versions.mk`, so Dependabot no longer needs to manage it.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

N/A — config-only change to `.github/dependabot.yml`.