### PR TITLE
fix(ci): use least-privilege token permissions in GHA workflows

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -21,9 +21,7 @@ on:
     types: [closed]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   add-labels:
@@ -32,9 +30,13 @@ jobs:
     # Run on /cherry-pick comments on PRs
     if: |
       github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request && 
+      github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/cherry-pick')
-    
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -62,7 +64,11 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.merged == true &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'cherry-pick/')
-    
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
     steps:
       - name: Checkout base branch repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
 
   code-scanning:
     permissions:
+      contents: read
       security-events: write
       packages: read
     uses: ./.github/workflows/code-scanning.yaml

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -17,6 +17,9 @@ name: "CodeQL"
 on:
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Go code with CodeQL

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -55,6 +55,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   variables:
     uses: ./.github/workflows/variables.yaml

--- a/.github/workflows/golang-checks.yaml
+++ b/.github/workflows/golang-checks.yaml
@@ -18,6 +18,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   go-check:
     runs-on: linux-amd64-cpu4

--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -30,6 +30,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   variables:
     runs-on: ubuntu-latest
@@ -147,6 +150,9 @@ jobs:
     needs: [variables, build-gpu-operator-arm64, build-gpu-operator-amd64]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         name: Check out code

--- a/.github/workflows/publish-helm-oci-chart.yaml
+++ b/.github/workflows/publish-helm-oci-chart.yaml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: publish-helm-oci-chart-${{ inputs.operator_version }}
@@ -43,6 +42,9 @@ jobs:
   publish-helm-chart:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
     outputs:
       chart_reference: ${{ steps.publish.outputs.chart_reference }}
       chart_version: ${{ steps.package.outputs.chart_version }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -5,9 +5,15 @@ on:
   schedule:
      - cron: "0 9 * * *" # every day at 9:00 AM UTC
 
+permissions:
+  contents: read
+
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/third-party-notices-check.yaml
+++ b/.github/workflows/third-party-notices-check.yaml
@@ -20,6 +20,9 @@ name: Third-Party Notices Check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-third-party-notices:
     runs-on: linux-amd64-cpu4

--- a/.github/workflows/variables.yaml
+++ b/.github/workflows/variables.yaml
@@ -48,6 +48,9 @@ on:
         description: "The operator image (with override support)"
         value: ${{ jobs.variables.outputs.operator_image }}
 
+permissions:
+  contents: read
+
 jobs:
   variables:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

OpenSSF Scorecard's Token-Permissions check flagged several reusable GHA workflows for not adhering to the principle of least-privilege for their GITHUB_TOKEN usage. This commit makes it so that the permissions definitions in each workflow's yaml file are set as read-only at the top level and the required write permissions are declared at the run-level.

Reference https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

Changes in this PR were made with the assistance of Claude Code.
## Checklist

- [X] No secrets, sensitive information, or unrelated changes
- [X] Lint checks passing (`make lint`)
- [X] Generated assets in-sync (`make validate-generated-assets`)
- [X] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

I ran https://github.com/ossf/scorecard with and without this change. With this change, our score for the `Token-Permissions` category jumps from 0/10 to 10/10

