### PR TITLE
allow configuring leader-lease-renew-deadline

### DIFF
--- a/deployments/gpu-operator/templates/operator.yaml
+++ b/deployments/gpu-operator/templates/operator.yaml
@@ -40,6 +40,11 @@ spec:
         command: ["gpu-operator"]
         args:
         - --leader-elect
+      {{- with .Values.operator.leaderElection }}
+        {{- if .renewDeadline }}
+        - --leader-lease-renew-deadline={{ .renewDeadline }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.operator.logging.develMode }}
         - --zap-devel
       {{- else }}

--- a/deployments/gpu-operator/values.yaml
+++ b/deployments/gpu-operator/values.yaml
@@ -76,6 +76,8 @@ operator:
   #version: ""
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
+  # leaderElection:
+  #   renewDeadline: 60s
   env: []
   priorityClassName: system-node-critical
   runtimeClass: nvidia


### PR DESCRIPTION
## Description

We currently configure leader-lease-renew-deadline with installs using OLM bundle. This change allows us to configure the same with helm installs as well.

See https://github.com/NVIDIA/gpu-operator/pull/2767#discussion_r3969939391
<!-- Brief description of the change, including context or motivation -->

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Lint checks passing (`make lint`)
- [x] Generated assets in-sync (`make validate-generated-assets`)
- [x] Go mod artifacts in-sync (`make validate-modules`)
- [ ] Test cases are added for new code paths

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

