### PR TITLE
Disable Renovate digest updates for builder-stage base images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -174,6 +174,13 @@
       "groupSlug": "go-toolchain",
       "separateMajorMinor": false,
       "separateMinorPatch": false
+    },
+    {
+      "description": "No digest-only updates for builder-stage images; digests are still re-pinned on tag changes",
+      "matchFileNames": ["docker/Dockerfile", "docker/Dockerfile.devel"],
+      "matchPackageNames": ["golang", "registry.access.redhat.com/ubi9/ubi", "debian"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description

golang, ubi9, and debian are only builder stages in `docker/Dockerfile` — no layers from them ship in the final image, so digest-only rebuilds of the same tag don't change what ships. Disable digest-type updates for them; digests remain pinned and are still updated when the tag changes. Digest updates stay enabled for the distroless runtime base.

Context: https://github.com/NVIDIA/gpu-operator/pull/2799#discussion_r3855272809

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

N/A — config-only change to `.github/renovate.json` (validated as well-formed JSON).