### PR TITLE
build: use the official docker image to install busybox

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,11 +76,8 @@ RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/v${
 # Build a static busybox layout: one binary plus applet symlinks (sh, rm,
 # ln, sleep, cat, ...) so PATH-resolved commands in init-container wrappers
 # and lifecycle hooks keep working on the non-*-dev* distroless base.
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS shell
-RUN apt-get update \
- && apt-get install -y --no-install-recommends busybox-static \
- && rm -rf /var/lib/apt/lists/* \
- && mkdir /busybox \
+FROM busybox:1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616 AS shell
+RUN mkdir /busybox \
  && cp /bin/busybox /busybox/busybox \
  && /busybox/busybox --install -s /busybox
 


### PR DESCRIPTION
Instead of using an immutable tag of the `debian:trixie-slim` image and an unpinned busybox apt package, we use the busybox binary from the official dockerhub busybox image.

This has two advantages

- We version-pin the extracted busybox binary
- Using the official busybox image helps us stay up-to-date with the latest versions faster as the debian-trixie apt package repos don't host the latest busybox versions immediately. For e.g., at the time of filing this PR, the latest busybox version available in the debian trixie package repo is still 1.37, whereas the actual latest version of busybox is 1.38
