### PR TITLE
revert the CUDA samples version bump to v13.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG CUDA_SAMPLES_VERSION=13.2
+# R580 is the minimum driver branch supported by gpu-operator and
+# its backcompat stretches all the way back to the Maxwell architecure.
+# CUDA SAMPLES v12.9 is used as that is the latest version with Maxwell support.
+ARG CUDA_SAMPLES_VERSION=12.9
 
 FROM golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb AS builder
 
@@ -64,7 +67,7 @@ WORKDIR /build
 ARG SAMPLE_NAME=vectorAdd
 
 RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/v${CUDA_SAMPLES_VERSION} | \
-    tar -xzvf - --strip-components=1 --wildcards */${SAMPLE_NAME}/* --wildcards */Common/* --wildcards */cmake/* && \
+    tar -xzvf - --strip-components=1 --wildcards */${SAMPLE_NAME}/* --wildcards */Common/* && \
     cd $(find /build/Samples -iname "${SAMPLE_NAME}") && \
     cmake . && \
     make && \


### PR DESCRIPTION
This reverts PR #2620

To align with the Supported architectures and GPUs of R580, we use the CUDA Samples version that is compatible with all the devices supported by R580.

This means that the CUDA Samples version will remain unchanged for as long as R580 is supported (EOL June 2028).