### PR TITLE
Cleanup stale todos

### DIFF
--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -993,11 +993,6 @@ func (n *ClusterPolicyController) step() (gpuv1.State, error) {
 	return result, nil
 }
 
-// TODO
-// func (n ClusterPolicyController) validate() {
-//	 add custom validation functions
-// }
-
 func (n ClusterPolicyController) last() bool {
 	return n.idx == len(n.controls)
 }

--- a/internal/state/nodepool.go
+++ b/internal/state/nodepool.go
@@ -36,7 +36,6 @@ const (
 )
 
 // TODO: move this code to it's own module?
-// TODO: add unit tests
 type nodePool struct {
 	name         string
 	osRelease    string


### PR DESCRIPTION
   ## Description
   Combines two small cleanup changes (previously #2830 and a separate nodepool.go PR, merged per reviewer request):

   1. Removes an unused, commented-out `validate()` function stub and its TODO comment in `state_manager.go`. 
   Never implemented, nothing references it.
   2. Removes a stale `// TODO: add unit tests` comment in `nodepool.go`. 
   Test coverage already exists in `nodepool_test.go` (6 test functions).

   No functional changes in either commit.

   ## Testing
   `go build ./...` and full test suite for `controllers` and `internal/state` packages, all pass.