### PR TITLE
Revert "Stop defaulting deprecated cdi.default in ClusterPolicy"

### DIFF
--- a/api/nvidia/v1/clusterpolicy_types.go
+++ b/api/nvidia/v1/clusterpolicy_types.go
@@ -1967,6 +1967,7 @@ type CDIConfigSpec struct {
 
 	// Deprecated: This field is no longer used. Setting cdi.enabled=true will configure CDI as the default mechanism for making GPUs accessible to containers.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Deprecated: This field is no longer used"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch,urn:alm:descriptor:com.tectonic.ui:hidden"

--- a/bundle/manifests/nvidia.com_clusterpolicies.yaml
+++ b/bundle/manifests/nvidia.com_clusterpolicies.yaml
@@ -139,6 +139,7 @@ spec:
                   used in the cluster
                 properties:
                   default:
+                    default: false
                     description: 'Deprecated: This field is no longer used. Setting
                       cdi.enabled=true will configure CDI as the default mechanism
                       for making GPUs accessible to containers.'

--- a/config/crd/bases/nvidia.com_clusterpolicies.yaml
+++ b/config/crd/bases/nvidia.com_clusterpolicies.yaml
@@ -139,6 +139,7 @@ spec:
                   used in the cluster
                 properties:
                   default:
+                    default: false
                     description: 'Deprecated: This field is no longer used. Setting
                       cdi.enabled=true will configure CDI as the default mechanism
                       for making GPUs accessible to containers.'

--- a/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
+++ b/deployments/gpu-operator/crds/nvidia.com_clusterpolicies.yaml
@@ -139,6 +139,7 @@ spec:
                   used in the cluster
                 properties:
                   default:
+                    default: false
                     description: 'Deprecated: This field is no longer used. Setting
                       cdi.enabled=true will configure CDI as the default mechanism
                       for making GPUs accessible to containers.'


### PR DESCRIPTION
This reverts commit 23464863fc4491f2fb6f6ef9b7a5b47bd41842c8.


- We do not typically make non-additive changes to a CRD
- This change was made in response to an ArgoCD behaviour, which is just one among several tools for Kubernetes application deployment
- The [issue](https://github.com/NVIDIA/gpu-operator/issues/2795) is well-known and there is a well-documented solution. Enabling `server-side diff strategy` in ArgoCD fixes the issue for Argo users who face this problem. That is a better solution than making an upstream CRD schema change 

