### PR TITLE
Modernize Go patterns and enforce them in lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - gocritic
     - gosec
     - misspell
+    - modernize
     - unconvert
   settings:
     gosec:

--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -2086,7 +2086,7 @@ func imagePath(repository string, image string, version string, imagePathEnvName
 }
 
 // ImagePath sets image path for given component type
-func ImagePath(spec interface{}) (string, error) {
+func ImagePath(spec any) (string, error) {
 	if spec == nil {
 		return "", fmt.Errorf("invalid nil spec to construct image path")
 	}

--- a/cmd/gpu-operator/main_test.go
+++ b/cmd/gpu-operator/main_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -72,32 +71,32 @@ func TestGPUPodSpecFilterResourceClaims(t *testing.T) {
 			name: "pod with a claim allocated by the NVIDIA GPU DRA driver",
 			objs: []runtime.Object{allocatedClaim("gpu-claim", "gpu.nvidia.com")},
 			pod: claimPod(corev1.PodRunning,
-				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: ptr.To("gpu-claim")}),
+				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: new("gpu-claim")}),
 			expected: true,
 		},
 		{
 			name: "pod with an admin-access claim is not a GPU pod",
 			objs: []runtime.Object{func() *resourcev1.ResourceClaim {
 				claim := allocatedClaim("admin-claim", "gpu.nvidia.com")
-				claim.Status.Allocation.Devices.Results[0].AdminAccess = ptr.To(true)
+				claim.Status.Allocation.Devices.Results[0].AdminAccess = new(true)
 				return claim
 			}()},
 			pod: claimPod(corev1.PodRunning,
-				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: ptr.To("admin-claim")}),
+				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: new("admin-claim")}),
 			expected: false,
 		},
 		{
 			name: "pod with a claim allocated by another DRA driver",
 			objs: []runtime.Object{allocatedClaim("nic-claim", "net.example.com")},
 			pod: claimPod(corev1.PodRunning,
-				corev1.PodResourceClaim{Name: "nic", ResourceClaimName: ptr.To("nic-claim")}),
+				corev1.PodResourceClaim{Name: "nic", ResourceClaimName: new("nic-claim")}),
 			expected: false,
 		},
 		{
 			name: "pod with an unallocated claim",
 			objs: []runtime.Object{allocatedClaim("pending-claim", "")},
 			pod: claimPod(corev1.PodRunning,
-				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: ptr.To("pending-claim")}),
+				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: new("pending-claim")}),
 			expected: false,
 		},
 		{
@@ -105,9 +104,9 @@ func TestGPUPodSpecFilterResourceClaims(t *testing.T) {
 			objs: []runtime.Object{allocatedClaim("pod-gpu-claim", "gpu.nvidia.com")},
 			pod: func() corev1.Pod {
 				p := claimPod(corev1.PodRunning,
-					corev1.PodResourceClaim{Name: "gpu", ResourceClaimTemplateName: ptr.To("single-gpu")})
+					corev1.PodResourceClaim{Name: "gpu", ResourceClaimTemplateName: new("single-gpu")})
 				p.Status.ResourceClaimStatuses = []corev1.PodResourceClaimStatus{
-					{Name: "gpu", ResourceClaimName: ptr.To("pod-gpu-claim")},
+					{Name: "gpu", ResourceClaimName: new("pod-gpu-claim")},
 				}
 				return p
 			}(),
@@ -116,14 +115,14 @@ func TestGPUPodSpecFilterResourceClaims(t *testing.T) {
 		{
 			name: "unresolvable claim counts as a GPU pod",
 			pod: claimPod(corev1.PodRunning,
-				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: ptr.To("missing-claim")}),
+				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: new("missing-claim")}),
 			expected: true,
 		},
 		{
 			name: "completed pod with a GPU claim is ignored",
 			objs: []runtime.Object{allocatedClaim("gpu-claim", "gpu.nvidia.com")},
 			pod: claimPod(corev1.PodSucceeded,
-				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: ptr.To("gpu-claim")}),
+				corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: new("gpu-claim")}),
 			expected: false,
 		},
 	}

--- a/cmd/nvidia-validator/main.go
+++ b/cmd/nvidia-validator/main.go
@@ -1317,8 +1317,8 @@ func (p *Plugin) runWorkload() error {
 	}
 
 	if os.Getenv(validatorImagePullSecretsEnvName) != "" {
-		pullSecrets := strings.Split(os.Getenv(validatorImagePullSecretsEnvName), ",")
-		for _, secret := range pullSecrets {
+		pullSecrets := strings.SplitSeq(os.Getenv(validatorImagePullSecretsEnvName), ",")
+		for secret := range pullSecrets {
 			pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: secret})
 		}
 	}
@@ -1385,7 +1385,7 @@ func (p *Plugin) runWorkload() error {
 
 // waits for the pod to be created
 func waitForPod(ctx context.Context, kubeClient kubernetes.Interface, name string, namespace string) error {
-	for i := 0; i < podCreationWaitRetries; i++ {
+	for range podCreationWaitRetries {
 		// check for the existence of the resource
 		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, meta_v1.GetOptions{})
 		if err != nil {
@@ -1581,8 +1581,8 @@ func (c *CUDA) runWorkload() error {
 	}
 
 	if os.Getenv(validatorImagePullSecretsEnvName) != "" {
-		pullSecrets := strings.Split(os.Getenv(validatorImagePullSecretsEnvName), ",")
-		for _, secret := range pullSecrets {
+		pullSecrets := strings.SplitSeq(os.Getenv(validatorImagePullSecretsEnvName), ",")
+		for secret := range pullSecrets {
 			pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: secret})
 		}
 	}

--- a/cmd/nvidia-validator/main_test.go
+++ b/cmd/nvidia-validator/main_test.go
@@ -160,8 +160,8 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 				target := filepath.Join(hostRoot, name)
 				require.NoError(t, os.MkdirAll(filepath.Dir(target), 0755))
 
-				if strings.HasPrefix(contents, "symlink=") {
-					require.NoError(t, os.Symlink(strings.TrimPrefix(contents, "symlink="), target))
+				if after, ok := strings.CutPrefix(contents, "symlink="); ok {
+					require.NoError(t, os.Symlink(after, target))
 					continue
 				}
 
@@ -484,4 +484,22 @@ func TestMdevParentDevicesExist(t *testing.T) {
 
 	require.NoError(t, mock.AddMockA100Parent("0000:3b:00.0", 0))
 	require.True(t, mdevParentDevicesExist(mock))
+}
+
+func TestCountNvidiaDevices(t *testing.T) {
+	testCases := []struct {
+		name     string
+		output   string
+		expected int
+	}{
+		{name: "empty output", expected: 0},
+		{name: "no NVIDIA devices", output: "Intel Corporation\nAMD", expected: 0},
+		{name: "multiple NVIDIA devices", output: "NVIDIA GPU\nIntel\nnvidia controller", expected: 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, countNvidiaDevices(tc.output))
+		})
+	}
 }

--- a/cmd/nvidia-validator/metrics.go
+++ b/cmd/nvidia-validator/metrics.go
@@ -261,7 +261,7 @@ func runLsPCI() (string, error) {
 
 func countNvidiaDevices(lspciStdout string) int {
 	count := 0
-	for _, line := range strings.Split(lspciStdout, "\n") {
+	for line := range strings.SplitSeq(lspciStdout, "\n") {
 		if strings.Contains(strings.ToLower(line), "nvidia") {
 			count++
 		}

--- a/controllers/clusterpolicy_controller_test.go
+++ b/controllers/clusterpolicy_controller_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -415,7 +414,7 @@ func TestClusterPolicyReconcileDriverUpgradeFailureCases(t *testing.T) {
 func clusterPolicyForUpgradeTest(useNvidiaDriverCRD bool) *gpuv1.ClusterPolicy {
 	return &gpuv1.ClusterPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster-policy"},
-		Spec:       gpuv1.ClusterPolicySpec{Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: ptr.To(useNvidiaDriverCRD)}},
+		Spec:       gpuv1.ClusterPolicySpec{Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: new(useNvidiaDriverCRD)}},
 	}
 }
 

--- a/controllers/gpucluster_controller_test.go
+++ b/controllers/gpucluster_controller_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -78,7 +77,7 @@ type fakeStateManager struct {
 	lastCatalog state.InfoCatalog
 }
 
-func (f *fakeStateManager) SyncState(_ context.Context, _ interface{}, catalog state.InfoCatalog) state.Results {
+func (f *fakeStateManager) SyncState(_ context.Context, _ any, catalog state.InfoCatalog) state.Results {
 	f.lastCatalog = catalog
 	return f.results
 }
@@ -160,7 +159,7 @@ func gccOwnedDaemonSet(name string, cr *nvidiav1alpha1.GPUCluster, claims bool, 
 				Kind:       "GPUCluster",
 				Name:       cr.Name,
 				UID:        cr.UID,
-				Controller: ptr.To(true),
+				Controller: new(true),
 			}},
 		},
 	}

--- a/controllers/nodelabeling_controller_test.go
+++ b/controllers/nodelabeling_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 
 	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
@@ -30,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -47,12 +47,10 @@ func podNodeNameIndexer(obj client.Object) []string {
 }
 
 // mergeLabels merges multiple label maps into one (last write wins).
-func mergeLabels(maps ...map[string]string) map[string]string {
+func mergeLabels(labels ...map[string]string) map[string]string {
 	out := make(map[string]string)
-	for _, m := range maps {
-		for k, v := range m {
-			out[k] = v
-		}
+	for _, labelSet := range labels {
+		maps.Copy(out, labelSet)
 	}
 	return out
 }
@@ -68,7 +66,7 @@ func TestNodeLabelingReconcileDefersDependentOperationsAfterGPULabelChanges(t *t
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster-policy"},
 		Spec: gpuv1.ClusterPolicySpec{
 			Driver: gpuv1.DriverSpec{
-				UseNvidiaDriverCRD: ptr.To(true),
+				UseNvidiaDriverCRD: new(true),
 			},
 		},
 	}
@@ -125,7 +123,7 @@ func TestNodeLabelingReconcileDoesNotDeferDependentOperationsForStateLabelChange
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster-policy"},
 		Spec: gpuv1.ClusterPolicySpec{
 			Driver: gpuv1.DriverSpec{
-				UseNvidiaDriverCRD: ptr.To(true),
+				UseNvidiaDriverCRD: new(true),
 			},
 		},
 	}
@@ -396,7 +394,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					SandboxWorkloads: gpuv1.SandboxWorkloadsSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Mode:    string(gpuv1.KubeVirt),
 					},
 				},
@@ -418,7 +416,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					SandboxWorkloads: gpuv1.SandboxWorkloadsSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Mode:    string(gpuv1.KubeVirt),
 					},
 				},
