### PR TITLE
Add configurable securityContext and dnsConfig for the operator Deployment

### DIFF
--- a/deployments/gpu-operator/templates/cleanup_crd.yaml
+++ b/deployments/gpu-operator/templates/cleanup_crd.yaml
@@ -32,10 +32,27 @@ spec:
       {{- end }}
       nodeSelector:
         {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
+      {{- with .Values.operator.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.dnsPolicy }}
+      dnsPolicy: {{ .Values.operator.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.operator.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cleanup-crd
           image: {{ include "gpu-operator.fullimage" . }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           command:
             - /usr/bin/manage-crds
           args:

--- a/deployments/gpu-operator/templates/cleanup_gpucluster.yaml
+++ b/deployments/gpu-operator/templates/cleanup_gpucluster.yaml
@@ -37,10 +37,27 @@ spec:
       {{- end }}
       nodeSelector:
         {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
+      {{- with .Values.operator.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.dnsPolicy }}
+      dnsPolicy: {{ .Values.operator.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.operator.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cleanup-gpucluster
           image: {{ include "gpu-operator.fullimage" . }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           command:
             - /usr/bin/cleanup-gpuclusters
             - --gpucluster-name

--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -33,6 +33,17 @@ spec:
       {{- if .Values.operator.priorityClassName }}
       priorityClassName: {{ .Values.operator.priorityClassName }}
       {{- end }}
+      {{- with .Values.operator.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.dnsPolicy }}
+      dnsPolicy: {{ .Values.operator.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.operator.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: gpu-operator
         image: {{ include "gpu-operator.fullimage" . }}
@@ -83,6 +94,12 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
       {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - name: metrics
             containerPort: 8080

--- a/deployments/gpu-operator/templates/upgrade_crd.yaml
+++ b/deployments/gpu-operator/templates/upgrade_crd.yaml
@@ -81,10 +81,27 @@ spec:
       {{- end }}
       nodeSelector:
         {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
+      {{- with .Values.operator.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.dnsPolicy }}
+      dnsPolicy: {{ .Values.operator.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.operator.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: upgrade-crd
           image: {{ include "gpu-operator.fullimage" . }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           command:
             - /usr/bin/manage-crds
           args:

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -121,6 +121,17 @@ operator:
     requests:
       cpu: 200m
       memory: 100Mi
+  # Restricted defaults for the operator Deployment (not operand DaemonSets).
+  # Do not pin runAsUser/runAsGroup/fsGroup: the image already uses USER 1000:1000
+  # on vanilla Kubernetes, and a hardcoded UID fails OpenShift namespaces whose
+  # allocated range does not include 1000 (restricted-readonly SCC is MustRunAsRange).
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  # Empty dnsPolicy keeps the cluster default (ClusterFirst).
+  dnsPolicy: ""
+  dnsConfig: {}
   # metrics:
   #   serviceMonitor:
   #     interval: 15s


### PR DESCRIPTION
## Description

The `gpu-operator` Deployment currently has no pod or container `securityContext`, so it runs with the cluster default (often unrestricted). This PR sets restricted defaults that still work on vanilla Kubernetes and OpenShift, makes the pod `securityContext` configurable through Helm values, and adds `dnsPolicy` / `dnsConfig` values.

This also covers the Helm hook Jobs that run the same operator image (`upgrade-crd`, `cleanup-crd`, `cleanup-gpucluster`). Those were previously empty like the Deployment.

**Not in this PR:** operand DaemonSets (driver, device plugin, toolkit, MIG, and so on). Those are created later by the operator, not by this chart, and they need host privileges. ClusterPolicy already has `spec.daemonsets.podSecurityContext` for that path.

Defaults:
- pod (`operator.securityContext`, configurable): `runAsNonRoot: true`, `seccompProfile: RuntimeDefault`
- container (fixed in the templates, not a values key): `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`
- `dnsPolicy: ""` (cluster default ClusterFirst) and `dnsConfig: {}`

The container-level fields are not exposed as a values key to keep the chart's API surface small, per review. They have to live at container level because `allowPrivilegeEscalation`, `readOnlyRootFilesystem`, and `capabilities` are not fields of `PodSecurityContext`.

No writable `/tmp` is added. The Deployment is already annotated with `openshift.io/scc: restricted-readonly`, and that SCC sets `readOnlyRootFilesystem: true`, so it has been running read-only on OpenShift without one. Neither `manage-crds` nor `cleanup-gpuclusters` creates temporary files.

UID/GID/`fsGroup` are not pinned. The operator image already uses `USER 1000:1000`, so vanilla Kubernetes still runs non-root. OpenShift `restricted-readonly` SCC uses `MustRunAsRange`; a hardcoded UID fails namespaces whose allocated range does not include that ID. Pin a UID with `operator.securityContext.runAsUser` if you need one.

Fixes #2533

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [ ] Lint checks passing (`make lint`) — n/a, no Go changes
- [ ] Generated assets in-sync (`make validate-generated-assets`) — n/a, no API/CRD/generated changes
- [ ] Go mod artifacts in-sync (`make validate-modules`) — n/a, no dependency changes
- [ ] Test cases are added for new code paths — n/a, Helm template-only change; verified with `helm template` below

## Testing

Helm-only change (no Go, CRD, or generated-asset edits). The diff against `main` is additions only (+79 / −0). Ran against this branch:

- `helm lint deployments/gpu-operator/` — pass
- `helm template` with chart defaults and `operator.cleanupCRD=true` / `operator.upgradeCRD=true` (both default to `false`), diffed against `main`: the only change is the added pod and container `securityContext` on the Deployment and the three hook Jobs. `dnsPolicy`/`dnsConfig` are omitted by default
- `helm template` with `operator.dnsPolicy=None` and `operator.dnsConfig.nameservers=[8.8.8.8]` — both render on the Deployment and hook Jobs
- `helm template` with `operator.securityContext=null` — pod `securityContext` is omitted
- `helm template` with `operator.securityContext.runAsUser=1000` — explicit UID still overrides
- `helm template` with `operator.pprof.bindAddress=:6060` — `--pprof-bind-address` still renders, same as `main`
- Confirmed `docker/Dockerfile` ends with `USER 1000:1000`

Did not apply this to a live GPU cluster.
