### PR TITLE
remove stale TODO for nodepool unit tests

### DIFF
--- a/internal/state/nodepool.go
+++ b/internal/state/nodepool.go
@@ -36,7 +36,6 @@ const (
 )
 
 // TODO: move this code to it's own module?
-// TODO: add unit tests
 type nodePool struct {
 	name         string
 	osRelease    string


### PR DESCRIPTION
## Description
Removes a stale `// TODO: add unit tests` comment on the `nodePool` type in `internal/state/nodepool.go`. 
Test coverage for `getOSTag` and `getNodePools` already exists in `nodepool_test.go` (6 test functions).
No functional changes.

## Testing
Ran `go build ./internal/state/...` and the existing `nodepool_test.go` suite locally, all pass. No new tests needed.