@@ -440,7 +438,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					SandboxWorkloads: gpuv1.SandboxWorkloadsSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Mode:    string(gpuv1.Kata),
 					},
 				},
@@ -462,7 +460,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					SandboxWorkloads: gpuv1.SandboxWorkloadsSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Mode:    string(gpuv1.Kata),
 					},
 				},
@@ -484,7 +482,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					SandboxWorkloads: gpuv1.SandboxWorkloadsSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Mode:    string(gpuv1.KubeVirt),
 					},
 				},
@@ -509,7 +507,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					MIGManager: gpuv1.MIGManagerSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Config:  &gpuv1.MIGPartedConfigSpec{Default: migConfigDisabledValue},
 					},
 				},
@@ -533,7 +531,7 @@ func TestUpdateGPUStateLabels(t *testing.T) {
 			clusterPolicy: &gpuv1.ClusterPolicy{
 				Spec: gpuv1.ClusterPolicySpec{
 					MIGManager: gpuv1.MIGManagerSpec{
-						Enabled: ptr.To(true),
+						Enabled: new(true),
 						Config:  &gpuv1.MIGPartedConfigSpec{Default: migConfigDisabledValue},
 					},
 				},
@@ -717,7 +715,7 @@ func TestDeferDRAPluginRemoval(t *testing.T) {
 		Spec: corev1.PodSpec{
 			NodeName: "test-node",
 			ResourceClaims: []corev1.PodResourceClaim{
-				{Name: "gpu", ResourceClaimName: ptr.To("gpu-claim")},
+				{Name: "gpu", ResourceClaimName: new("gpu-claim")},
 			},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
@@ -748,10 +746,10 @@ func TestDeferDRAPluginRemoval(t *testing.T) {
 		// unpreparing them still needs the kubelet-plugin, so they must defer its removal.
 		adminClaim := gpuClaim.DeepCopy()
 		adminClaim.Name = "admin-claim"
-		adminClaim.Status.Allocation.Devices.Results[0].AdminAccess = ptr.To(true)
+		adminClaim.Status.Allocation.Devices.Results[0].AdminAccess = new(true)
 		adminPod := claimPod.DeepCopy()
 		adminPod.Name = "admin-pod"
-		adminPod.Spec.ResourceClaims[0].ResourceClaimName = ptr.To("admin-claim")
+		adminPod.Spec.ResourceClaims[0].ResourceClaimName = new("admin-claim")
 		nlc := &nodeLabelingController{
 			client:        fake.NewClientBuilder().WithScheme(scheme).WithIndex(&corev1.Pod{}, podNodeNameIndexKey, podNodeNameIndexer).WithObjects(adminClaim, adminPod).Build(),
 			clusterPolicy: &gpuv1.ClusterPolicy{},
@@ -1046,7 +1044,7 @@ func TestLabelNodesWithOrphanedDriverPods(t *testing.T) {
 			nvidiaDrivers: []*nvidiav1alpha1.NVIDIADriver{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              driverName,
-					DeletionTimestamp: ptr.To(metav1.Now()),
+					DeletionTimestamp: new(metav1.Now()),
 					Finalizers:        []string{"test-finalizer"},
 				},
 			}},

--- a/controllers/nvidiadriver_controller_test.go
+++ b/controllers/nvidiadriver_controller_test.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -128,7 +127,7 @@ func TestReconcile(t *testing.T) {
 	}{
 		{
 			name:   "ClusterPolicy has driver CRD false → reconciliation skips driver",
-			useCRD: ptr.To(false),
+			useCRD: new(false),
 			validator: &FakeNodeSelectorValidator{
 				CustomError: errors.New("fake list error"),
 			},
@@ -137,7 +136,7 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:             "driver CRD false with GPUCluster → reconciliation still skips driver",
-			useCRD:           ptr.To(false),
+			useCRD:           new(false),
 			gpuClusterExists: true,
 			validator: &FakeNodeSelectorValidator{
 				CustomError: errors.New("fake list error"),
@@ -147,7 +146,7 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:   "ClusterPolicy has driver CRD true but validator errors",
-			useCRD: ptr.To(true),
+			useCRD: new(true),
 			validator: &FakeNodeSelectorValidator{
 				CustomError: errors.New("fake list error"),
 			},
@@ -156,8 +155,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:          "ClusterPolicy has driver disabled and driver CRD true but validator errors",
-			useCRD:        ptr.To(true),
-			driverEnabled: ptr.To(false),
+			useCRD:        new(true),
+			driverEnabled: new(false),
 			validator: &FakeNodeSelectorValidator{
 				CustomError: errors.New("fake list error"),
 			},
@@ -166,11 +165,11 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:   "driver CRD true, no validator errors, use precompiled drivers and GDS enabled",
-			useCRD: ptr.To(true),
+			useCRD: new(true),
 			spec: nvidiav1alpha1.NVIDIADriverSpec{
-				UsePrecompiled: ptr.To(true),
+				UsePrecompiled: new(true),
 				GPUDirectStorage: &nvidiav1alpha1.GPUDirectStorageSpec{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 				},
 			},
 			validator: &FakeNodeSelectorValidator{
@@ -256,7 +255,7 @@ func TestReconcileStandalone(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster-policy"},
 		Spec: gpuv1.ClusterPolicySpec{
 			Driver: gpuv1.DriverSpec{
-				UseNvidiaDriverCRD: ptr.To(true),
+				UseNvidiaDriverCRD: new(true),
 			},
 			HostPaths: gpuv1.HostPathsSpec{RootFS: "/cp-root"},
 		},
@@ -349,7 +348,7 @@ func TestReconcileConflictSetsNotReadyState(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Spec: gpuv1.ClusterPolicySpec{
 			Driver: gpuv1.DriverSpec{
-				UseNvidiaDriverCRD: ptr.To(true),
+				UseNvidiaDriverCRD: new(true),
 			},
 		},
 	}
@@ -394,7 +393,7 @@ func TestReconcileMultipleDefaultDriversSetsNotReadyState(t *testing.T) {
 	cp := &gpuv1.ClusterPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Spec: gpuv1.ClusterPolicySpec{
-			Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: ptr.To(true)},
+			Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: new(true)},
 		},
 	}
 

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -219,7 +220,7 @@ const (
 )
 
 // rootUID represents user 0
-var rootUID = ptr.To(int64(0))
+var rootUID = new(int64(0))
 
 // RepoConfigPathMap indicates standard OS specific paths for repository configuration files
 var RepoConfigPathMap = map[string]string{
@@ -805,9 +806,7 @@ func applyCommonDaemonsetMetadata(obj *appsv1.DaemonSet, dsSpec *gpuv1.Daemonset
 		if obj.Spec.Template.Annotations == nil {
 			obj.Spec.Template.Annotations = make(map[string]string)
 		}
-		for annoKey, annoVal := range dsSpec.Annotations {
-			obj.Spec.Template.Annotations[annoKey] = annoVal
-		}
+		maps.Copy(obj.Spec.Template.Annotations, dsSpec.Annotations)
 	}
 }
 
@@ -1483,7 +1482,7 @@ func transformRuntimeConfigAndSocketMounts(obj *appsv1.DaemonSet, runtime string
 	const runtimeConfigSourceFile = "file"
 	if runtimeConfigSources := getContainerEnv(container, "RUNTIME_CONFIG_SOURCE"); runtimeConfigSources != "" {
 		var sources []string
-		for _, runtimeConfigSource := range strings.Split(runtimeConfigSources, ",") {
+		for runtimeConfigSource := range strings.SplitSeq(runtimeConfigSources, ",") {
 			parts := strings.SplitN(runtimeConfigSource, "=", 2)
 			if len(parts) == 1 || parts[0] != runtimeConfigSourceFile {
 				sources = append(sources, runtimeConfigSource)
@@ -1896,7 +1895,7 @@ func TransformDCGMExporter(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpe
 	// Override the base asset's automountServiceAccountToken=false when the
 	// configuration reads from the Kubernetes API.
 	if config.DCGMExporter.IsKubernetesPodMetadataEnabled() || dcgmExporterEnvRequiresAPIAccess(config.DCGMExporter.Env) {
-		obj.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(true)
+		obj.Spec.Template.Spec.AutomountServiceAccountToken = new(true)
 	}
 
 	// mount configmap for custom metrics if provided by user
@@ -1976,9 +1975,7 @@ func addExtraAnnotations(obj *appsv1.DaemonSet, annotations map[string]string) {
 	if obj.Spec.Template.Annotations == nil {
 		obj.Spec.Template.Annotations = make(map[string]string)
 	}
-	for k, v := range annotations {
-		obj.Spec.Template.Annotations[k] = v
-	}
+	maps.Copy(obj.Spec.Template.Annotations, annotations)
 }
 
 // TransformDCGM transforms dcgm daemonset with required config as per ClusterPolicy
@@ -3380,7 +3377,7 @@ func transformOpenShiftDriverToolkitContainer(obj *appsv1.DaemonSet, config *gpu
 }
 
 // resolveDriverTag resolves image tag based on the OS of the worker node
-func resolveDriverTag(n ClusterPolicyController, driverSpec interface{}) (string, error) {
+func resolveDriverTag(n ClusterPolicyController, driverSpec any) (string, error) {
 	// obtain image path
 	var image string
 	var err error
@@ -4054,7 +4051,6 @@ func isDaemonSetReady(name string, n ClusterPolicyController) gpuv1.State {
 	n.logger.V(2).Info("daemonset template revision hash", "hash", daemonsetRevisionHash)
 
 	for _, pod := range dsPods {
-		pod := pod
 		podRevisionHash, err := getPodControllerRevisionHash(ctx, &pod)
 		if err != nil {
 			n.logger.Error(
@@ -4250,7 +4246,6 @@ func (n ClusterPolicyController) cleanupAllDriverDaemonSets(ctx context.Context,
 	}
 
 	for _, ds := range list.Items {
-		ds := ds
 		// filter out DaemonSets which are not the NVIDIA driver/vgpu-manager
 		if strings.HasPrefix(ds.Name, commonDriverDaemonsetName) || strings.HasPrefix(ds.Name, commonVGPUManagerDaemonsetName) {
 			n.logger.Info("Deleting NVIDIA driver daemonset owned by ClusterPolicy", "Name", ds.Name, "PropagationPolicy", propagationPolicy)
@@ -4741,18 +4736,14 @@ func DaemonSet(n ClusterPolicyController) (gpuv1.State, error) {
 		obj.Labels = make(map[string]string)
 	}
 
-	for labelKey, labelValue := range n.singleton.Spec.Daemonsets.Labels {
-		obj.Labels[labelKey] = labelValue
-	}
+	maps.Copy(obj.Labels, n.singleton.Spec.Daemonsets.Labels)
 
 	// Daemonsets will always have at least one annotation applied, so allocate if necessary
 	if obj.Annotations == nil {
 		obj.Annotations = make(map[string]string)
 	}
 
-	for annoKey, annoValue := range n.singleton.Spec.Daemonsets.Annotations {
-		obj.Annotations[annoKey] = annoValue
-	}
+	maps.Copy(obj.Annotations, n.singleton.Spec.Daemonsets.Annotations)
 
 	found := &appsv1.DaemonSet{}
 	err = n.client.Get(ctx, types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
@@ -4989,9 +4980,7 @@ func applyServiceMonitorCustomEdits(desiredState *gpuv1.ServiceMonitorConfig, cu
 		if currentState.Labels == nil {
 			currentState.Labels = map[string]string{}
 		}
-		for key, value := range desiredState.AdditionalLabels {
-			currentState.Labels[key] = value
-		}
+		maps.Copy(currentState.Labels, desiredState.AdditionalLabels)
 	}
 
 	// The following edits are endpoint-specific and require at least one endpoint
@@ -5247,7 +5236,6 @@ func transformKataRuntimeClasses(n ClusterPolicyController) (gpuv1.State, error)
 	// Delete all Kata RuntimeClasses
 	n.logger.Info("Kata Manager disabled, deleting all Kata RuntimeClasses")
 	for _, rc := range list.Items {
-		rc := rc
 		n.logger.V(1).Info("Deleting Kata RuntimeClass", "Name", rc.Name)
 		err := n.client.Delete(ctx, &rc)
 		if err != nil {
@@ -5281,7 +5269,6 @@ func RuntimeClasses(n ClusterPolicyController) (gpuv1.State, error) {
 	}
 
 	for _, obj := range nvidiaRuntimeClasses {
-		obj := obj
 		// When CDI is disabled, do not create the additional 'nvidia-cdi' and
 		// 'nvidia-legacy' runtime classes. Delete these objects if they were
 		// previously created.

--- a/controllers/object_controls_test.go
+++ b/controllers/object_controls_test.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -587,7 +586,7 @@ func newCluster(nodes int, s *runtime.Scheme) (client.Client, error) {
 	// Build fake client
 	cl := fake.NewClientBuilder().WithScheme(s).Build()
 
-	for i := 0; i < nodes; i++ {
+	for i := range nodes {
 		ready := corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue}
 		name := fmt.Sprintf("node%d", i)
 		n := &corev1.Node{
@@ -903,9 +902,9 @@ func getDriverTestInput(testCase string) *gpuv1.ClusterPolicy {
 
 // getDriverTestOutput returns a map containing expected output for
 // driver test case. This function will grow as new test cases are added
-func getDriverTestOutput(testCase string) map[string]interface{} {
+func getDriverTestOutput(testCase string) map[string]any {
 	// default output
-	output := map[string]interface{}{
+	output := map[string]any{
 		"numDaemonsets":      1,
 		"nvPeerMemPresent":   false,
 		"driverManagerImage": "nvcr.io/nvidia/cloud-native/k8s-driver-manager:test",
@@ -930,7 +929,7 @@ func TestDriver(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",
@@ -1019,9 +1018,9 @@ func getDevicePluginTestInput(testCase string) *gpuv1.ClusterPolicy {
 
 // getDevicePluginTestOutput returns a map containing expected output for
 // device-plugin test case. This function will grow as new test cases are added
-func getDevicePluginTestOutput(testCase string) map[string]interface{} {
+func getDevicePluginTestOutput(testCase string) map[string]any {
 	// default output
-	output := map[string]interface{}{
+	output := map[string]any{
 		"numDaemonsets":               1,
 		"configManagerInitPresent":    false,
 		"configManagerSidecarPresent": false,
@@ -1052,7 +1051,7 @@ func TestDevicePlugin(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",
@@ -1156,9 +1155,9 @@ func getVGPUManagerTestInput(testCase string) *gpuv1.ClusterPolicy {
 
 // getVGPUManagerTestOutput returns a map containing expected output for
 // driver test case. This function will grow as new test cases are added
-func getVGPUManagerTestOutput(testCase string) map[string]interface{} {
+func getVGPUManagerTestOutput(testCase string) map[string]any {
 	// default output
-	output := map[string]interface{}{
+	output := map[string]any{
 		"numDaemonsets":      1,
 		"driverImage":        "nvcr.io/nvidia/vgpu-manager:470.57.02-ubuntu22.04",
 		"driverManagerImage": "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.3.0",
@@ -1182,7 +1181,7 @@ func TestVGPUManager(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",
@@ -1330,9 +1329,9 @@ func getSandboxDevicePluginTestInput(testCase string) *gpuv1.ClusterPolicy {
 
 // getSandboxDevicePluginTestOutput returns a map containing expected output for
 // driver test case. This function will grow as new test cases are added
-func getSandboxDevicePluginTestOutput(testCase string) map[string]interface{} {
+func getSandboxDevicePluginTestOutput(testCase string) map[string]any {
 	// default output
-	output := map[string]interface{}{
+	output := map[string]any{
 		"numDaemonsets":   1,
 		"image":           "nvcr.io/nvidia/kubevirt-device-plugin:v1.1.0",
 		"imagePullSecret": "ngc-secret",
@@ -1354,7 +1353,7 @@ func TestSandboxDevicePlugin(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",
@@ -1436,8 +1435,8 @@ func getKataDevicePluginTestInput(testCase string) *gpuv1.ClusterPolicy {
 
 // getKataDevicePluginTestOutput returns a map containing expected output for
 // kata device plugin test case.
-func getKataDevicePluginTestOutput(testCase string) map[string]interface{} {
-	output := map[string]interface{}{
+func getKataDevicePluginTestOutput(testCase string) map[string]any {
+	output := map[string]any{
 		"numDaemonsets":   1,
 		"image":           "nvcr.io/nvidia/kata-gpu-device-plugin:v0.0.1",
 		"imagePullSecret": "ngc-secret",
@@ -1459,7 +1458,7 @@ func TestKataDevicePlugin(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",
@@ -1533,9 +1532,9 @@ func getDCGMExporterTestInput(testCase string) *gpuv1.ClusterPolicy {
 		dcgmEnabled := true
 		cp.Spec.DCGM.Enabled = &dcgmEnabled
 	case "pod-labels-enabled":
-		cp.Spec.DCGMExporter.EnablePodLabels = ptr.To(true)
+		cp.Spec.DCGMExporter.EnablePodLabels = new(true)
 	case "pod-uid-enabled":
-		cp.Spec.DCGMExporter.EnablePodUID = ptr.To(true)
+		cp.Spec.DCGMExporter.EnablePodUID = new(true)
 	case "pod-labels-env":
 		cp.Spec.DCGMExporter.Env = []gpuv1.EnvVar{
 			{Name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS", Value: "true"},
@@ -1553,9 +1552,9 @@ func getDCGMExporterTestInput(testCase string) *gpuv1.ClusterPolicy {
 
 // getDCGMExporterTestOutput returns a map containing expected output for
 // dcgm-exporter test case.
-func getDCGMExporterTestOutput(testCase string) map[string]interface{} {
+func getDCGMExporterTestOutput(testCase string) map[string]any {
 	// default output
-	output := map[string]interface{}{
+	output := map[string]any{
 		"numDaemonsets":     1,
 		"dcgmExporterImage": "nvcr.io/nvidia/k8s/dcgm-exporter:3.3.0-3.2.0-ubuntu22.04",
 		"imagePullSecret":   "ngc-secret",
@@ -1606,7 +1605,7 @@ func TestDCGMExporter(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",
@@ -1772,7 +1771,7 @@ func TestServiceMonitor(t *testing.T) {
 			stateName:   "state-dcgm-exporter",
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
-				DCGMExporter: gpuv1.DCGMExporterSpec{Enabled: ptr.To(false)},
+				DCGMExporter: gpuv1.DCGMExporterSpec{Enabled: new(false)},
 			},
 			expectedState:          gpuv1.Ready,
 			expectedServiceMonitor: nil,
@@ -1783,8 +1782,8 @@ func TestServiceMonitor(t *testing.T) {
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled:        ptr.To(true),
-					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{Enabled: ptr.To(true)},
+					Enabled:        new(true),
+					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{Enabled: new(true)},
 				},
 			},
 			expectedState:          gpuv1.Ready,
@@ -1796,7 +1795,7 @@ func TestServiceMonitor(t *testing.T) {
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 				},
 			},
 			expectedState:          gpuv1.Ready,
@@ -1808,7 +1807,7 @@ func TestServiceMonitor(t *testing.T) {
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled:        ptr.To(true),
+					Enabled:        new(true),
 					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{},
 				},
 			},
@@ -1821,7 +1820,7 @@ func TestServiceMonitor(t *testing.T) {
 			k8sObjects:  []client.Object{serviceMonitorCRD},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled:        ptr.To(true),
+					Enabled:        new(true),
 					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{},
 				},
 			},
@@ -1834,8 +1833,8 @@ func TestServiceMonitor(t *testing.T) {
 			k8sObjects:  []client.Object{serviceMonitorCRD},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled:        ptr.To(true),
-					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{Enabled: ptr.To(false)},
+					Enabled:        new(true),
+					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{Enabled: new(false)},
 				},
 			},
 			expectedState:          gpuv1.Disabled,
@@ -1854,7 +1853,7 @@ func TestServiceMonitor(t *testing.T) {
 			stateName:   "state-node-status-exporter",
 			k8sObjects:  []client.Object{serviceMonitorCRD},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
-				NodeStatusExporter: gpuv1.NodeStatusExporterSpec{Enabled: ptr.To(false)},
+				NodeStatusExporter: gpuv1.NodeStatusExporterSpec{Enabled: new(false)},
 			},
 			expectedState:          gpuv1.Disabled,
 			expectedServiceMonitor: nil,
@@ -1885,9 +1884,9 @@ func TestServiceMonitor(t *testing.T) {
 				Operator: gpuv1.OperatorSpec{
 					Metrics: gpuv1.OperatorMetricsSpec{
 						ServiceMonitor: &gpuv1.ServiceMonitorConfig{
-							Enabled:          ptr.To(true),
+							Enabled:          new(true),
 							Interval:         promv1.Duration("30s"),
-							HonorLabels:      ptr.To(true),
+							HonorLabels:      new(true),
 							AdditionalLabels: map[string]string{"custom": "label"},
 							Relabelings:      []*promv1.RelabelConfig{{Action: "drop"}},
 						},
@@ -1919,12 +1918,12 @@ func TestServiceMonitor(t *testing.T) {
 			k8sObjects:  []client.Object{serviceMonitorCRD},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 					ServiceMonitor: &gpuv1.DCGMExporterServiceMonitorConfig{
-						Enabled:          ptr.To(true),
+						Enabled:          new(true),
 						Interval:         promv1.Duration("15s"),
 						ScrapeTimeout:    promv1.Duration("10s"),
-						HonorLabels:      ptr.To(true),
+						HonorLabels:      new(true),
 						AdditionalLabels: map[string]string{"a": "b"},
 						Relabelings:      []*promv1.RelabelConfig{{Action: "keep"}},
 					},
@@ -2034,7 +2033,7 @@ func TestService(t *testing.T) {
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 					ServiceSpec: &gpuv1.DCGMExporterServiceConfig{
 						Type:                  corev1.ServiceTypeNodePort,
 						InternalTrafficPolicy: &localPolicy,
@@ -2057,7 +2056,7 @@ func TestService(t *testing.T) {
 			}},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				DCGMExporter: gpuv1.DCGMExporterSpec{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 					ServiceSpec: &gpuv1.DCGMExporterServiceConfig{
 						Type:                  corev1.ServiceTypeNodePort,
 						InternalTrafficPolicy: &localPolicy,
@@ -2080,7 +2079,7 @@ func TestService(t *testing.T) {
 				},
 			}},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
-				DCGMExporter: gpuv1.DCGMExporterSpec{Enabled: ptr.To(false)},
+				DCGMExporter: gpuv1.DCGMExporterSpec{Enabled: new(false)},
 			},
 			expectedState: gpuv1.Disabled,
 			expectService: false,
@@ -2230,7 +2229,7 @@ func TestRuntimeClasses(t *testing.T) {
 			k8sVersion:  "v1.33.0",
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
-				CDI: gpuv1.CDIConfigSpec{Enabled: ptr.To(true)},
+				CDI: gpuv1.CDIConfigSpec{Enabled: new(true)},
 			},
 			expectedState:          gpuv1.Ready,
 			expectedRuntimeClasses: []string{"nvidia", "nvidia-legacy", "nvidia-cdi"},
@@ -2242,8 +2241,8 @@ func TestRuntimeClasses(t *testing.T) {
 			k8sObjects:  nil,
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				CDI: gpuv1.CDIConfigSpec{
-					Enabled:          ptr.To(true),
-					NRIPluginEnabled: ptr.To(true),
+					Enabled:          new(true),
+					NRIPluginEnabled: new(true),
 				},
 			},
 			expectedState:          gpuv1.Ready,
@@ -2272,8 +2271,8 @@ func TestRuntimeClasses(t *testing.T) {
 			},
 			clusterPolicySpec: gpuv1.ClusterPolicySpec{
 				CDI: gpuv1.CDIConfigSpec{
-					Enabled:          ptr.To(true),
-					NRIPluginEnabled: ptr.To(true),
+					Enabled:          new(true),
+					NRIPluginEnabled: new(true),
 				},
 			},
 			expectedState:          gpuv1.Ready,
@@ -2335,8 +2334,8 @@ func getMIGManagerTestInput(testCase string) *gpuv1.ClusterPolicy {
 }
 
 // getMIGManagerTestOutput returns expected output for a MIG Manager test case
-func getMIGManagerTestOutput(testCase string) map[string]interface{} {
-	output := map[string]interface{}{
+func getMIGManagerTestOutput(testCase string) map[string]any {
+	output := map[string]any{
 		"numDaemonsets":          1,
 		"migManagerImage":        "nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.5.0",
 		"imagePullSecret":        "ngc-secret",
@@ -2365,7 +2364,7 @@ func TestMIGManager(t *testing.T) {
 	testCases := []struct {
 		description   string
 		clusterPolicy *gpuv1.ClusterPolicy
-		output        map[string]interface{}
+		output        map[string]any
 	}{
 		{
 			"Default",

--- a/controllers/state_manager_test.go
+++ b/controllers/state_manager_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -169,7 +168,7 @@ func TestStep(t *testing.T) {
 	expectedErr := errors.New("step failed")
 	driverCRDPolicy := &gpuv1.ClusterPolicy{
 		Spec: gpuv1.ClusterPolicySpec{
-			Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: ptr.To(true)},
+			Driver: gpuv1.DriverSpec{UseNvidiaDriverCRD: new(true)},
 		},
 	}
 
@@ -474,8 +473,8 @@ func TestValidateClusterPolicySpec(t *testing.T) {
 			description: "valid CDI object in spec",
 			spec: &gpuv1.ClusterPolicySpec{
 				CDI: gpuv1.CDIConfigSpec{
-					Enabled:          ptr.To(true),
-					NRIPluginEnabled: ptr.To(true),
+					Enabled:          new(true),
+					NRIPluginEnabled: new(true),
 				},
 			},
 		},
@@ -483,8 +482,8 @@ func TestValidateClusterPolicySpec(t *testing.T) {
 			description: "invalid CDI object in spec",
 			spec: &gpuv1.ClusterPolicySpec{
 				CDI: gpuv1.CDIConfigSpec{
-					Enabled:          ptr.To(false),
-					NRIPluginEnabled: ptr.To(true),
+					Enabled:          new(false),
+					NRIPluginEnabled: new(true),
 				},
 			},
 			err: errors.New("the NRI Plugin cannot be enabled when CDI is disabled"),
@@ -493,11 +492,11 @@ func TestValidateClusterPolicySpec(t *testing.T) {
 			description: "invalid CDI and Toolkit config combination",
 			spec: &gpuv1.ClusterPolicySpec{
 				CDI: gpuv1.CDIConfigSpec{
-					Enabled:          ptr.To(true),
-					NRIPluginEnabled: ptr.To(true),
+					Enabled:          new(true),
+					NRIPluginEnabled: new(true),
 				},
 				Toolkit: gpuv1.ToolkitSpec{
-					Enabled: ptr.To(false),
+					Enabled: new(false),
 				},
 			},
 			err: errors.New("the NRI Plugin cannot be enabled when the Container Toolkit is disabled"),
@@ -597,8 +596,8 @@ func TestRemoveAllGPUStateLabels(t *testing.T) {
 }
 
 func TestIsStateEnabled_SandboxAndKataDevicePlugin(t *testing.T) {
-	boolTrue := ptr.To(true)
-	boolFalse := ptr.To(false)
+	boolTrue := new(true)
+	boolFalse := new(false)
 	tests := []struct {
 		name           string
 		sandboxEnabled bool

--- a/controllers/transforms_test.go
+++ b/controllers/transforms_test.go
@@ -190,7 +190,7 @@ func (d Daemonset) WithHostPID(enabled bool) Daemonset {
 }
 
 func (d Daemonset) WithAutomountServiceAccountToken(enabled bool) Daemonset {
-	d.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(enabled)
+	d.Spec.Template.Spec.AutomountServiceAccountToken = new(enabled)
 	return d
 }
 
@@ -722,17 +722,17 @@ func TestApplyCommonDaemonSetConfig(t *testing.T) {
 			ds:          NewDaemonset(),
 			dsSpec: gpuv1.DaemonsetsSpec{
 				PodSecurityContext: &corev1.PodSecurityContext{
-					RunAsUser:    ptr.To(int64(1000)),
-					RunAsGroup:   ptr.To(int64(3000)),
-					FSGroup:      ptr.To(int64(2000)),
-					RunAsNonRoot: ptr.To(true),
+					RunAsUser:    new(int64(1000)),
+					RunAsGroup:   new(int64(3000)),
+					FSGroup:      new(int64(2000)),
+					RunAsNonRoot: new(true),
 				},
 			},
 			expectedDs: NewDaemonset().WithPodSecurityContext(&corev1.PodSecurityContext{
-				RunAsUser:    ptr.To(int64(1000)),
-				RunAsGroup:   ptr.To(int64(3000)),
-				FSGroup:      ptr.To(int64(2000)),
-				RunAsNonRoot: ptr.To(true),
+				RunAsUser:    new(int64(1000)),
+				RunAsGroup:   new(int64(3000)),
+				FSGroup:      new(int64(2000)),
+				RunAsNonRoot: new(true),
 			}),
 		},
 	}
@@ -768,13 +768,13 @@ func TestApplyHostNetworkConfig(t *testing.T) {
 		},
 		{
 			name:            "hostNetwork true, should set hostNetwork and DNSPolicy",
-			hostNetwork:     ptr.To(true),
+			hostNetwork:     new(true),
 			expectEnabled:   true,
 			expectDNSPolicy: corev1.DNSClusterFirstWithHostNet,
 		},
 		{
 			name:            "hostNetwork false, should not set hostNetwork",
-			hostNetwork:     ptr.To(false),
+			hostNetwork:     new(false),
 			expectEnabled:   false,
 			expectDNSPolicy: "",
 		},
@@ -1913,7 +1913,7 @@ func TestTransformDCGM(t *testing.T) {
 			description: "dcgm enabled does not set remote engine env",
 			daemonset:   NewDaemonset().WithContainer(corev1.Container{Name: "dcgm"}),
 			clusterPolicySpec: &gpuv1.ClusterPolicySpec{
-				DCGM: gpuv1.DCGMSpec{Enabled: ptr.To(true), Repository: "nvcr.io/nvidia/cloud-native", Image: "dcgm", Version: "v1.0.0"},
+				DCGM: gpuv1.DCGMSpec{Enabled: new(true), Repository: "nvcr.io/nvidia/cloud-native", Image: "dcgm", Version: "v1.0.0"},
 			},
 			expectedDaemonset: NewDaemonset().WithContainer(corev1.Container{
 				Name:            "dcgm",
@@ -1928,7 +1928,7 @@ func TestTransformDCGM(t *testing.T) {
 				Env:  []corev1.EnvVar{{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: "localhost:5555"}},
 			}),
 			clusterPolicySpec: &gpuv1.ClusterPolicySpec{
-				DCGM: gpuv1.DCGMSpec{Enabled: ptr.To(false), Repository: "nvcr.io/nvidia/cloud-native", Image: "dcgm", Version: "v1.0.0"},
+				DCGM: gpuv1.DCGMSpec{Enabled: new(false), Repository: "nvcr.io/nvidia/cloud-native", Image: "dcgm", Version: "v1.0.0"},
 			},
 			expectedDaemonset: NewDaemonset().
 				WithContainer(corev1.Container{

--- a/internal/driver/hostsmi_test.go
+++ b/internal/driver/hostsmi_test.go
@@ -77,8 +77,8 @@ func TestResolveHostNvidiaSMI(t *testing.T) {
 				target := filepath.Join(hostRoot, name)
 				require.NoError(t, os.MkdirAll(filepath.Dir(target), 0755))
 
-				if strings.HasPrefix(contents, "symlink=") {
-					require.NoError(t, os.Symlink(strings.TrimPrefix(contents, "symlink="), target))
+				if after, ok := strings.CutPrefix(contents, "symlink="); ok {
+					require.NoError(t, os.Symlink(after, target))
 					continue
 				}
 

--- a/internal/nvidiadriver/nvidiadriver_errors_test.go
+++ b/internal/nvidiadriver/nvidiadriver_errors_test.go
@@ -19,6 +19,7 @@ package nvidiadriver
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,9 +44,7 @@ func assignOwnersScheme(t *testing.T) *runtime.Scheme {
 
 func gpuNode(name string, extraLabels map[string]string) *corev1.Node {
 	labels := map[string]string{consts.GPUPresentLabel: "true"}
-	for k, v := range extraLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, extraLabels)
 	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
 }
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -59,7 +59,7 @@ type TemplatingData struct {
 	// Funcs are additional Functions used during the templating process
 	Funcs template.FuncMap
 	// Data used for the rendering process
-	Data interface{}
+	Data any
 }
 
 // NewRenderer creates a Renderer object, that will render all template files provided.
@@ -102,7 +102,7 @@ func (r *textTemplateRenderer) renderFile(filePath string, data *TemplatingData)
 	tmpl := template.New(path.Base(filePath)).Funcs(sprig.FuncMap()).Option("missingkey=error")
 
 	tmpl.Funcs(template.FuncMap{
-		"yaml": func(obj interface{}) (string, error) {
+		"yaml": func(obj any) (string, error) {
 			yamlBytes, err := yamlConverter.Marshal(obj)
 			return string(yamlBytes), err
 		},

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -39,9 +39,9 @@ type templateData struct {
 func checkRenderedUnstructured(objs []*unstructured.Unstructured, t *templateData) {
 	for idx, obj := range objs {
 		Expect(obj.GetKind()).To(Equal(fmt.Sprint("TestObj", idx+1)))
-		Expect(obj.Object["metadata"].(map[string]interface{})["name"].(string)).To(Equal(t.Foo))
-		Expect(obj.Object["spec"].(map[string]interface{})["attribute"].(string)).To(Equal(t.Bar))
-		Expect(obj.Object["spec"].(map[string]interface{})["anotherAttribute"].(string)).To(Equal(t.Baz))
+		Expect(obj.Object["metadata"].(map[string]any)["name"].(string)).To(Equal(t.Foo))
+		Expect(obj.Object["spec"].(map[string]any)["attribute"].(string)).To(Equal(t.Bar))
+		Expect(obj.Object["spec"].(map[string]any)["anotherAttribute"].(string)).To(Equal(t.Baz))
 	}
 }
 
@@ -155,9 +155,9 @@ var _ = Describe("Test Renderer builtin template functions and edge cases", func
 
 			data := &TemplatingData{
 				Data: struct {
-					Spec map[string]interface{}
+					Spec map[string]any
 				}{
-					Spec: map[string]interface{}{"attribute": "value"},
+					Spec: map[string]any{"attribute": "value"},
 				},
 			}
 
@@ -166,13 +166,13 @@ var _ = Describe("Test Renderer builtin template functions and edge cases", func
 			Expect(err).ToNot(HaveOccurred())
 			Expect(objs).To(HaveLen(1))
 			Expect(objs[0].GetKind()).To(Equal("TestObjYaml"))
-			spec := objs[0].Object["spec"].(map[string]interface{})
+			spec := objs[0].Object["spec"].(map[string]any)
 			Expect(spec["attribute"]).To(Equal("value"))
 		})
 	})
 
 	Context("Render template using the builtin 'deref' function", func() {
-		renderDeref := func(ptr *bool) []map[string]interface{} {
+		renderDeref := func(ptr *bool) []map[string]any {
 			content := strings.Join([]string{
 				"apiVersion: v1",
 				"kind: TestObjDeref",
@@ -190,9 +190,9 @@ var _ = Describe("Test Renderer builtin template functions and edge cases", func
 			objs, err := r.RenderObjects(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(objs).To(HaveLen(1))
-			specs := make([]map[string]interface{}, 0, len(objs))
+			specs := make([]map[string]any, 0, len(objs))
 			for _, o := range objs {
-				specs = append(specs, o.Object["spec"].(map[string]interface{}))
+				specs = append(specs, o.Object["spec"].(map[string]any))
 			}
 			return specs
 		}
@@ -229,7 +229,7 @@ var _ = Describe("Test Renderer builtin template functions and edge cases", func
 			objs, err := r.RenderObjects(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(objs).To(HaveLen(1))
-			name := objs[0].Object["metadata"].(map[string]interface{})["name"].(string)
+			name := objs[0].Object["metadata"].(map[string]any)["name"].(string)
 			Expect(name).To(Equal("LOWERED"))
 		})
 	})

--- a/internal/state/configurable_state.go
+++ b/internal/state/configurable_state.go
@@ -48,12 +48,12 @@ type configurableState struct {
 	// buildRenderData builds the operand-specific templating data from the resolved
 	// image path and DRA apiVersion. It receives ctx and the skeleton so operands that
 	// need the client or logging (e.g. dcgm-exporter's ServiceMonitor CRD probe) can use them.
-	buildRenderData func(ctx context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (interface{}, error)
+	buildRenderData func(ctx context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (any, error)
 }
 
 var _ State = (*configurableState)(nil)
 
-func (s *configurableState) Sync(ctx context.Context, customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *configurableState) Sync(ctx context.Context, customResource any, infoCatalog InfoCatalog) (SyncState, error) {
 	cr, ok := customResource.(*nvidiav1alpha1.GPUCluster)
 	if !ok {
 		return SyncStateError, fmt.Errorf("GPUCluster CR not provided as input to Sync()")

--- a/internal/state/dcgm.go
+++ b/internal/state/dcgm.go
@@ -54,7 +54,7 @@ func NewStateDCGM(
 	}, nil
 }
 
-func buildDCGMRenderData(_ context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (interface{}, error) {
+func buildDCGMRenderData(_ context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (any, error) {
 	daemonsets := cr.Spec.Daemonsets
 	return &dcgmRenderData{
 		DCGM:                    &dcgmSpec{Spec: cr.Spec.DCGM, ImagePath: imagePath},

--- a/internal/state/dcgm_exporter.go
+++ b/internal/state/dcgm_exporter.go
@@ -70,7 +70,7 @@ func NewStateDCGMExporter(
 	}, nil
 }
 
-func buildDCGMExporterRenderData(ctx context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (interface{}, error) {
+func buildDCGMExporterRenderData(ctx context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (any, error) {
 	spec := cr.Spec.DCGMExporter
 
 	// When standalone DCGM is enabled the exporter targets it; otherwise it runs embedded.

--- a/internal/state/dcgm_exporter_test.go
+++ b/internal/state/dcgm_exporter_test.go
@@ -113,7 +113,7 @@ func TestDCGMExporterEnabledByDefault(t *testing.T) {
 
 func TestDCGMExporterDisabled(t *testing.T) {
 	s := newTestDCGMExporterState(t, false)
-	cr := exporterCR(&nvidiav1.DCGMExporterSpec{Enabled: ptr.To(false)})
+	cr := exporterCR(&nvidiav1.DCGMExporterSpec{Enabled: new(false)})
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestDCGMExporterDisabled(t *testing.T) {
 func TestDCGMExporterRemoteEngineWhenDCGMEnabled(t *testing.T) {
 	s := newTestDCGMExporterState(t, false)
 	cr := exporterCR(&nvidiav1.DCGMExporterSpec{})
-	cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: ptr.To(true)}
+	cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: new(true)}
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)
@@ -136,8 +136,8 @@ func TestDCGMExporterRemoteEngineWhenDCGMEnabled(t *testing.T) {
 func TestDCGMExporterPodMetadataEnrichment(t *testing.T) {
 	s := newTestDCGMExporterState(t, false)
 	cr := exporterCR(&nvidiav1.DCGMExporterSpec{
-		EnablePodLabels:        ptr.To(true),
-		EnablePodUID:           ptr.To(true),
+		EnablePodLabels:        new(true),
+		EnablePodUID:           new(true),
 		PodLabelAllowlistRegex: []string{"^app$", "^team$"},
 	})
 
@@ -173,7 +173,7 @@ func TestDCGMExporterCustomMetricsConfig(t *testing.T) {
 func TestDCGMExporterHPCJobMapping(t *testing.T) {
 	s := newTestDCGMExporterState(t, false)
 	cr := exporterCR(&nvidiav1.DCGMExporterSpec{
-		HPCJobMapping: &nvidiav1.DCGMExporterHPCJobMappingConfig{Enabled: ptr.To(true)},
+		HPCJobMapping: &nvidiav1.DCGMExporterHPCJobMappingConfig{Enabled: new(true)},
 	})
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
@@ -190,7 +190,7 @@ func TestDCGMExporterHPCJobMapping(t *testing.T) {
 func TestDCGMExporterServiceMonitorSkippedWithoutCRD(t *testing.T) {
 	s := newTestDCGMExporterState(t, false) // ServiceMonitor CRD not served
 	cr := exporterCR(&nvidiav1.DCGMExporterSpec{
-		ServiceMonitor: &nvidiav1.ServiceMonitorConfig{Enabled: ptr.To(true)},
+		ServiceMonitor: &nvidiav1.ServiceMonitorConfig{Enabled: new(true)},
 	})
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
@@ -203,7 +203,7 @@ func TestDCGMExporterServiceMonitorRendered(t *testing.T) {
 	s := newTestDCGMExporterState(t, true) // ServiceMonitor CRD served
 	cr := exporterCR(&nvidiav1.DCGMExporterSpec{
 		ServiceMonitor: &nvidiav1.ServiceMonitorConfig{
-			Enabled:  ptr.To(true),
+			Enabled:  new(true),
 			Interval: "15s",
 		},
 	})

--- a/internal/state/dcgm_test.go
+++ b/internal/state/dcgm_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	nvidiav1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
@@ -65,10 +64,10 @@ func claimHasAdminAccess(t *testing.T, rct *unstructured.Unstructured) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, requests, 1)
-	req := requests[0].(map[string]interface{})
+	req := requests[0].(map[string]any)
 	// v1/v1beta2 nest under "exactly"; v1beta1 is flat. The test cluster serves v1.
 	device := req
-	if exactly, ok := req["exactly"].(map[string]interface{}); ok {
+	if exactly, ok := req["exactly"].(map[string]any); ok {
 		device = exactly
 	}
 	assert.Equal(t, "gpu.nvidia.com", device["deviceClassName"])
@@ -93,7 +92,7 @@ func TestDCGMDisabledByDefault(t *testing.T) {
 	assert.Empty(t, objs, "DCGM must default to disabled when enabled is nil")
 
 	// Explicitly disabled.
-	cr.Spec.DCGM.Enabled = ptr.To(false)
+	cr.Spec.DCGM.Enabled = new(false)
 	objs, err = s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)
 	assert.Empty(t, objs, "DCGM must not render when explicitly disabled")
@@ -103,7 +102,7 @@ func TestDCGMEnabled(t *testing.T) {
 	s := newTestDCGMState(t)
 	cr := sampleGPUCluster()
 	cr.Spec.DCGM = &nvidiav1.DCGMSpec{
-		Enabled:    ptr.To(true),
+		Enabled:    new(true),
 		Repository: "nvcr.io/nvidia/cloud-native",
 		Image:      "dcgm",
 		Version:    "4.5.2",
@@ -145,14 +144,14 @@ func TestDCGMEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, port, 1)
-	assert.Equal(t, int64(5555), port[0].(map[string]interface{})["port"])
+	assert.Equal(t, int64(5555), port[0].(map[string]any)["port"])
 }
 
 func TestDCGMImageFromEnvFallback(t *testing.T) {
 	s := newTestDCGMState(t)
 	cr := sampleGPUCluster()
 	// No repository/image/version — must fall back to DCGM_IMAGE.
-	cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: ptr.To(true)}
+	cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: new(true)}
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)

--- a/internal/state/dra_driver.go
+++ b/internal/state/dra_driver.go
@@ -76,7 +76,7 @@ func NewStateDRADriver(
 	return &stateDRADriver{stateSkel: skel}, nil
 }
 
-func (s *stateDRADriver) Sync(ctx context.Context, customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *stateDRADriver) Sync(ctx context.Context, customResource any, infoCatalog InfoCatalog) (SyncState, error) {
 	cr, ok := customResource.(*nvidiav1alpha1.GPUCluster)
 	if !ok {
 		return SyncStateError, fmt.Errorf("GPUCluster CR not provided as input to Sync()")

--- a/internal/state/dra_driver_test.go
+++ b/internal/state/dra_driver_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	nvidiav1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
@@ -165,7 +164,7 @@ func TestDRADriverHealthcheckPortOverride(t *testing.T) {
 	s := newTestDRAState(t)
 	cr := sampleGPUCluster()
 	cr.Spec.DRADriver.GPUs.KubeletPlugin.Healthcheck = &nvidiav1alpha1.DRADriverHealthcheckSpec{
-		Port: ptr.To(int32(52000)),
+		Port: new(int32(52000)),
 	}
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
@@ -281,7 +280,7 @@ func TestDRADriverHealthcheckDisabled(t *testing.T) {
 	s := newTestDRAState(t)
 	cr := sampleGPUCluster()
 	cr.Spec.DRADriver.GPUs.KubeletPlugin.Healthcheck = &nvidiav1alpha1.DRADriverHealthcheckSpec{
-		Enabled: ptr.To(false),
+		Enabled: new(false),
 	}
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
@@ -380,7 +379,7 @@ func containerByName(t *testing.T, ds *appsv1.DaemonSet, name string) corev1.Con
 func TestDRADriverRenderComputeDomains(t *testing.T) {
 	s := newTestDRAState(t)
 	cr := sampleGPUCluster()
-	cr.Spec.DRADriver.ComputeDomains.Enabled = ptr.To(true)
+	cr.Spec.DRADriver.ComputeDomains.Enabled = new(true)
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)
@@ -417,7 +416,7 @@ func TestDRADriverRenderComputeDomains(t *testing.T) {
 func TestDRADriverComputeDomainsContainerAndController(t *testing.T) {
 	s := newTestDRAState(t)
 	cr := sampleGPUCluster()
-	cr.Spec.DRADriver.ComputeDomains.Enabled = ptr.To(true)
+	cr.Spec.DRADriver.ComputeDomains.Enabled = new(true)
 
 	objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 	require.NoError(t, err)
@@ -470,7 +469,7 @@ func TestDRADriverDaemonsetsAnnotations(t *testing.T) {
 func TestDRADriverControllerInheritsGlobalConfig(t *testing.T) {
 	s := newTestDRAState(t)
 	cr := sampleGPUCluster()
-	cr.Spec.DRADriver.ComputeDomains.Enabled = ptr.To(true)
+	cr.Spec.DRADriver.ComputeDomains.Enabled = new(true)
 	cr.Spec.Daemonsets.Labels = map[string]string{"team": "platform"}
 	cr.Spec.Daemonsets.Annotations = map[string]string{"monitoring": "enabled"}
 	cr.Spec.Daemonsets.Tolerations = []corev1.Toleration{{
@@ -501,7 +500,7 @@ func TestDRADriverControllerInheritsGlobalConfig(t *testing.T) {
 func TestDRADriverKubeletPluginScheduling(t *testing.T) {
 	s := newTestDRAState(t)
 	cr := sampleGPUCluster()
-	cr.Spec.DRADriver.ComputeDomains.Enabled = ptr.To(true)
+	cr.Spec.DRADriver.ComputeDomains.Enabled = new(true)
 	cr.Spec.Daemonsets.Tolerations = []corev1.Toleration{{Key: "ds-tol", Operator: corev1.TolerationOpExists}}
 	cr.Spec.Daemonsets.PriorityClassName = "ds-priority"
 

--- a/internal/state/dra_validation.go
+++ b/internal/state/dra_validation.go
@@ -50,7 +50,7 @@ func NewStateDRAValidation(
 	}, nil
 }
 
-func buildValidatorRenderData(_ context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (interface{}, error) {
+func buildValidatorRenderData(_ context.Context, s *configurableState, cr *nvidiav1alpha1.GPUCluster, imagePath, apiVersion, openshiftVersion string) (any, error) {
 	// Reuse the DRA driver spec for the image pull settings.
 	spec := cr.Spec.DRADriver
 	daemonsets := cr.Spec.Daemonsets

--- a/internal/state/driver.go
+++ b/internal/state/driver.go
@@ -131,7 +131,7 @@ func NewStateDriver(
 	return state, nil
 }
 
-func (s *stateDriver) Sync(ctx context.Context, customResource interface{}, infoCatalog InfoCatalog) (SyncState, error) {
+func (s *stateDriver) Sync(ctx context.Context, customResource any, infoCatalog InfoCatalog) (SyncState, error) {
 	cr, ok := customResource.(*nvidiav1alpha1.NVIDIADriver)
 	if !ok {
 		return SyncStateError, fmt.Errorf("NVIDIADriver CR not provided as input to Sync()")
@@ -203,7 +203,6 @@ func (s *stateDriver) cleanupStaleDriverDaemonsets(ctx context.Context, cr *nvid
 	}
 
 	for _, ds := range list.Items {
-		ds := ds
 		// Delete DaemonSets that are not in the desired list. This handles the case where
 		// the CR's nodeSelector changes and certain node pools no longer match.
 		if _, exists := desiredDaemonSetNames[ds.Name]; !exists {

--- a/internal/state/driver_test.go
+++ b/internal/state/driver_test.go
@@ -281,7 +281,7 @@ func TestDriverHostNetwork(t *testing.T) {
 	require.True(t, ok)
 
 	renderData := getMinimalDriverRenderData()
-	renderData.Driver.Spec.HostNetwork = ptr.To(true)
+	renderData.Driver.Spec.HostNetwork = new(true)
 
 	objs, err := stateDriver.renderer.RenderObjects(
 		&render.TemplatingData{
@@ -315,7 +315,7 @@ func TestDriverRenderRDMA(t *testing.T) {
 	renderData.AdditionalConfigs = getSampleAdditionalConfigs()
 
 	renderData.GPUDirectRDMA = &nvidiav1alpha1.GPUDirectRDMASpec{
-		Enabled: ptr.To(true),
+		Enabled: new(true),
 	}
 
 	objs, err := stateDriver.renderer.RenderObjects(
@@ -348,8 +348,8 @@ func TestDriverRDMAHostMOFED(t *testing.T) {
 	renderData.AdditionalConfigs = getSampleAdditionalConfigs()
 
 	renderData.GPUDirectRDMA = &nvidiav1alpha1.GPUDirectRDMASpec{
-		Enabled:      ptr.To(true),
-		UseHostMOFED: ptr.To(true),
+		Enabled:      new(true),
+		UseHostMOFED: new(true),
 	}
 
 	objs, err := stateDriver.renderer.RenderObjects(
@@ -476,7 +476,7 @@ func TestDriverGDS(t *testing.T) {
 	renderData.GDS = &gdsDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1",
 		Spec: &nvidiav1alpha1.GPUDirectStorageSpec{
-			Enabled:          ptr.To(true),
+			Enabled:          new(true),
 			ImagePullSecrets: []string{"ngc-secrets"},
 		},
 	}
@@ -514,7 +514,7 @@ func TestDriverGDRCopy(t *testing.T) {
 	renderData.GDRCopy = &gdrcopyDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1",
 		Spec: &nvidiav1alpha1.GDRCopySpec{
-			Enabled:          ptr.To(true),
+			Enabled:          new(true),
 			ImagePullSecrets: []string{"ngc-secrets"},
 		},
 	}
@@ -571,7 +571,7 @@ func TestDriverGDRCopyOpenShift(t *testing.T) {
 	renderData.GDRCopy = &gdrcopyDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1-rhcos4.13",
 		Spec: &nvidiav1alpha1.GDRCopySpec{
-			Enabled:          ptr.To(true),
+			Enabled:          new(true),
 			ImagePullSecrets: []string{"ngc-secret"},
 		},
 	}
@@ -742,7 +742,7 @@ func TestDriverPrecompiledLibModules(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			driver := &nvidiav1alpha1.NVIDIADriver{}
-			driver.Spec.UsePrecompiled = ptr.To(tc.usePrecompiled)
+			driver.Spec.UsePrecompiled = new(tc.usePrecompiled)
 
 			additionalConfigs, err := stateDriver.getDriverAdditionalConfigs(
 				context.Background(),
@@ -753,7 +753,7 @@ func TestDriverPrecompiledLibModules(t *testing.T) {
 			require.NoError(t, err)
 
 			renderData := getMinimalDriverRenderData()
-			renderData.Driver.Spec.UsePrecompiled = ptr.To(tc.usePrecompiled)
+			renderData.Driver.Spec.UsePrecompiled = new(tc.usePrecompiled)
 			renderData.AdditionalConfigs = additionalConfigs
 			if tc.usePrecompiled {
 				renderData.Precompiled = &precompiledSpec{
@@ -907,7 +907,7 @@ func TestDriverPrecompiled(t *testing.T) {
 	require.True(t, ok)
 
 	renderData := getMinimalDriverRenderData()
-	renderData.Driver.Spec.UsePrecompiled = ptr.To(true)
+	renderData.Driver.Spec.UsePrecompiled = new(true)
 	renderData.Driver.Name = "nvidia-gpu-driver-ubuntu22.04"
 	renderData.Driver.AppName = "nvidia-gpu-driver-ubuntu22.04-646cdfdb96"
 	renderData.Driver.ImagePath = "nvcr.io/nvidia/driver:535-5.4.0-150-generic-ubuntu22.04"
@@ -1268,7 +1268,7 @@ func TestDriverVGPULicensingSecret(t *testing.T) {
 
 	renderData.Driver.Spec.LicensingConfig = &nvidiav1alpha1.DriverLicensingConfigSpec{
 		SecretName: "licensing-config-secret",
-		NLSEnabled: ptr.To(true),
+		NLSEnabled: new(true),
 	}
 
 	renderData.AdditionalConfigs = &additionalConfigs{
@@ -1337,13 +1337,13 @@ func TestDriverSecretEnv(t *testing.T) {
 	renderData.GDS = &gdsDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/nvidia-fs:2.16.1",
 		Spec: &nvidiav1alpha1.GPUDirectStorageSpec{
-			Enabled: ptr.To(true),
+			Enabled: new(true),
 		},
 	}
 	renderData.GDRCopy = &gdrcopyDriverSpec{
 		ImagePath: "nvcr.io/nvidia/cloud-native/gdrdrv:v2.4.1",
 		Spec: &nvidiav1alpha1.GDRCopySpec{
-			Enabled: ptr.To(true),
+			Enabled: new(true),
 		},
 	}
 
@@ -1388,7 +1388,7 @@ func TestGetDriverSpecMultipleNodePools(t *testing.T) {
 		},
 		Spec: nvidiav1alpha1.NVIDIADriverSpec{
 			DriverType:     nvidiav1alpha1.GPU,
-			UsePrecompiled: ptr.To(true),
+			UsePrecompiled: new(true),
 			Repository:     "nvcr.io/nvidia",
 			Image:          "driver",
 			Version:        "535.104.05",

--- a/internal/state/gpucluster_render_test.go
+++ b/internal/state/gpucluster_render_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/ptr"
 
 	nvidiav1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
@@ -49,10 +48,10 @@ func fullSpecGPUCluster() *nvidiav1alpha1.GPUCluster {
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 		},
-		Healthcheck: &nvidiav1alpha1.DRADriverHealthcheckSpec{Port: ptr.To(int32(52000))},
+		Healthcheck: &nvidiav1alpha1.DRADriverHealthcheckSpec{Port: new(int32(52000))},
 	}
 	cr.Spec.DRADriver.ComputeDomains = nvidiav1alpha1.DRADriverComputeDomainsSpec{
-		Enabled: ptr.To(true),
+		Enabled: new(true),
 		Controller: nvidiav1alpha1.DRADriverControllerSpec{
 			Env: []nvidiav1.EnvVar{{Name: "CD_CONTROLLER_EXTRA", Value: "1"}},
 		},
@@ -125,7 +124,7 @@ func TestGPUClusterRenderGolden(t *testing.T) {
 			render: func(t *testing.T) []*unstructured.Unstructured {
 				s := newTestDCGMState(t)
 				cr := sampleGPUCluster()
-				cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: ptr.To(true)}
+				cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: new(true)}
 				objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 				require.NoError(t, err)
 				return objs
@@ -147,7 +146,7 @@ func TestGPUClusterRenderGolden(t *testing.T) {
 			name: "gpucluster-dcgm-exporter-pod-metadata",
 			render: func(t *testing.T) []*unstructured.Unstructured {
 				s := newTestDCGMExporterState(t, false)
-				cr := exporterCR(&nvidiav1.DCGMExporterSpec{EnablePodLabels: ptr.To(true)})
+				cr := exporterCR(&nvidiav1.DCGMExporterSpec{EnablePodLabels: new(true)})
 				objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 				require.NoError(t, err)
 				return objs
@@ -160,7 +159,7 @@ func TestGPUClusterRenderGolden(t *testing.T) {
 			render: func(t *testing.T) []*unstructured.Unstructured {
 				s := newTestDCGMExporterState(t, false)
 				cr := exporterCR(&nvidiav1.DCGMExporterSpec{})
-				cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: ptr.To(true)}
+				cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: new(true)}
 				objs, err := s.getManifestObjects(context.Background(), cr, draSupportedCatalog())
 				require.NoError(t, err)
 				return objs

--- a/internal/state/gpucluster_scc_test.go
+++ b/internal/state/gpucluster_scc_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	nvidiav1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 )
@@ -97,7 +96,7 @@ func TestGPUClusterOperandSCCs(t *testing.T) {
 			render: func(t *testing.T, catalog InfoCatalog) []*unstructured.Unstructured {
 				s := newTestDCGMState(t)
 				cr := sampleGPUCluster()
-				cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: ptr.To(true)}
+				cr.Spec.DCGM = &nvidiav1.DCGMSpec{Enabled: new(true)}
 				objs, err := s.getManifestObjects(context.Background(), cr, catalog)
 				require.NoError(t, err)
 				return objs

--- a/internal/state/info_source.go
+++ b/internal/state/info_source.go
@@ -28,7 +28,7 @@ func NewInfoCatalog() InfoCatalog {
 }
 
 // InfoSource represents an object that is a souce of information
-type InfoSource interface{}
+type InfoSource any
 
 // InfoCatalog is an information catalog to be used to retrieve infoSources. used for State implementation that require
 // additional helping functionality to perfrom the Sync operation. As more States are added,

--- a/internal/state/manager.go
+++ b/internal/state/manager.go
@@ -30,7 +30,7 @@ import (
 
 type Manager interface {
 	GetWatchSources(ctrlManager) []SyncingSource
-	SyncState(ctx context.Context, customResource interface{}, infoCatalog InfoCatalog) Results
+	SyncState(ctx context.Context, customResource any, infoCatalog InfoCatalog) Results
 }
 
 type stateManager struct {
@@ -74,7 +74,7 @@ func (m *stateManager) GetWatchSources(ctrlManager ctrlManager) []SyncingSource 
 	return sources
 }
 
-func (m *stateManager) SyncState(ctx context.Context, customResource interface{}, infoCatalog InfoCatalog) Results {
+func (m *stateManager) SyncState(ctx context.Context, customResource any, infoCatalog InfoCatalog) Results {
 	logger := log.FromContext(ctx)
 	logger.V(consts.LogLevelInfo).Info("Syncing system state")
 

--- a/internal/state/nodepool.go
+++ b/internal/state/nodepool.go
@@ -75,7 +75,6 @@ func getNodePools(ctx context.Context, k8sClient client.Client, cr *nvidiav1alph
 	}
 
 	for _, node := range nodeList.Items {
-		node := node
 		nodeLabels := node.GetLabels()
 
 		nodePool := nodePool{}

--- a/internal/state/nodepool_test.go
+++ b/internal/state/nodepool_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
@@ -257,7 +256,7 @@ func TestGetNodePoolsPartitionsPrecompiledNodesByKernel(t *testing.T) {
 	driver := &nvidiav1alpha1.NVIDIADriver{
 		ObjectMeta: metav1.ObjectMeta{Name: "driver-a"},
 		Spec: nvidiav1alpha1.NVIDIADriverSpec{
-			UsePrecompiled: ptr.To(true),
+			UsePrecompiled: new(true),
 		},
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -34,6 +34,6 @@ const (
 type State interface {
 	Name() string
 	Description() string
-	Sync(ctx context.Context, customResource interface{}, infoCatalog InfoCatalog) (SyncState, error)
+	Sync(ctx context.Context, customResource any, infoCatalog InfoCatalog) (SyncState, error)
 	GetWatchSources(ctrlManager) map[string]SyncingSource
 }

--- a/internal/state/state_skel.go
+++ b/internal/state/state_skel.go
@@ -87,7 +87,7 @@ func newStateSkel(
 }
 
 // renderObjects renders the state's manifests with the given templating data.
-func (s *stateSkel) renderObjects(ctx context.Context, data interface{}) ([]*unstructured.Unstructured, error) {
+func (s *stateSkel) renderObjects(ctx context.Context, data any) ([]*unstructured.Unstructured, error) {
 	logger := log.FromContext(ctx)
 	logger.V(consts.LogLevelDebug).Info("Rendering objects", "State:", s.name, "data", data)
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -72,7 +72,7 @@ var spewPrinter = spew.ConfigState{
 }
 
 // GetObjectHash returns an FNV-32a hash of the full object (all fields).
-func GetObjectHash(obj interface{}) string {
+func GetObjectHash(obj any) string {
 	hasher := fnv.New32a()
 	spewPrinter.Fprintf(hasher, "%#v", obj)
 	return fmt.Sprint(hasher.Sum32())
@@ -81,7 +81,7 @@ func GetObjectHash(obj interface{}) string {
 // GetObjectHashIgnoreEmptyKeys returns an FNV-32a hash of only the non-zero
 // fields of a struct. Adding a new zero-valued field will not change
 // the digest. Embedded structs are flattened.
-func GetObjectHashIgnoreEmptyKeys(obj interface{}) string {
+func GetObjectHashIgnoreEmptyKeys(obj any) string {
 	hasher := fnv.New32a()
 	hashNonZeroFields(hasher, reflect.Indirect(reflect.ValueOf(obj)))
 	return fmt.Sprint(hasher.Sum32())

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -135,7 +135,7 @@ func TestGetObjectHashIgnoreEmptyKeys(t *testing.T) {
 func TestIsEffectivelyZero(t *testing.T) {
 	tests := []struct {
 		name     string
-		value    interface{}
+		value    any
 		expected bool
 	}{
 		{"zero int", 0, true},

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
@@ -148,7 +147,7 @@ func TestCheckNodeSelectorRejectsMultipleDefaultDrivers(t *testing.T) {
 func TestCheckNodeSelectorIgnoresDeletingDefaultDriver(t *testing.T) {
 	defaultDriver := makeTestDriver("default-a", nil, true)
 	deletingDefaultDriver := makeTestDriver("default-b", nil, true)
-	deletingDefaultDriver.DeletionTimestamp = ptr.To(metav1.Now())
+	deletingDefaultDriver.DeletionTimestamp = new(metav1.Now())
 	deletingDefaultDriver.Finalizers = []string{"test-finalizer"}
 
 	s := scheme.Scheme

--- a/tests/e2e/framework/expect.go
+++ b/tests/e2e/framework/expect.go
@@ -55,13 +55,13 @@ func (f FailureError) Backtrace() string {
 var ErrFailure error = FailureError{}
 
 // ExpectNoError checks if "err" is set, and if so, fails assertion while logs the error.
-func ExpectNoError(err error, explain ...interface{}) {
+func ExpectNoError(err error, explain ...any) {
 	ExpectNoErrorWithOffset(1, err, explain...)
 }
 
 // ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logs the error at "offset" levels above its caller
 // (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
-func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
+func ExpectNoErrorWithOffset(offset int, err error, explain ...any) {
 	if err == nil {
 		return
 	}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -24,6 +24,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"strings"
 	"time"
@@ -207,9 +208,7 @@ func (f *Framework) CreateNamespace(ctx context.Context, baseName string, labels
 		labels = make(map[string]string)
 	} else {
 		labelsCopy := make(map[string]string)
-		for k, v := range labels {
-			labelsCopy[k] = v
-		}
+		maps.Copy(labelsCopy, labels)
 		labels = labelsCopy
 	}
 

--- a/tests/e2e/framework/logs/logging.go
+++ b/tests/e2e/framework/logs/logging.go
@@ -74,18 +74,18 @@ func nowStamp() string {
 	return time.Now().Format(time.StampMilli)
 }
 
-func logf(level string, format string, args ...interface{}) {
+func logf(level string, format string, args ...any) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
 // Logf logs the info.
-func Logf(format string, args ...interface{}) {
+func Logf(format string, args ...any) {
 	logf("INFO", format, args...)
 }
 
 // Failf logs the fail info, including a stack trace starts with its direct caller
 // (for example, for call chain f -> g -> Failf("foo", ...) error would be logged for "g").
-func Failf(format string, args ...interface{}) {
+func Failf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	skip := 1
 	ginkgo.Fail(msg, skip)

--- a/tests/e2e/helpers/clusterpolicy.go
+++ b/tests/e2e/helpers/clusterpolicy.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 
 	nvidiav1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	gpuclientset "github.com/NVIDIA/gpu-operator/api/versioned"
@@ -72,49 +71,49 @@ func (h *ClusterPolicyClient) UpdateDriverVersion(ctx context.Context, name, ver
 
 func (h *ClusterPolicyClient) EnableDCGM(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.DCGM.Enabled = ptr.To(true)
+		clusterPolicy.Spec.DCGM.Enabled = new(true)
 	})
 }
 
 func (h *ClusterPolicyClient) DisableDCGM(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.DCGM.Enabled = ptr.To(false)
+		clusterPolicy.Spec.DCGM.Enabled = new(false)
 	})
 }
 
 func (h *ClusterPolicyClient) EnableDCGMExporter(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.DCGMExporter.Enabled = ptr.To(true)
+		clusterPolicy.Spec.DCGMExporter.Enabled = new(true)
 	})
 }
 
 func (h *ClusterPolicyClient) DisableDCGMExporter(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.DCGMExporter.Enabled = ptr.To(false)
+		clusterPolicy.Spec.DCGMExporter.Enabled = new(false)
 	})
 }
 
 func (h *ClusterPolicyClient) EnableGFD(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.GPUFeatureDiscovery.Enabled = ptr.To(true)
+		clusterPolicy.Spec.GPUFeatureDiscovery.Enabled = new(true)
 	})
 }
 
 func (h *ClusterPolicyClient) DisableGFD(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.GPUFeatureDiscovery.Enabled = ptr.To(false)
+		clusterPolicy.Spec.GPUFeatureDiscovery.Enabled = new(false)
 	})
 }
 
 func (h *ClusterPolicyClient) EnableDevicePlugin(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.DevicePlugin.Enabled = ptr.To(true)
+		clusterPolicy.Spec.DevicePlugin.Enabled = new(true)
 	})
 }
 
 func (h *ClusterPolicyClient) DisableDevicePlugin(ctx context.Context, name string) error {
 	return h.modify(ctx, name, func(clusterPolicy *nvidiav1.ClusterPolicy) {
-		clusterPolicy.Spec.DevicePlugin.Enabled = ptr.To(false)
+		clusterPolicy.Spec.DevicePlugin.Enabled = new(false)
 	})
 }
 


### PR DESCRIPTION
## Description

 go fix now takes care of go modernize changes, I think this is a good addition to the repo to ensure our code base is up to date with the latest go changes. I have also included the modernize rule in golangci-lint so that future PRs will catch any regressions as well.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [x] Test cases are added for new code paths

## Testing
Ran lint locally and the unit tests locally. 

