### PR TITLE
Add pprof endpoint flag to the operator

### DIFF
--- a/cmd/gpu-operator/main.go
+++ b/cmd/gpu-operator/main.go
@@ -78,9 +78,12 @@ func main() {
 	var enableLeaderElection bool
 	var leaderElectionNamespace string
 	var probeAddr string
+	var pprofAddr string
 	var renewDeadline time.Duration
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "",
+		"The address the pprof endpoint binds to (e.g. \":6060\"). Disabled when empty.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -136,6 +139,7 @@ func main() {
 		Scheme:                  scheme,
 		Metrics:                 metricsOptions,
 		HealthProbeBindAddress:  probeAddr,
+		PprofBindAddress:        pprofAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionNamespace: leaderElectionNamespace,
 		LeaderElectionID:        "53822513.nvidia.com",

--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -50,6 +50,9 @@ spec:
         - --zap-log-level={{- .Values.operator.logging.level }}
         {{- end }}
       {{- end }}
+      {{- if .Values.operator.pprof.bindAddress }}
+        - --pprof-bind-address={{ .Values.operator.pprof.bindAddress }}
+      {{- end }}
         env:
         - name: WATCH_NAMESPACE
           value: ""

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -111,6 +111,9 @@ operator:
     # Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn)
     # Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
     develMode: false
+  pprof:
+    # Bind address for the pprof profiling endpoint (e.g. ":6060"). Disabled when empty.
+    bindAddress: ""
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
## Description

Add a `--pprof-bind-address` flag wired to controller-runtime's built-in
pprof server (`ctrl.Options.PprofBindAddress`), for profiling the
operator's memory and CPU at large node counts. The endpoint is disabled
by default and only serves when an address (e.g. `":6060"`) is given.

The address is exposed as the `operator.pprof.bindAddress` chart value,
passed to the operator only when set.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

`go build ./cmd/gpu-operator`; `helm template` with and without
`operator.pprof.bindAddress` set (flag rendered only when set); `helm lint`.