### PR TITLE
Add per-state duration metric to reconciliation

### DIFF
--- a/controllers/clusterpolicy_controller.go
+++ b/controllers/clusterpolicy_controller.go
@@ -47,6 +47,7 @@ import (
 	nvidiav1alpha1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1alpha1"
 	"github.com/NVIDIA/gpu-operator/internal/conditions"
 	"github.com/NVIDIA/gpu-operator/internal/consts"
+	"github.com/NVIDIA/gpu-operator/internal/state"
 )
 
 const (
@@ -172,7 +173,12 @@ func (r *ClusterPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	statesNotReady := []string{}
 	notReadyReasons := []string{}
 	for {
+		stateName := clusterPolicyCtrl.stateNames[clusterPolicyCtrl.idx]
+		stateStart := time.Now()
 		status, statusError := clusterPolicyCtrl.step()
+		state.StateDurationSeconds.
+			WithLabelValues(gpuv1.ClusterPolicyCRDName, stateName).
+			Observe(time.Since(stateStart).Seconds())
 		if statusError != nil {
 			clusterPolicyCtrl.operatorMetrics.reconciliationStatus.Set(reconciliationStatusNotReady)
 			clusterPolicyCtrl.operatorMetrics.reconciliationFailed.Inc()

--- a/internal/state/manager.go
+++ b/internal/state/manager.go
@@ -19,6 +19,7 @@ package state
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +35,7 @@ type Manager interface {
 }
 
 type stateManager struct {
+	crdKind   string
 	states    []State
 	client    client.Client
 	namespace string
@@ -48,6 +50,7 @@ func NewManager(crdKind string, namespace string, k8sClient client.Client, schem
 	}
 
 	manager := &stateManager{
+		crdKind:   crdKind,
 		namespace: namespace,
 		states:    states,
 		client:    k8sClient,
@@ -86,7 +89,9 @@ func (m *stateManager) SyncState(ctx context.Context, customResource any, infoCa
 	for _, state := range m.states {
 		logger.V(consts.LogLevelInfo).Info("Sync State", "Name", state.Name(), "Description", state.Description())
 		stateCtx := log.IntoContext(ctx, logger.WithName("state").WithName(state.Name()))
+		stateStart := time.Now()
 		ss, err := state.Sync(stateCtx, customResource, infoCatalog)
+		StateDurationSeconds.WithLabelValues(m.crdKind, state.Name()).Observe(time.Since(stateStart).Seconds())
 		result := Result{StateName: state.Name(), Status: ss, ErrInfo: err}
 		managerResult.StatesStatus = append(managerResult.StatesStatus, result)
 

--- a/internal/state/metrics.go
+++ b/internal/state/metrics.go
@@ -1,0 +1,39 @@
+/**
+# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package state
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// StateDurationSeconds records the time spent per reconcile in each state,
+// labeled by the owning controller's CRD kind and the state name.
+var StateDurationSeconds = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: "gpu_operator",
+		Name:      "state_seconds",
+		Help:      "Time spent per reconcile in each state",
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 15, 60, 300},
+	},
+	[]string{"controller", "state"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(StateDurationSeconds)
+}


### PR DESCRIPTION
## Description

A reconcile processes many component states, but existing metrics only
expose whole-reconcile totals, so a slow state cannot be identified
from metrics alone. Add a `gpu_operator_state_seconds` histogram
labeled by controller and state, covering the ClusterPolicy,
GPUCluster, and NVIDIADriver paths.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

`go test ./controllers/ ./internal/state/`; `go build`; `gofmt`.