### PR TITLE
remove dead commented-out validate() stub

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -993,11 +993,6 @@ func (n *ClusterPolicyController) step() (gpuv1.State, error) {
 	return result, nil
 }
 
-// TODO
-// func (n ClusterPolicyController) validate() {
-//	 add custom validation functions
-// }
-
 func (n ClusterPolicyController) last() bool {
 	return n.idx == len(n.controls)
 }


### PR DESCRIPTION
## Description
Removes an unused, commented-out `validate()` function stub and its TODO comment in `state_manager.go`. 
Never implemented, nothing references it. No functional changes.

## Testing
Ran `go build ./controllers/...` and full `go test ./controllers/... -v`, all pass.