### PR TITLE
[ci] wait for dcgm pod to be terminated if its installed

### DIFF
--- a/tests/scripts/verify-disable-operands.sh
+++ b/tests/scripts/verify-disable-operands.sh
@@ -18,4 +18,4 @@ check_pod_deleted "nvidia-device-plugin-daemonset"
 check_pod_deleted "nvidia-dcgm-exporter"
 check_pod_deleted "gpu-feature-discovery"
 check_pod_deleted "nvidia-operator-validator"
-
+check_pod_deleted "nvidia-dcgm"


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
In our CI, we enabled dcgm as well for some of the tests. When checking if all operands are disabled, we should also check for dcgm to make sure its pod is also deleted before enabling operands again.

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [ ] Generated assets in-sync (`make validate-generated-assets`)
- [ ] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

